### PR TITLE
[fix: admin]: mapping objects exception

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/MetaDataTransfer.java
@@ -78,6 +78,7 @@ public enum MetaDataTransfer {
                         .methodName(dto.getMethodName())
                         .parameterTypes(dto.getParameterTypes())
                         .rpcExt(dto.getRpcExt())
+                        .enabled(dto.isEnabled())
                         .build())
                 .orElse(null);
     }


### PR DESCRIPTION
fix bug where field `enable` lost when mapping object

fix a bug:
when i start `shenyu-examples` dubbo client , an error occurred. I found him and fixed him，I think u losed this field named `enabled` and it's necessary  at database schema

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor/).
- [x] Your local test passed `mvn clean install -Dmaven.javadoc.skip=true`.
- [ ] You submit test cases (unit or integration tests) that back your changes.
