### PR TITLE
[type: feat] update docker-publish workflow, make it only push image when release

### DIFF
--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -19,7 +19,7 @@ on:
   release:
     # pre-release or draft status don't trigger this job.
     # this job called if and only if pre-release -> release or release directly.
-    type: ["released"]
+    types: ["released"]
 
 env:
   REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -13,20 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: docker-publish-ghcr
+name: docker-publish-dockerhub
 
 on:
-  push:
-    branches: [ "master" ]
-    tags: [ 'v*.*.*' ]
+  release:
+    type: ["published"]
 
 env:
-  REGISTRY: ghcr.io
   REPOSITORY: ${{ github.repository }}
-  TAG: ${{ github.sha }}
+  TAG: ${{ github.ref_name }}
 
 jobs:
-  build:
+  dockerhub:
+    # pre-release or draft status don't trigger this job.
+    # this job called if and only if pre-release -> release or release directly.
+    if: "!github.event.release.prerelease && !github.event.release.draft"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,13 +42,11 @@ jobs:
       - name: Set Skip Env Var
         uses: ./.github/actions/skip-ci
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v2
-        if: env.SKIP_CI != 'true'
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -79,7 +78,7 @@ jobs:
         if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean -Prelease -Dmaven.javadoc.skip=true -B -Drat.skip=true -Djacoco.skip=true -DskipITs -DskipTests package
 
-      - name: Build and push (admin) (ghcr.io)
+      - name: Build and push (admin) (dockerhub)
         uses: docker/build-push-action@v3
         if: env.SKIP_CI != 'true'
         with:
@@ -88,10 +87,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:latest
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:${{ env.TAG }}
+            ${{ env.REPOSITORY }}/admin:latest
+            ${{ env.REPOSITORY }}/admin:${{ env.TAG }}
 
-      - name: Build and push (bootstrap) (ghcr.io)
+      - name: Build and push (bootstrap) (dockerhub)
         uses: docker/build-push-action@v3
         if: env.SKIP_CI != 'true'
         with:
@@ -100,5 +99,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:latest
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}
+            ${{ env.REPOSITORY }}/bootstrap:latest
+            ${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}

--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -17,7 +17,9 @@ name: docker-publish-dockerhub
 
 on:
   release:
-    type: ["published"]
+    # pre-release or draft status don't trigger this job.
+    # this job called if and only if pre-release -> release or release directly.
+    type: ["released"]
 
 env:
   REPOSITORY: ${{ github.repository }}
@@ -25,9 +27,6 @@ env:
 
 jobs:
   dockerhub:
-    # pre-release or draft status don't trigger this job.
-    # this job called if and only if pre-release -> release or release directly.
-    if: "!github.event.release.prerelease && !github.event.release.draft"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,9 +38,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Set Skip Env Var
-        uses: ./.github/actions/skip-ci
-
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -50,18 +46,14 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-        if: env.SKIP_CI != 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: env.SKIP_CI != 'true'
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-        if: env.SKIP_CI != 'true'
 
       - name: Cache Maven Repos
-        if: env.SKIP_CI != 'true'
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
@@ -70,17 +62,14 @@ jobs:
             ${{ runner.os }}-maven-
 
       - uses: actions/setup-java@v1
-        if: env.SKIP_CI != 'true'
         with:
           java-version: 8
 
       - name: Build with Maven
-        if: env.SKIP_CI != 'true'
         run: ./mvnw -B clean -Prelease -Dmaven.javadoc.skip=true -B -Drat.skip=true -Djacoco.skip=true -DskipITs -DskipTests package
 
       - name: Build and push (admin) (dockerhub)
         uses: docker/build-push-action@v3
-        if: env.SKIP_CI != 'true'
         with:
           context: ./shenyu-dist/shenyu-admin-dist
           build-args: APP_NAME=apache-shenyu-incubating-*-admin-bin
@@ -92,7 +81,6 @@ jobs:
 
       - name: Build and push (bootstrap) (dockerhub)
         uses: docker/build-push-action@v3
-        if: env.SKIP_CI != 'true'
         with:
           context: ./shenyu-dist/shenyu-bootstrap-dist
           build-args: APP_NAME=apache-shenyu-incubating-*-bootstrap-bin

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,17 +16,19 @@
 name: docker-publish
 
 on:
-  push:
-    branches: [ "master" ]
-    tags: [ 'v*.*.*' ]
+  release:
+    type: ["published"]
 
 env:
   REGISTRY: ghcr.io
   REPOSITORY: ${{ github.repository }}
-  TAG: ${{ github.sha }}
+  TAG: ${{ github.ref_name }}
 
 jobs:
   build:
+    # pre-release or draft status don't trigger this job.
+    # this job called if and only if pre-release -> release or release directly.
+    if: "!github.event.release.prerelease && !github.event.release.draft"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,6 +42,12 @@ jobs:
 
       - name: Set Skip Env Var
         uses: ./.github/actions/skip-ci
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -87,7 +95,11 @@ jobs:
           build-args: APP_NAME=apache-shenyu-incubating-*-admin-bin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:${{ env.TAG }}
+          tags: |
+            ${{ env.REPOSITORY }}/admin:latest
+            ${{ env.REPOSITORY }}/admin:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:${{ env.TAG }}
 
       - name: Build and push(bootstrap)
         uses: docker/build-push-action@v3
@@ -97,4 +109,8 @@ jobs:
           build-args: APP_NAME=apache-shenyu-incubating-*-bootstrap-bin
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}
+          tags: |
+            ${{ env.REPOSITORY }}/bootstrap:latest
+            ${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/bootstrap:${{ env.TAG }}


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

### Now

~[docker-publish workflow](https://github.com/apache/incubator-shenyu/actions/workflows/docker-publish.yml) run every time new commits merged into master.~ And this workflow can only push image to "ghcr.io", which means that images need pushed to dockerhub manually if there is a new release.

~Additionally, images on ghcr.io use "github.sha" as label.~

### This PR

Update as below:

* Add new workflow to publish image to dockerhub.
* Use "release published" as trigger event.
* Use "github.ref_name" instead of "github.sha" in new workflow. ref: [get-the-current-pushed-tag-in-github-actions](https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions).
* ~Still use "build-push-action", push images to multi-registries. ref: [build-push-action : push-multi-registries](https://github.com/docker/build-push-action/blob/master/docs/advanced/push-multi-registries.md)~.
* Use filter "!github.event.release.prerelease && !github.event.release.draft" to avoid redundant or unnecessary run. ref: [RESTful API of releases](https://docs.github.com/en/rest/releases/releases).

### Test

I only create a [playground repo](https://github.com/skyleaworlder/docker-plugin-example), and test in it.

I use [this workflow yaml](https://github.com/skyleaworlder/docker-plugin-example/actions/runs/2682291485/workflow), append a tag (v0.0.1-alpha.8) and [release](https://github.com/skyleaworlder/docker-plugin-example/releases/tag/v0.0.1-alpha.8).

You can check [job execute summary](https://github.com/skyleaworlder/docker-plugin-example/runs/7371362589?check_suite_focus=true), [image pushed to ghcr.io](https://github.com/skyleaworlder/docker-plugin-example/pkgs/container/normal-dockerfile):

![image](https://user-images.githubusercontent.com/45269589/179361100-1009b032-5aca-48db-8bc1-44644cae42f1.png)

and [image pushed to dockerhub](https://hub.docker.com/repository/docker/skyleaworlder/normal-dockerfile):

![image](https://user-images.githubusercontent.com/45269589/179361117-1cde3c7d-7efc-4c33-8bd4-58f80049b4d0.png)

~### TODO~

~"docker/login-action" need dockerhub username and password:~

```yaml
      - name: Login to DockerHub
        uses: docker/login-action@v2
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_PASSWORD }}
```

~Here I use "DOCKERHUB_USERNAME" and "DOCKERHUB_PASSWORD", so it need set secrets in `settings | Security | Secrets | Actions`.~

I use "DOCKERHUB_USER" and "DOCKERHUB_TOKEN" as [cwiki - Github Secrets and Tokens](https://cwiki.apache.org/confluence/display/INFRA/Github+Secrets+and+Tokens) said.

### Need help

Actually, I'm not very confident whether my PR would work. So I would be very happy if reviewers can help to check.