### PR TITLE
[ISSUE #3741] use pathPatter as default rule condition operator

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
@@ -242,6 +242,8 @@ public abstract class AbstractShenyuClientRegisterServiceImpl extends FallbackSh
                 .build();
         if (path.endsWith(AdminConstants.URI_SLASH_SUFFIX)) {
             ruleConditionDTO.setOperator(OperatorEnum.STARTS_WITH.getAlias());
+        } else if (path.endsWith(AdminConstants.URI_SUFFIX)) {
+            ruleConditionDTO.setOperator(OperatorEnum.PATH_PATTER.getAlias());
         } else if (path.indexOf("*") > 1) {
             ruleConditionDTO.setOperator(OperatorEnum.MATCH.getAlias());
         } else {


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
Dear Community:
    I have finished task [#3741](https://github.com/apache/shenyu/issues/3741)
    please review code.
    like this  test case ,request uri `/http/shenyu/client/hi` can match 3 rule result. please review to confirm whether it is allowed
    
```java
    
PathPatternPredicateJudge:ConditionData{paramType='uri', operator='pathPatter', paramName='/', paramValue='/http/test/**'},realData:/http/shenyu/client/hi

PathPatternPredicateJudge:ConditionData{paramType='uri', operator='pathPatter', paramName='/', paramValue='/http/request/**'},realData:/http/shenyu/client/hi

PathPatternPredicateJudge:ConditionData{paramType='uri', operator='pathPatter', paramName='/', paramValue='/http/order/path/**'},realData:/http/shenyu/client/hi

```



<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
