### PR TITLE
[type:test] Fix the unit test for CurrentTimeGenerator

### DIFF
--- a/shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/CurrentTimeGeneratorTest.java
+++ b/shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/CurrentTimeGeneratorTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.shenyu.plugin.mock.generator;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,14 +30,9 @@ public final class CurrentTimeGeneratorTest {
     @Test
     public void testGenerate() {
         generator.parseRule("${current}");
-        Assertions.assertEquals(generator.generate(), currentTime("YYYY-MM-dd HH:mm:ss"));
+        Assertions.assertTrue(generator.generate().matches("^\\d{4}(-\\d{2}){2} \\d{2}(:\\d{2}){2}$"));
         generator.parseRule("current|YYYY-MM-dd");
-        Assertions.assertEquals(generator.generate(), currentTime("YYYY-MM-dd"));
-        
-    }
-    
-    private String currentTime(final String format) {
-        return new SimpleDateFormat(format).format(new Date());
+        Assertions.assertTrue(generator.generate().matches("^\\d{4}(-\\d{2}){2}$"));
     }
     
     @Test


### PR DESCRIPTION
Fix the problem that the unit test of CurrentTimeGenerator is unstable.
- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
