### PR TITLE
[ISSUE #3796] [fix] Shenyu client registration by consul only register 1 metadata

### DIFF
--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
@@ -19,15 +19,19 @@ package org.apache.shenyu.register.client.consul;
 
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.agent.model.NewService;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.Properties;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.constant.Constants;
+
 import static org.apache.shenyu.common.constant.Constants.PATH_SEPARATOR;
 import static org.apache.shenyu.common.constant.DefaultPathConstants.SELECTOR_JOIN_RULE;
+
 import org.apache.shenyu.common.enums.RpcTypeEnum;
 import org.apache.shenyu.common.exception.ShenyuException;
 import org.apache.shenyu.common.utils.ContextPathUtils;
@@ -49,13 +53,12 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
 
     private static final char SEPARATOR = '-';
 
-    private static MetaDataRegisterDTO metaDataRegisterDTO;
-
     private ConsulClient consulClient;
 
     private NewService service;
 
-    public ConsulClientRegisterRepository() { }
+    public ConsulClientRegisterRepository() {
+    }
 
     public ConsulClientRegisterRepository(final ShenyuRegisterCenterConfig config) {
         init(config);
@@ -131,7 +134,8 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
 
     @Override
     public void persistInterface(final MetaDataRegisterDTO metadata) {
-        metaDataRegisterDTO = metadata;
+        registerMetadata(metadata);
+        LogUtils.info(LOGGER, "{} Consul client register success: {}", metadata.getRpcType(), metadata);
     }
 
     /**
@@ -142,19 +146,12 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
     @Override
     public void persistURI(final URIRegisterDTO registerDTO) {
         registerURI(registerDTO);
-        registerMetadata(metaDataRegisterDTO);
-        LogUtils.info(LOGGER, "{} Consul client register success: {}", metaDataRegisterDTO.getRpcType(), metaDataRegisterDTO);
+        LogUtils.info(LOGGER, "{} Consul client register success: {}", registerDTO.getRpcType(), registerDTO);
     }
 
     @Override
     public void close() {
-        try {
-            consulClient.agentServiceDeregister(this.service.getId());
-        } finally {
-            metaDataRegisterDTO.setTimeMillis(System.currentTimeMillis());
-            registerMetadata(metaDataRegisterDTO);
-            LogUtils.info(LOGGER, "{} Consul client deregister success: {}", metaDataRegisterDTO.getRpcType(), metaDataRegisterDTO);
-        }
+        consulClient.agentServiceDeregister(this.service.getId());
     }
 
     private void registerMetadata(final MetaDataRegisterDTO metadata) {
@@ -171,7 +168,7 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
         this.service.getMeta().put(Constants.URI, GsonUtils.getInstance().toJson(metadata));
         consulClient.agentServiceRegister(this.service);
     }
-    
+
     private String buildMetadataNodeName(final MetaDataRegisterDTO metadata) {
         String nodeName;
         String rpcType = metadata.getRpcType();

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
@@ -57,8 +57,7 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
 
     private NewService service;
 
-    public ConsulClientRegisterRepository() {
-    }
+    public ConsulClientRegisterRepository() { }
 
     public ConsulClientRegisterRepository(final ShenyuRegisterCenterConfig config) {
         init(config);


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

For #3796 , fix consul registration can only register 1 metadata issue.
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
