### PR TITLE
[ BUG ] bug fix: spi does not match sql script config.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
@@ -243,7 +243,7 @@ public abstract class AbstractShenyuClientRegisterServiceImpl extends FallbackSh
         if (path.endsWith(AdminConstants.URI_SLASH_SUFFIX)) {
             ruleConditionDTO.setOperator(OperatorEnum.STARTS_WITH.getAlias());
         } else if (path.endsWith(AdminConstants.URI_SUFFIX)) {
-            ruleConditionDTO.setOperator(OperatorEnum.PATH_PATTER.getAlias());
+            ruleConditionDTO.setOperator(OperatorEnum.PATH_PATTERN.getAlias());
         } else if (path.indexOf("*") > 1) {
             ruleConditionDTO.setOperator(OperatorEnum.MATCH.getAlias());
         } else {

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/enums/OperatorEnum.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/enums/OperatorEnum.java
@@ -84,7 +84,7 @@ public enum OperatorEnum {
     /**
      * Path patter operator enum.
      */
-    PATH_PATTER("pathPatter", true);
+    PATH_PATTERN("pathPattern", true);
 
     private final String alias;
 

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/enums/OperatorEnumTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/enums/OperatorEnumTest.java
@@ -42,7 +42,7 @@ public final class OperatorEnumTest {
         assertTrue(enums.contains(OperatorEnum.EQ));
         assertTrue(enums.contains(OperatorEnum.REGEX));
         assertTrue(enums.contains(OperatorEnum.CONTAINS));
-        assertTrue(enums.contains(OperatorEnum.PATH_PATTER));
+        assertTrue(enums.contains(OperatorEnum.PATH_PATTERN));
         assertTrue(enums.contains(OperatorEnum.TIME_BEFORE));
         assertTrue(enums.contains(OperatorEnum.TIME_AFTER));
         assertTrue(enums.contains(OperatorEnum.STARTS_WITH));

--- a/shenyu-plugin/shenyu-plugin-base/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.base.condition.judge.PredicateJudge
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.base.condition.judge.PredicateJudge
@@ -25,4 +25,4 @@ regex=org.apache.shenyu.plugin.base.condition.judge.RegexPredicateJudge
 TimeAfter=org.apache.shenyu.plugin.base.condition.judge.TimerAfterPredicateJudge
 TimeBefore=org.apache.shenyu.plugin.base.condition.judge.TimerBeforePredicateJudge
 exclude=org.apache.shenyu.plugin.base.condition.judge.ExcludePredicateJudge
-pathPatter=org.apache.shenyu.plugin.base.condition.judge.PathPatternPredicateJudge
+pathPattern=org.apache.shenyu.plugin.base.condition.judge.PathPatternPredicateJudge

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/condition/judge/PredicateJudgeFactoryTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/condition/judge/PredicateJudgeFactoryTest.java
@@ -79,7 +79,7 @@ public final class PredicateJudgeFactoryTest {
     
     @Test
     public void testPathPatternJudge() {
-        conditionData.setOperator(OperatorEnum.PATH_PATTER.getAlias());
+        conditionData.setOperator(OperatorEnum.PATH_PATTERN.getAlias());
         conditionData.setParamValue("/http/**");
         assertTrue(PredicateJudgeFactory.judge(conditionData, "/http/**"));
         assertTrue(PredicateJudgeFactory.judge(conditionData, "/http/test"));


### PR DESCRIPTION
Spi does not match sql script config, therefore selector or ruler that added in admin with 'pathPattern' value cannot work.

![image](https://user-images.githubusercontent.com/49482363/182755359-c1bdf2e2-39df-45fe-9163-22a7bf8dcb9a.png)

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
