### PR TITLE
[ISSUE #3852] bug fix , request plugin can't replaceCookie 

### DIFF
--- a/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
@@ -187,8 +187,9 @@ public class RequestPlugin extends AbstractShenyuPlugin {
     private void replaceCookieKey(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
         List<HttpCookie> httpCookies = cookies.get(shenyuCookie.getKey());
         if (Objects.nonNull(httpCookies)) {
-            cookies.addAll(shenyuCookie.getValue(), httpCookies);
             cookies.remove(shenyuCookie.getKey());
+            List<HttpCookie> newKeyCookieList = httpCookies.stream().filter(Objects::nonNull).map(cookie -> new HttpCookie(shenyuCookie.getValue(), cookie.getValue())).collect(Collectors.toList());
+            cookies.addAll(shenyuCookie.getValue(), newKeyCookieList);
         }
     }
 


### PR DESCRIPTION

Fixes #3870
- fix request plugin can't replaceCookie bug
- add test case for request plugin ensure the replacement cookie rules meet expectations
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
