### PR TITLE
[type: build] Support user-defined jvm param in startup scripts

### DIFF
--- a/shenyu-dist/shenyu-admin-dist/Dockerfile
+++ b/shenyu-dist/shenyu-admin-dist/Dockerfile
@@ -15,10 +15,11 @@
 # limitations under the License.
 
 FROM openjdk:8-jre-alpine
-        
+
 ARG APP_NAME
 
 ENV LOCAL_PATH /opt/shenyu-admin
+ENV ADMIN_JVM ""
 
 RUN apk --no-cache add procps
 

--- a/shenyu-dist/shenyu-admin-dist/src/main/resources/bin/start.sh
+++ b/shenyu-dist/shenyu-admin-dist/src/main/resources/bin/start.sh
@@ -31,7 +31,7 @@ LOG_FILES=${LOGS_DIR}/shenyu-admin.log
 EXT_LIB=${DEPLOY_DIR}/ext-lib
 
 CLASS_PATH=.:${DEPLOY_DIR}/conf:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
-if [ -z "${SHENYU_ADMIN_JAVA_OPTS}" ]; then
+if [ -z "${ADMIN_JVM}" ]; then
     JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC  -XX:LargePageSizeInBytes=128m"
     version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
     echo "current jdk version:${version}"
@@ -44,7 +44,7 @@ if [ -z "${SHENYU_ADMIN_JAVA_OPTS}" ]; then
     fi
     echo "Use default jvm param: $JAVA_OPTS"
 else
-    JAVA_OPTS=${SHENYU_ADMIN_JAVA_OPTS}
+    JAVA_OPTS=${ADMIN_JVM}
     echo "Start with the environment variable JAVA_OPTS set: $JAVA_OPTS"
 fi
 

--- a/shenyu-dist/shenyu-admin-dist/src/main/resources/bin/start.sh
+++ b/shenyu-dist/shenyu-admin-dist/src/main/resources/bin/start.sh
@@ -31,16 +31,21 @@ LOG_FILES=${LOGS_DIR}/shenyu-admin.log
 EXT_LIB=${DEPLOY_DIR}/ext-lib
 
 CLASS_PATH=.:${DEPLOY_DIR}/conf:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
-JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
-
-version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
-echo "current jdk version:${version}"
-if [[ "$version" =~ "1.8" ]];then
-JAVA_OPTS="${JAVA_OPTS} -XX:+UseFastAccessorMethods  -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly  -XX:CMSInitiatingOccupancyFraction=70"
-elif [[ "$version" =~ "11" ]];then
-JAVA_OPTS="${JAVA_OPTS}"
-elif [[ "$version" =~ "17" ]];then
-JAVA_OPTS="${JAVA_OPTS}"
+if [ -z "${SHENYU_ADMIN_JAVA_OPTS}" ]; then
+    JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC  -XX:LargePageSizeInBytes=128m"
+    version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
+    echo "current jdk version:${version}"
+    if [[ "$version" =~ "1.8" ]];then
+        JAVA_OPTS="${JAVA_OPTS} -XX:+UseFastAccessorMethods  -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly  -XX:CMSInitiatingOccupancyFraction=70"
+    elif [[ "$version" =~ "11" ]];then
+        JAVA_OPTS="${JAVA_OPTS}"
+    elif [[ "$version" =~ "17" ]];then
+        JAVA_OPTS="${JAVA_OPTS}"
+    fi
+    echo "Use default jvm param: $JAVA_OPTS"
+else
+    JAVA_OPTS=${SHENYU_ADMIN_JAVA_OPTS}
+    echo "Start with the environment variable JAVA_OPTS set: $JAVA_OPTS"
 fi
 
 MAIN_CLASS=org.apache.shenyu.admin.ShenyuAdminBootstrap

--- a/shenyu-dist/shenyu-bootstrap-dist/Dockerfile
+++ b/shenyu-dist/shenyu-bootstrap-dist/Dockerfile
@@ -17,7 +17,9 @@
 FROM openjdk:8-jre-alpine
 
 ARG APP_NAME
+
 ENV LOCAL_PATH /opt/shenyu-bootstrap
+ENV BOOT_JVM ""
 
 RUN apk --no-cache add procps
 

--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
@@ -31,7 +31,7 @@ LOG_FILES=${LOGS_DIR}/shenyu-bootstrap.log
 EXT_LIB=${DEPLOY_DIR}/ext-lib
 
 CLASS_PATH=.:${DEPLOY_DIR}/conf:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
-if [ -z "${SHENYU_BOOTSTRAP_JAVA_OPTS}" ]; then
+if [ -z "${BOOT_JVM}" ]; then
     JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss512k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
     version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
     echo "current jdk version:${version}"
@@ -44,7 +44,7 @@ if [ -z "${SHENYU_BOOTSTRAP_JAVA_OPTS}" ]; then
     fi
     echo "Use default jvm param: $JAVA_OPTS"
 else
-    JAVA_OPTS=${SHENYU_BOOTSTRAP_JAVA_OPTS}
+    JAVA_OPTS=${BOOT_JVM}
     echo "Start with the environment variable JAVA_OPTS set: $JAVA_OPTS"
 fi
 

--- a/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
+++ b/shenyu-dist/shenyu-bootstrap-dist/src/main/resources/bin/start.sh
@@ -31,16 +31,21 @@ LOG_FILES=${LOGS_DIR}/shenyu-bootstrap.log
 EXT_LIB=${DEPLOY_DIR}/ext-lib
 
 CLASS_PATH=.:${DEPLOY_DIR}/conf:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
-JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss512k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
-
-version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
-echo "current jdk version:${version}"
-if [[ "$version" =~ "1.8" ]];then
-JAVA_OPTS="${JAVA_OPTS} -XX:+UseFastAccessorMethods  -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly  -XX:CMSInitiatingOccupancyFraction=70"
-elif [[ "$version" =~ "11" ]];then
-JAVA_OPTS="${JAVA_OPTS}"
-elif [[ "$version" =~ "17" ]];then
-JAVA_OPTS="${JAVA_OPTS}"
+if [ -z "${SHENYU_BOOTSTRAP_JAVA_OPTS}" ]; then
+    JAVA_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss512k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m"
+    version=`java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
+    echo "current jdk version:${version}"
+    if [[ "$version" =~ "1.8" ]];then
+        JAVA_OPTS="${JAVA_OPTS} -XX:+UseFastAccessorMethods  -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly  -XX:CMSInitiatingOccupancyFraction=70"
+    elif [[ "$version" =~ "11" ]];then
+        JAVA_OPTS="${JAVA_OPTS}"
+    elif [[ "$version" =~ "17" ]];then
+        JAVA_OPTS="${JAVA_OPTS}"
+    fi
+    echo "Use default jvm param: $JAVA_OPTS"
+else
+    JAVA_OPTS=${SHENYU_BOOTSTRAP_JAVA_OPTS}
+    echo "Start with the environment variable JAVA_OPTS set: $JAVA_OPTS"
 fi
 
 MAIN_CLASS=org.apache.shenyu.bootstrap.ShenyuBootstrapApplication


### PR DESCRIPTION
Resolve #3916

Use environment variables to pass JVM parameters, corresponding to `SHENYU_ADMIN_JAVA_OPTS` in `shenyu-admin` and `SHENYU_BOOTSTRAP_JAVA_OPTS` in `shenyu-bootstrap`.

In docker, we just need to add `-e` to set environment variables.

In docker-compose, we just need to add `environment` config.

![image](https://user-images.githubusercontent.com/62384022/188797216-f8d9b567-ac89-4571-83ff-8edafe409135.png)

![image](https://user-images.githubusercontent.com/62384022/188797274-e0562c70-037f-4c4e-8a53-fb9e8af0ad89.png)

![image](https://user-images.githubusercontent.com/62384022/188797369-8e44beca-273c-45dc-b1d5-96369c94fe11.png)

![image](https://user-images.githubusercontent.com/62384022/188797407-54801283-632e-402a-b461-d678360e501a.png)
