### PR TITLE
[type:bug] Fix sentinel plugin bug

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java
@@ -148,6 +148,11 @@ public interface Constants {
     String MODULE = "module";
 
     /**
+     * WATCHER_HTTP_STATUS.
+     */
+    String WATCHER_HTTP_STATUS = "WATCHER_HTTP_STATUS";
+
+    /**
      * The constant METHOD.
      */
     String METHOD = "method";

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java
@@ -148,6 +148,11 @@ public interface Constants {
     String MODULE = "module";
 
     /**
+     * RESPONSE_MONO.
+     */
+    String RESPONSE_MONO = "RESPONSE_MONO";
+
+    /**
      * WATCHER_HTTP_STATUS.
      */
     String WATCHER_HTTP_STATUS = "WATCHER_HTTP_STATUS";

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java
@@ -34,6 +34,8 @@ import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
 import java.net.URI;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * The type Netty http client plugin.
@@ -76,6 +78,9 @@ public class NettyHttpClientPlugin extends AbstractHttpClientPlugin<HttpClientRe
                         throw new IllegalStateException("Unable to set status code on response: " + res.status().code() + ", " + response.getClass());
                     }
                     response.getHeaders().putAll(headers);
+                    // watcher httpStatus
+                    final Consumer<HttpStatus> consumer = exchange.getAttribute(Constants.WATCHER_HTTP_STATUS);
+                    Optional.ofNullable(consumer).ifPresent(c -> c.accept(response.getStatusCode()));
                     return Mono.just(res);
                 }));
     }

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -24,6 +24,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -33,6 +34,7 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * The type Web client plugin.
@@ -79,6 +81,9 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
                     }
                     exchange.getResponse().setStatusCode(res.statusCode());
                     exchange.getAttributes().put(Constants.CLIENT_RESPONSE_ATTR, res);
+                    // sentinel watcher httpStatus
+                    final Consumer<HttpStatus> consumer = exchange.getAttribute(Constants.WATCHER_HTTP_STATUS);
+                    Optional.ofNullable(consumer).ifPresent(c -> c.accept(res.statusCode()));
                 });
     }
     

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -24,7 +24,6 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -34,7 +33,6 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 /**
  * The type Web client plugin.
@@ -81,9 +79,6 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
                     }
                     exchange.getResponse().setStatusCode(res.statusCode());
                     exchange.getAttributes().put(Constants.CLIENT_RESPONSE_ATTR, res);
-                    // watcher httpStatus
-                    final Consumer<HttpStatus> consumer = exchange.getAttribute(Constants.WATCHER_HTTP_STATUS);
-                    Optional.ofNullable(consumer).ifPresent(c -> c.accept(res.statusCode()));
                 });
     }
     

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -81,7 +81,7 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ClientResponse> {
                     }
                     exchange.getResponse().setStatusCode(res.statusCode());
                     exchange.getAttributes().put(Constants.CLIENT_RESPONSE_ATTR, res);
-                    // sentinel watcher httpStatus
+                    // watcher httpStatus
                     final Consumer<HttpStatus> consumer = exchange.getAttribute(Constants.WATCHER_HTTP_STATUS);
                     Optional.ofNullable(consumer).ifPresent(c -> c.accept(res.statusCode()));
                 });

--- a/shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/strategy/RPCMessageWriter.java
+++ b/shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/strategy/RPCMessageWriter.java
@@ -24,11 +24,14 @@ import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * The type Rpc message writer.
@@ -43,7 +46,12 @@ public class RPCMessageWriter implements MessageWriter {
                 Object error = ShenyuResultWrap.error(exchange, ShenyuResultEnum.SERVICE_RESULT_ERROR);
                 return WebFluxResultUtils.result(exchange, error);
             }
-            return WebFluxResultUtils.result(exchange, result);
+            Mono<Void> responseMono = WebFluxResultUtils.result(exchange, result);
+            exchange.getAttributes().put(Constants.RESPONSE_MONO, responseMono);
+            // watcher httpStatus
+            final Consumer<HttpStatus> consumer = exchange.getAttribute(Constants.WATCHER_HTTP_STATUS);
+            Optional.ofNullable(consumer).ifPresent(c -> c.accept(exchange.getResponse().getStatusCode()));
+            return responseMono;
         }));
     }
     

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java
@@ -57,7 +57,6 @@ public class SentinelPlugin extends AbstractShenyuPlugin {
         sentinelHandle.checkData(sentinelHandle);
         exchange.getAttributes().put(Constants.WATCHER_HTTP_STATUS, (Consumer<HttpStatus>) status -> {
             if (status == null || !status.is2xxSuccessful()) {
-                exchange.getResponse().setStatusCode(null);
                 throw new SentinelFallbackException(status == null ? HttpStatus.INTERNAL_SERVER_ERROR : status);
             }
         });

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java
@@ -24,16 +24,18 @@ import org.apache.shenyu.common.dto.SelectorData;
 import org.apache.shenyu.common.dto.convert.rule.SentinelHandle;
 import org.apache.shenyu.common.enums.PluginEnum;
 import org.apache.shenyu.common.utils.GsonUtils;
+import org.apache.shenyu.common.utils.UriUtils;
 import org.apache.shenyu.plugin.api.ShenyuPluginChain;
 import org.apache.shenyu.plugin.api.context.ShenyuContext;
 import org.apache.shenyu.plugin.base.AbstractShenyuPlugin;
 import org.apache.shenyu.plugin.base.fallback.FallbackHandler;
 import org.apache.shenyu.plugin.base.utils.CacheKeyUtils;
-import org.apache.shenyu.common.utils.UriUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.util.function.Consumer;
 
 /**
  * Sentinel Plugin.
@@ -53,13 +55,13 @@ public class SentinelPlugin extends AbstractShenyuPlugin {
         String resourceName = CacheKeyUtils.INST.getKey(rule);
         SentinelHandle sentinelHandle = GsonUtils.getInstance().fromJson(rule.getHandle(), SentinelHandle.class);
         sentinelHandle.checkData(sentinelHandle);
-        return chain.execute(exchange).doOnSuccess(v -> {
-            HttpStatus status = exchange.getResponse().getStatusCode();
+        exchange.getAttributes().put(Constants.WATCHER_HTTP_STATUS, (Consumer<HttpStatus>) status -> {
             if (status == null || !status.is2xxSuccessful()) {
                 exchange.getResponse().setStatusCode(null);
                 throw new SentinelFallbackException(status == null ? HttpStatus.INTERNAL_SERVER_ERROR : status);
             }
-        }).transform(new SentinelReactorTransformer<>(resourceName)).onErrorResume(throwable ->
+        });
+        return chain.execute(exchange).transform(new SentinelReactorTransformer<>(resourceName)).onErrorResume(throwable ->
                 fallbackHandler.fallback(exchange, UriUtils.createUri(sentinelHandle.getFallbackUri()), throwable));
     }
 

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandler.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/fallback/SentinelFallbackHandler.java
@@ -20,10 +20,12 @@ package org.apache.shenyu.plugin.sentinel.fallback;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.degrade.DegradeException;
 import com.alibaba.csp.sentinel.slots.block.flow.FlowException;
+import org.apache.shenyu.common.constant.Constants;
 import org.apache.shenyu.plugin.api.result.ShenyuResultEnum;
 import org.apache.shenyu.plugin.base.fallback.FallbackHandler;
 import org.apache.shenyu.plugin.api.result.ShenyuResultWrap;
 import org.apache.shenyu.plugin.api.utils.WebFluxResultUtils;
+import org.apache.shenyu.plugin.sentinel.SentinelPlugin;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -45,6 +47,8 @@ public class SentinelFallbackHandler implements FallbackHandler {
         } else if (throwable instanceof BlockException) {
             exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
             error = ShenyuResultWrap.error(exchange, ShenyuResultEnum.SENTINEL_BLOCK_ERROR);
+        } else if (throwable instanceof SentinelPlugin.SentinelFallbackException) {
+            return exchange.getAttribute(Constants.RESPONSE_MONO);
         } else {
             return Mono.error(throwable);
         }

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/SentinelPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/SentinelPluginTest.java
@@ -212,8 +212,7 @@ public final class SentinelPluginTest {
 
         Mono mono = Mono.empty().doOnSuccess(v -> exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS));
         when(chain.execute(exchange)).thenReturn(mono);
-        StepVerifier.create(sentinelPlugin.doExecute(exchange, chain, selectorData, data))
-                .expectError(HttpStatusCodeException.class).verify();
+        StepVerifier.create(sentinelPlugin.doExecute(exchange, chain, selectorData, data)).expectComplete().verify();
 
         // remove rule
         sentinelRuleHandle.removeRule(data);

--- a/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/SentinelPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-sentinel/src/test/java/org/apache/shenyu/plugin/sentinel/SentinelPluginTest.java
@@ -41,7 +41,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
Fixes #3952
`SentinelPlugin` should not use `doOnSuccess`, this method is not called until the response is sent to the client.

After the completion of `respnsePlugin`, the status should be notified to `SentinelPlugin` to determine whether it is abnormal,

We need to transparently transmit the abnormal data that the application responds to the client.
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
