### PR TITLE
[type:bugfix] fix task that publish docker image to ghcr does not work

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,9 +19,9 @@ on:
   push:
     branches: [ "master" ]
     tags: [ 'v*.*.*' ]
-    paths:
-      - '!**.md'
-      - '!**/resources/static/'
+    paths-ignore:
+      - '**.md'
+      - '**/resources/static/'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

`on.push.paths` seem like that cannot start with `'!**'`. 
I change it to `on.push.paths-ignore`, and it is more clear semantics.

See https://github.com/apache/shenyu/actions/workflows/docker-publish.yml, this work has not worked since 23 days ago.