### PR TITLE
Fix issue: an error occurs when saving modified Dictionary.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ShenyuDictDTO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ShenyuDictDTO.java
@@ -76,8 +76,7 @@ public class ShenyuDictDTO implements Serializable {
     /**
      * whether enabled.
      */
-    @NotNull
-    private Boolean enabled;
+    private Boolean enabled = true;
     
     public ShenyuDictDTO() {
     }


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
Fixes #3998.
Because there is no enable item on edit page, an error will occurs when saving Dictionary. So in the application, remove the enable field's NotNull validation and give it a default `true` value. 

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
