### PR TITLE
[type:fix] fixed AbstractShenyuPluginTest:increase independence of te…

### DIFF
--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/AbstractShenyuPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/AbstractShenyuPluginTest.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -75,9 +77,10 @@ public final class AbstractShenyuPluginTest {
         this.pluginData = PluginData.builder().name("SHENYU").enabled(true).build();
         this.selectorData = SelectorData.builder().id("1").pluginName("SHENYU")
                 .enabled(true).type(SelectorTypeEnum.CUSTOM_FLOW.getCode()).build();
-        this.testShenyuPlugin = new TestShenyuPlugin();
+        this.testShenyuPlugin = spy(new TestShenyuPlugin());
         this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/http/SHENYU/SHENYU")
                 .build());
+        clearCache();
         when(shenyuPluginChain.execute(exchange)).thenReturn(Mono.empty());
     }
 
@@ -87,6 +90,7 @@ public final class AbstractShenyuPluginTest {
     @Test
     public void executePluginIsNullTest() {
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(shenyuPluginChain).execute(exchange);
     }
 
     /**
@@ -96,6 +100,7 @@ public final class AbstractShenyuPluginTest {
     public void executeSelectorIsNullTest() {
         BaseDataCache.getInstance().cachePluginData(pluginData);
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(shenyuPluginChain).execute(exchange);
     }
 
     /**
@@ -106,6 +111,7 @@ public final class AbstractShenyuPluginTest {
         BaseDataCache.getInstance().cachePluginData(pluginData);
         BaseDataCache.getInstance().cacheSelectData(selectorData);
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(shenyuPluginChain).execute(exchange);
     }
 
     /**
@@ -120,6 +126,7 @@ public final class AbstractShenyuPluginTest {
         BaseDataCache.getInstance().cachePluginData(pluginData);
         BaseDataCache.getInstance().cacheSelectData(selectorData);
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(shenyuPluginChain).execute(exchange);
     }
 
     /**
@@ -137,6 +144,7 @@ public final class AbstractShenyuPluginTest {
         BaseDataCache.getInstance().cacheSelectData(selectorData);
         BaseDataCache.getInstance().cacheRuleData(ruleData);
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(testShenyuPlugin).doExecute(exchange, shenyuPluginChain, selectorData, ruleData);
     }
 
     /**
@@ -155,12 +163,19 @@ public final class AbstractShenyuPluginTest {
         BaseDataCache.getInstance().cacheSelectData(selectorData);
         BaseDataCache.getInstance().cacheRuleData(ruleData);
         StepVerifier.create(testShenyuPlugin.execute(exchange, shenyuPluginChain)).expectSubscription().verifyComplete();
+        verify(testShenyuPlugin).doExecute(exchange, shenyuPluginChain, selectorData, ruleData);
     }
 
     private void mockShenyuConfig() {
         ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
         when(context.getBean(ShenyuConfig.class)).thenReturn(new ShenyuConfig());
         SpringBeanUtils.getInstance().setApplicationContext(context);
+    }
+
+    private void clearCache() {
+        BaseDataCache.getInstance().cleanPluginData();
+        BaseDataCache.getInstance().cleanSelectorData();
+        BaseDataCache.getInstance().cleanRuleData();
     }
 
     static class TestShenyuPlugin extends AbstractShenyuPlugin {


### PR DESCRIPTION
increase independence of testing and accuracy of test

<!-- Describe your PR here; eg. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.


Completion does not indicate success , so add  verify();
When I added verify , I found ths tests influence each other becase  of cache  .

If I didnt add clearing cache , it happens some tests have errors
![image](https://user-images.githubusercontent.com/42602026/198922442-282d51aa-0a4d-4209-86c2-4ecfdedee65b.png)

If I did it, it works
![image](https://user-images.githubusercontent.com/42602026/198922652-f857ce72-c66f-4a98-81f6-6ce39f91f5da.png)

