### PR TITLE
[ISSUE #4049] remove validation of field `enabled`

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/AuthPathDTO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/AuthPathDTO.java
@@ -18,7 +18,6 @@
 package org.apache.shenyu.admin.model.dto;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/AuthPathDTO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/AuthPathDTO.java
@@ -34,7 +34,6 @@ public class AuthPathDTO implements Serializable {
     @NotBlank
     private String path;
 
-    @NotNull
     private Boolean enabled;
 
     /**


### PR DESCRIPTION
fix #4049 
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

Base on `v2.5.0`, the field `enabled` in AuthPathDTO is never used exclude in unit test.

When path update, we will transfer AuthPathDTO to AuthPathDO. 
![image](https://user-images.githubusercontent.com/15926669/207755615-d1fc8525-fbb7-4963-99d4-8540e62be313.png)

However, the `enebled` field is always set as `true`.
Therefore, the `@NotNull` on `enabled` is unnecessary.
