### PR TITLE
[type:fix] ModifyResponsePlugin resetting the configuration of maxInMemorySize in yml to the default value 256K

### DIFF
--- a/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
+++ b/shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -143,8 +144,9 @@ public class ModifyResponsePlugin extends AbstractShenyuPlugin {
             this.getDelegate().getHeaders().clear();
             this.getDelegate().getHeaders().putAll(httpHeaders);
             int rowStatusCode = clientResponse.rawStatusCode();
+            ExchangeStrategies strategies = clientResponse.strategies();
 
-            return ClientResponse.create(statusCode)
+            return ClientResponse.create(statusCode, strategies)
                     .rawStatusCode(rowStatusCode)
                     .headers(headers -> headers.addAll(httpHeaders))
                     .cookies(cookies -> cookies.addAll(this.getCookies()))


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.


Fixed the ModifyResponsePlugin resetting the configuration of maxInMemorySize in yml to the default value 256K.

![73321673264004_ pic](https://user-images.githubusercontent.com/5889405/211318646-9c556f23-4d0b-4e0e-98d8-8bb54347a7aa.jpg)

