### PR TITLE
smart h2 path

### DIFF
--- a/shenyu-admin/src/main/resources/application-h2.yml
+++ b/shenyu-admin/src/main/resources/application-h2.yml
@@ -21,7 +21,7 @@ shenyu:
 
 spring:
   datasource:
-    url: jdbc:h2:mem:~/shenyu;DB_CLOSE_DELAY=-1;MODE=MySQL;
+    url: jdbc:h2:mem:${HOME:${HOMEDRIVE}${HOMEPATH}}/shenyu;DB_CLOSE_DELAY=-1;MODE=MySQL;
     username: sa
     password: sa
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
Intelligent access to the user directory of the system, so that Windows and Mac can try it immediately without changing the path through H2.

I tried it on Mac and Windows.

Hope it helps.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
