### PR TITLE
Revert "Resolve shenyu project global version."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.apache.shenyu</groupId>
     <artifactId>shenyu</artifactId>
     <packaging>pom</packaging>
-    <version>${shenyu.version}</version>
+    <version>2.6.0-SNAPSHOT</version>
     <name>shenyu</name>
     <modules>
         <module>shenyu-admin</module>
@@ -77,7 +77,6 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <shenyu.version>2.6.0-SNAPSHOT</shenyu.version>
         <hutool.version>4.0.8</hutool.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jasypt.version>1.9.2</jasypt.version>
@@ -150,7 +149,6 @@
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
-        <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
@@ -619,34 +617,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>${versions-maven-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten-maven-plugin.version}</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                    <pomElements>
-                        <dependencies>expand</dependencies>
-                    </pomElements>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-admin</artifactId>

--- a/shenyu-alert/pom.xml
+++ b/shenyu-alert/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-alert</artifactId>

--- a/shenyu-bootstrap/pom.xml
+++ b/shenyu-bootstrap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-bootstrap</artifactId>

--- a/shenyu-client/pom.xml
+++ b/shenyu-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client</artifactId>

--- a/shenyu-client/shenyu-client-api-docs-annotations/pom.xml
+++ b/shenyu-client/shenyu-client-api-docs-annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/shenyu-client/shenyu-client-brpc/pom.xml
+++ b/shenyu-client/shenyu-client-brpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-client/shenyu-client-core/pom.xml
+++ b/shenyu-client/shenyu-client-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-core</artifactId>

--- a/shenyu-client/shenyu-client-dubbo/pom.xml
+++ b/shenyu-client/shenyu-client-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-dubbo</artifactId>

--- a/shenyu-client/shenyu-client-dubbo/shenyu-client-alibaba-dubbo/pom.xml
+++ b/shenyu-client/shenyu-client-dubbo/shenyu-client-alibaba-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-alibaba-dubbo</artifactId>

--- a/shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml
+++ b/shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-apache-dubbo</artifactId>

--- a/shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml
+++ b/shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-dubbo-common</artifactId>

--- a/shenyu-client/shenyu-client-grpc/pom.xml
+++ b/shenyu-client/shenyu-client-grpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-grpc</artifactId>

--- a/shenyu-client/shenyu-client-http/pom.xml
+++ b/shenyu-client/shenyu-client-http/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-http</artifactId>

--- a/shenyu-client/shenyu-client-http/shenyu-client-springcloud/pom.xml
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springcloud/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-http</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-springcloud</artifactId>

--- a/shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-http</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-springmvc</artifactId>

--- a/shenyu-client/shenyu-client-motan/pom.xml
+++ b/shenyu-client/shenyu-client-motan/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-client/shenyu-client-sofa/pom.xml
+++ b/shenyu-client/shenyu-client-sofa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-sofa</artifactId>

--- a/shenyu-client/shenyu-client-tars/pom.xml
+++ b/shenyu-client/shenyu-client-tars/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-tars</artifactId>

--- a/shenyu-client/shenyu-client-websocket/pom.xml
+++ b/shenyu-client/shenyu-client-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-websocket</artifactId>

--- a/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml
+++ b/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-client-websocket</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-client-spring-websocket</artifactId>

--- a/shenyu-common/pom.xml
+++ b/shenyu-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-common</artifactId>

--- a/shenyu-disruptor/pom.xml
+++ b/shenyu-disruptor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-disruptor</artifactId>

--- a/shenyu-dist/pom.xml
+++ b/shenyu-dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-dist</artifactId>

--- a/shenyu-dist/shenyu-admin-dist/pom.xml
+++ b/shenyu-dist/shenyu-admin-dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-dist</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-admin-dist</artifactId>

--- a/shenyu-dist/shenyu-bootstrap-dist/pom.xml
+++ b/shenyu-dist/shenyu-bootstrap-dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-dist</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-bootstrap-dist</artifactId>

--- a/shenyu-dist/shenyu-docker-compose-dist/pom.xml
+++ b/shenyu-dist/shenyu-docker-compose-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-dist</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>shenyu-docker-compose-dist</artifactId>
     <packaging>pom</packaging>

--- a/shenyu-dist/shenyu-src-dist/pom.xml
+++ b/shenyu-dist/shenyu-src-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-dist</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>shenyu-src-dist</artifactId>
     <packaging>pom</packaging>

--- a/shenyu-examples/pom.xml
+++ b/shenyu-examples/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.shenyu</groupId>
     <artifactId>shenyu-examples</artifactId>
-    <version>${shenyu.version}</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -38,7 +38,6 @@
         <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
         <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-        <shenyu.version>2.6.0-SNAPSHOT</shenyu.version>
     </properties>
 
     <modules>

--- a/shenyu-examples/shenyu-examples-brpc/pom.xml
+++ b/shenyu-examples/shenyu-examples-brpc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-brpc</artifactId>

--- a/shenyu-examples/shenyu-examples-brpc/shenyu-examples-brpc-api/pom.xml
+++ b/shenyu-examples/shenyu-examples-brpc/shenyu-examples-brpc-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-brpc</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-brpc-api</artifactId>

--- a/shenyu-examples/shenyu-examples-brpc/shenyu-examples-brpc-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-brpc/shenyu-examples-brpc-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-brpc</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-brpc-service</artifactId>

--- a/shenyu-examples/shenyu-examples-common/pom.xml
+++ b/shenyu-examples/shenyu-examples-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-dubbo/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-dubbo</artifactId>

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-alibaba-dubbo-service-annotation/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-alibaba-dubbo-service-annotation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-dubbo</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-alibaba-dubbo-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-alibaba-dubbo-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-dubbo</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-apache-dubbo-service-xml</artifactId>
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-examples-dubbo-api</artifactId>
-            <version>${shenyu.version}</version>
+            <version>2.6.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-apache-dubbo-service</artifactId>

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-dubbo-api</artifactId>

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-spring-cloud-alibaba-dubbo-service-annotation/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-spring-cloud-alibaba-dubbo-service-annotation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>shenyu-examples-dubbo</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-eureka/pom.xml
+++ b/shenyu-examples/shenyu-examples-eureka/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-eureka</artifactId>

--- a/shenyu-examples/shenyu-examples-grpc/pom.xml
+++ b/shenyu-examples/shenyu-examples-grpc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-grpc</artifactId>

--- a/shenyu-examples/shenyu-examples-http/pom.xml
+++ b/shenyu-examples/shenyu-examples-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-http</artifactId>

--- a/shenyu-examples/shenyu-examples-https/pom.xml
+++ b/shenyu-examples/shenyu-examples-https/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-https</artifactId>

--- a/shenyu-examples/shenyu-examples-motan/pom.xml
+++ b/shenyu-examples/shenyu-examples-motan/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml
+++ b/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-motan</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-motan</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-plugin/pom.xml
+++ b/shenyu-examples/shenyu-examples-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-plugin</artifactId>

--- a/shenyu-examples/shenyu-examples-sdk/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <shenyu-sdk.version>${shenyu.version}</shenyu-sdk.version>
+        <shenyu-sdk.version>2.6.0-SNAPSHOT</shenyu-sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-sdk</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sdk-dubbo</artifactId>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-alibaba-dubbo-consumer/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-alibaba-dubbo-consumer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-dubbo</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-alibaba-dubbo-provider/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-alibaba-dubbo-provider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-sdk-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sdk-alibaba-dubbo-provider</artifactId>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-dubbo</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-sdk-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sdk-apache-dubbo-provider</artifactId>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-grpc</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-grpc</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-springcloud</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-register-instance-eureka</artifactId>
-            <version>${shenyu.version}</version>
+            <version>2.6.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>servlet-api</artifactId>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>shenyu-examples-sdk-springcloud</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-examples/shenyu-examples-sofa/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sofa</artifactId>

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-sofa</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sofa-api</artifactId>

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples-sofa</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-sofa-service</artifactId>

--- a/shenyu-examples/shenyu-examples-springcloud/pom.xml
+++ b/shenyu-examples/shenyu-examples-springcloud/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-springcloud</artifactId>

--- a/shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml
+++ b/shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>shenyu-examples</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-springmvc-tomcat</artifactId>

--- a/shenyu-examples/shenyu-examples-springmvc/pom.xml
+++ b/shenyu-examples/shenyu-examples-springmvc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-springmvc</artifactId>

--- a/shenyu-examples/shenyu-examples-tars/pom.xml
+++ b/shenyu-examples/shenyu-examples-tars/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-tars</artifactId>

--- a/shenyu-examples/shenyu-examples-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-examples</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-examples-websocket</artifactId>

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-websocket</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-example-spring-annotation-websocket</artifactId>

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-websocket</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-example-spring-native-websocket</artifactId>

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-examples-websocket</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/pom.xml
+++ b/shenyu-integrated-test/pom.xml
@@ -19,13 +19,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-integrated-test</artifactId>
-    <version>${shenyu.version}</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/shenyu-integrated-test/shenyu-integrated-test-alibaba-dubbo/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-alibaba-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-alibaba-dubbo</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-apache-dubbo</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-brpc/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-brpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-common/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>shenyu-integrated-test-common</artifactId>
     <name>shenyu-integrated-test-common</name>

--- a/shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-http/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-http</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-https/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-https/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-https</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-sdk-alibaba-dubbo/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sdk-alibaba-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-sdk-alibaba-dubbo</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-sdk-apache-dubbo</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-integrated-test</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>shenyu-integrated-test-spring-cloud</artifactId>

--- a/shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml
+++ b/shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shenyu-integrated-test</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-loadbalancer/pom.xml
+++ b/shenyu-loadbalancer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-loadbalancer</artifactId>

--- a/shenyu-plugin/pom.xml
+++ b/shenyu-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-api/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-api</artifactId>

--- a/shenyu-plugin/shenyu-plugin-base/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-base/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-base</artifactId>

--- a/shenyu-plugin/shenyu-plugin-brpc/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-brpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-cache/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cache/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-cache</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-cache</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-cache</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-cache</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-casdoor/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-casdoor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-context-path/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-context-path/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-context-path</artifactId>

--- a/shenyu-plugin/shenyu-plugin-cryptor/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-cryptor/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-divide/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-divide/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-divide</artifactId>

--- a/shenyu-plugin/shenyu-plugin-dubbo/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-alibaba-dubbo/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-alibaba-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-alibaba-dubbo</artifactId>

--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-apache-dubbo</artifactId>

--- a/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-dubbo-common</artifactId>

--- a/shenyu-plugin/shenyu-plugin-general-context/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-general-context/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-global/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-global/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-global</artifactId>

--- a/shenyu-plugin/shenyu-plugin-grpc/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-grpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-grpc</artifactId>

--- a/shenyu-plugin/shenyu-plugin-httpclient/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-httpclient/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-httpclient</artifactId>

--- a/shenyu-plugin/shenyu-plugin-hystrix/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-hystrix/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-hystrix</artifactId>

--- a/shenyu-plugin/shenyu-plugin-jwt/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-jwt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-jwt</artifactId>

--- a/shenyu-plugin/shenyu-plugin-key-auth/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-key-auth/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-key-auth</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-aliyun-sls</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>shenyu-plugin-logging</artifactId>
     <groupId>org.apache.shenyu</groupId>
-    <version>${shenyu.version}</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>shenyu-plugin-logging-clickhouse</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-logging</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-elasticsearch</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-kafka</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-mask-api/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-mask-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin-logging</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-mask-api</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-rocketmq</artifactId>

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin-logging</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-logging-tencent-cls</artifactId>

--- a/shenyu-plugin/shenyu-plugin-metrics/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-metrics</artifactId>

--- a/shenyu-plugin/shenyu-plugin-mock/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-mock/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-modify-response/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-modify-response/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-motan/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-motan/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-mqtt/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-mqtt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-oauth2/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-oauth2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-param-mapping/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-param-mapping/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-ratelimiter/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-ratelimiter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-ratelimiter</artifactId>

--- a/shenyu-plugin/shenyu-plugin-redirect/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-redirect/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-request/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-request/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-resilience4j/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-resilience4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-response/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-response/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-rewrite/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-rewrite/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-rewrite</artifactId>

--- a/shenyu-plugin/shenyu-plugin-sentinel/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-sentinel/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-sentinel</artifactId>

--- a/shenyu-plugin/shenyu-plugin-sign/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-sign/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-sign</artifactId>

--- a/shenyu-plugin/shenyu-plugin-sofa/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-sofa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-sofa</artifactId>

--- a/shenyu-plugin/shenyu-plugin-springcloud/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-springcloud/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-springcloud</artifactId>

--- a/shenyu-plugin/shenyu-plugin-tars/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-tars/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-uri/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-uri/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-uri</artifactId>

--- a/shenyu-plugin/shenyu-plugin-waf/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-waf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-plugin/shenyu-plugin-websocket/pom.xml
+++ b/shenyu-plugin/shenyu-plugin-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-plugin-websocket</artifactId>

--- a/shenyu-protocol/pom.xml
+++ b/shenyu-protocol/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-protocol</artifactId>

--- a/shenyu-protocol/shenyu-protocol-grpc/pom.xml
+++ b/shenyu-protocol/shenyu-protocol-grpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-protocol</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-protocol-grpc</artifactId>

--- a/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
+++ b/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-protocol</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-register-center/pom.xml
+++ b/shenyu-register-center/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-center</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-api/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client-server</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server-api</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-consul/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client-server</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server-consul</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-etcd/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client-server</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server-etcd</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-nacos/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-nacos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client-server</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server-nacos</artifactId>

--- a/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client-server/shenyu-register-client-server-zookeeper/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client-server</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-server-zookeeper</artifactId>

--- a/shenyu-register-center/shenyu-register-client/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-api</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-http</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-nacos</artifactId>

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-client-zookeeper</artifactId>

--- a/shenyu-register-center/shenyu-register-common/pom.xml
+++ b/shenyu-register-center/shenyu-register-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-common</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-api/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-api</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-consul/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-register-instance</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-consul</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-core/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-core</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-etcd/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-etcd</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-eureka/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-eureka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-eureka</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-nacos/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-nacos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-nacos</artifactId>

--- a/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
+++ b/shenyu-register-center/shenyu-register-instance/shenyu-register-instance-zookeeper/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-register-instance</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-register-instance-zookeeper</artifactId>

--- a/shenyu-sdk/pom.xml
+++ b/shenyu-sdk/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sdk</artifactId>

--- a/shenyu-sdk/shenyu-sdk-core/pom.xml
+++ b/shenyu-sdk/shenyu-sdk-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sdk</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sdk-core</artifactId>

--- a/shenyu-sdk/shenyu-sdk-httpclient/pom.xml
+++ b/shenyu-sdk/shenyu-sdk-httpclient/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sdk</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sdk-httpclient</artifactId>

--- a/shenyu-sdk/shenyu-sdk-okhttp/pom.xml
+++ b/shenyu-sdk/shenyu-sdk-okhttp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sdk</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sdk-okhttp</artifactId>

--- a/shenyu-sdk/shenyu-sdk-spring/pom.xml
+++ b/shenyu-sdk/shenyu-sdk-spring/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sdk</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sdk-spring</artifactId>

--- a/shenyu-spi/pom.xml
+++ b/shenyu-spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/pom.xml
+++ b/shenyu-spring-boot-starter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-alibaba-dubbo/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-alibaba-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-alibaba-dubbo</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-apache-dubbo</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-brpc/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-brpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-brpc</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-common</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-grpc</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-sofa</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-springcloud</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-client</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-client-tars</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-gateway</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-instance/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-instance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-instance</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-brpc/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-brpc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-context-path</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-divide</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-alibaba-dubbo/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-alibaba-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-alibaba-dubbo</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-apache-dubbo</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin-dubbo</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-dubbo-common</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-global</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-grpc</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-httpclient</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-hystrix</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-jwt</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-key-auth</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
     <groupId>org.apache.shenyu</groupId>
-    <version>${shenyu.version}</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>shenyu-spring-boot-starter-plugin-logging-clickhouse</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-metrics</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-ratelimiter</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-redirect</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-resilience4j</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
         <groupId>org.apache.shenyu</groupId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-rewrite</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-sentinel</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-sign</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-sofa</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-springcloud</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-tars</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-uri</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-waf</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-plugin</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-plugin-websocket</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-sdk</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-spring-boot-starter-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/shenyu-sync-data-center/pom.xml
+++ b/shenyu-sync-data-center/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-center</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-api/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-api</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-consul</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-etcd</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-http/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-http</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-nacos</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-websocket</artifactId>

--- a/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
+++ b/shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu-sync-data-center</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-sync-data-zookeeper</artifactId>

--- a/shenyu-web/pom.xml
+++ b/shenyu-web/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shenyu</groupId>
         <artifactId>shenyu</artifactId>
-        <version>${shenyu.version}</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shenyu-web</artifactId>


### PR DESCRIPTION
@yu199195 @li-keguo 
([release-maven-plugin](https://maven.apache.org/maven-release/maven-release-plugin/plugin-info.html) referred to as RMP)
> I am very sorry to explain here, and request to restore the previous merger.

### Here are the Reasons:

Ignorance of the RMP, I have just seen the pr [#4350](https://github.com/apache/shenyu/pull/4350)'s files changed, Especially ignored the commit messages. I feel that changing the version impacts a number of too many files, based on experience, I mentioned the previous pr.

After an in-depth understanding of the RMP, there is no compromise solution, unless the extension RMP increases the extension implementation of the global version variable, but there is no need to go the other way.

Pls, revert the wrong pr, I will raise more issues to discuss in the future to improve the quality of pr.