### PR TITLE
[bug fiexd]A nullpointerEXException occurred when starting example-springcloud with nacos configuration.

### DIFF
--- a/shenyu-examples/shenyu-examples-springcloud/src/main/resources/application.yml
+++ b/shenyu-examples/shenyu-examples-springcloud/src/main/resources/application.yml
@@ -51,6 +51,7 @@ shenyu:
     props:
       username: admin
       password: 123456
+      nacosNameSpace: 
   client:
     springCloud:
       props:

--- a/shenyu-examples/shenyu-examples-springcloud/src/main/resources/application.yml
+++ b/shenyu-examples/shenyu-examples-springcloud/src/main/resources/application.yml
@@ -51,7 +51,7 @@ shenyu:
     props:
       username: admin
       password: 123456
-      nacosNameSpace: 
+      nacosNameSpace: ShenyuRegisterCenter
   client:
     springCloud:
       props:


### PR DESCRIPTION
A nullpointerEXException occurred when starting example-springcloud with nacos configuration. The associated code is in org.apache.shenyu.register.client.nacos.NacosClientRegisterRepository:nacosProperties.put(PropertyKeyConst.NAMESPACE, properties.getProperty(NAMESPACE));

<!-- Describe your PR here; eg. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x ] You submit test cases (unit or integration tests) that back your changes.
- [ x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
