### PR TITLE
[type:fix] fix error cache usage

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
@@ -55,7 +55,7 @@ public class WindowTinyLFUMap<K, V> extends AbstractMap<K, V> implements Seriali
      * initial caffeine cache include WeakReference cache and StrongReference cache.
      *
      * <p>when the weakKey is true that means using weakKeys cache, gc will collect the weak key, please refer to:
-     * {@link com.github.benmanes.caffeine.cache.References.WeakKeyReference }</p>
+     * com.github.benmanes.caffeine.cache.References.WeakKeyReference</p>
      *
      * <p>when the weakKey is false, use strong reference, jvm maybe throw oom-error.</p>
      *

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
@@ -28,8 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * this cache is provided by caffeine, the cache has two implements including weak-key cache and strong-key cache.<br>
- * <p>the weak-key cache applies to scenarios where objects can be collected. when memory lock causes full gc, the weakKey will collect by gc.<br>
- * <p>the strong-key cache applies to immutable cache object data, and the user determines the cache size.<br>
+ * <p>the weak-key cache applies to scenarios where objects can be collected. when memory lock causes full gc, the weakKey will collect by gc.</p>
+ * <p>the strong-key cache applies to immutable cache object data, and the user determines the cache size.</p>
  * <p>about the weak-key cache and strong-key cache, please refer to:
  * <a href="https://github.com/ben-manes/caffeine/issues/776">caffeine cache ISSUES #776</a></p>
  */
@@ -55,9 +55,9 @@ public class WindowTinyLFUMap<K, V> extends AbstractMap<K, V> implements Seriali
      * initial caffeine cache include WeakReference cache and StrongReference cache.
      *
      * <p>when the weakKey is true that means using weakKeys cache, gc will collect the weak key, please refer to:
-     * {@link com.github.benmanes.caffeine.cache.References.WeakKeyReference }
+     * {@link com.github.benmanes.caffeine.cache.References.WeakKeyReference }</p>
      *
-     * <p>when the weakKey is false, use strong reference, jvm maybe throw oom-error.
+     * <p>when the weakKey is false, use strong reference, jvm maybe throw oom-error.</p>
      *
      * <pre>{@code Map<String, Object> strongMap = new WindowTinyLFUMap<>(100, 100, Boolean.FALSE);
      * strongMap.put(new String("abc"), 1);

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/cache/WindowTinyLFUMap.java
@@ -22,17 +22,16 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.Serializable;
-import java.lang.ref.WeakReference;
 import java.util.AbstractMap;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
- * this cache is provided by caffeine, the cache has two implements including weak-key cache and regular cache.<br>
- * the weak-key cache applies to scenarios where objects can be collected. when memory lock causes full gc, the weakKey will collect by gc.<br>
- * the regular cache applies to immutable cache object data, and the user determines the cache size.<br>
- * about the weak-key cache and regular cache, please refer to:
- * <a href="https://github.com/ben-manes/caffeine/issues/776">caffeine cache ISSUES #776</a>
+ * this cache is provided by caffeine, the cache has two implements including weak-key cache and strong-key cache.<br>
+ * <p>the weak-key cache applies to scenarios where objects can be collected. when memory lock causes full gc, the weakKey will collect by gc.<br>
+ * <p>the strong-key cache applies to immutable cache object data, and the user determines the cache size.<br>
+ * <p>about the weak-key cache and strong-key cache, please refer to:
+ * <a href="https://github.com/ben-manes/caffeine/issues/776">caffeine cache ISSUES #776</a></p>
  */
 @ThreadSafe
 public class WindowTinyLFUMap<K, V> extends AbstractMap<K, V> implements Serializable {
@@ -42,9 +41,34 @@ public class WindowTinyLFUMap<K, V> extends AbstractMap<K, V> implements Seriali
     private final Cache<K, V> cache;
     
     /**
-     * initial caffeine cache.
-     * when weakKey is true, create weakKeys cache, please refer to: {@linkplain WeakReference},
-     * weak reference make cache be memory-safe. however, the weakKey is false, caffeine eject cache by strategy.
+     * build caffeine cache.
+     *
+     * @param maximumSize maximumSize
+     */
+    public WindowTinyLFUMap(final long maximumSize) {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .build();
+    }
+    
+    /**
+     * initial caffeine cache include WeakReference cache and StrongReference cache.
+     *
+     * <p>when the weakKey is true that means using weakKeys cache, gc will collect the weak key, please refer to:
+     * {@link com.github.benmanes.caffeine.cache.References.WeakKeyReference }
+     *
+     * <p>when the weakKey is false, use strong reference, jvm maybe throw oom-error.
+     *
+     * <pre>{@code Map<String, Object> strongMap = new WindowTinyLFUMap<>(100, 100, Boolean.FALSE);
+     * strongMap.put(new String("abc"), 1);
+     * strongMap.put(new String("abc"), 1);
+     * assert strongMap.get("abc") != null;
+     *
+     * Map<String, Object> strongMap = new WindowTinyLFUMap<>(100, 100, Boolean.TRUE);
+     * strongMap.put(new String("abc"), 1);
+     * strongMap.put(new String("abc"), 1);
+     * assert strongMap.get("abc") == null;
+     * }</pre>
      *
      * @param initialCapacity initial capacity
      * @param maximumSize maximum size
@@ -101,6 +125,17 @@ public class WindowTinyLFUMap<K, V> extends AbstractMap<K, V> implements Seriali
         cache.invalidate(key);
         cache.cleanUp();
         return value;
+    }
+    
+    @Override
+    public void clear() {
+        this.cache.invalidateAll();
+        this.cache.cleanUp();
+    }
+    
+    @Override
+    public int size() {
+        return this.cache.asMap().entrySet().size();
     }
     
     @Override

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
@@ -1,0 +1,37 @@
+package org.apache.shenyu.common.cache;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * WindowTinyLFUMapTest.
+ */
+public class WindowTinyLFUMapTest {
+    
+    @Test
+    public void weakKeyCache() {
+        Map<String, String> map = new WindowTinyLFUMap<>(100, 100, Boolean.TRUE);
+        String key1 = new String("abc");
+        String key2 = new String("abc");
+        map.put(key1, "1");
+        map.put(key2, "1");
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(key1, key2);
+        Assert.assertNull(map.get("abc"));
+    }
+    
+    @Test
+    public void strongKeyCache() {
+        Map<String, String> map = new WindowTinyLFUMap<>(100, 100, Boolean.FALSE);
+        String key1 = new String("abc");
+        String key2 = new String("abc");
+        map.put(key1, "1");
+        map.put(key2, "1");
+        Assert.assertEquals(map.get(key1), map.get(key2));
+        Assert.assertEquals(1, map.size());
+    }
+    
+}

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
@@ -1,5 +1,21 @@
-package org.apache.shenyu.common.cache;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.apache.shenyu.common.cache;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/cache/WindowTinyLFUMapTest.java
@@ -49,5 +49,4 @@ public class WindowTinyLFUMapTest {
         Assert.assertEquals(map.get(key1), map.get(key2));
         Assert.assertEquals(1, map.size());
     }
-    
 }

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
@@ -312,7 +312,7 @@ public abstract class AbstractShenyuPlugin implements ShenyuPlugin {
         RuleData ruleData = null;
         ShenyuTrieNode shenyuTrieNode = trie.match(path, selectorData.getId());
         if (Objects.nonNull(shenyuTrieNode)) {
-            List<RuleData> ruleDataList = shenyuTrieNode.getPathRuleCache().getIfPresent(selectorData.getId());
+            List<RuleData> ruleDataList = shenyuTrieNode.getPathRuleCache().get(selectorData.getId());
             if (CollectionUtils.isNotEmpty(ruleDataList)) {
                 Pair<Boolean, RuleData> ruleDataPair = matchRule(exchange, ruleDataList);
                 ruleData = ruleDataPair.getRight();

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
@@ -316,7 +316,12 @@ public abstract class AbstractShenyuPlugin implements ShenyuPlugin {
             LOG.info("{} rule match path from shenyu trie", named());
             List<RuleData> ruleDataList = shenyuTrieNode.getPathRuleCache().get(selectorData.getId());
             if (CollectionUtils.isNotEmpty(ruleDataList)) {
-                Pair<Boolean, RuleData> ruleDataPair = matchRule(exchange, ruleDataList);
+                Pair<Boolean, RuleData> ruleDataPair;
+                if (ruleDataList.size() > 1) {
+                    ruleDataPair = matchRule(exchange, ruleDataList);
+                } else {
+                    ruleDataPair = Pair.of(Boolean.TRUE, ruleDataList.stream().findFirst().orElse(null));
+                }
                 ruleData = ruleDataPair.getRight();
                 if (ruleDataPair.getLeft()) {
                     // exist only one rule data, cache rule

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java
@@ -142,6 +142,7 @@ public abstract class AbstractShenyuPlugin implements ShenyuPlugin {
                 ruleData = trieMatchRule(exchange, selectorData, path);
                 // trie cache fails to hit, execute default strategy
                 if (Objects.isNull(ruleData)) {
+                    LOG.info("{} rule match path from default strategy", named());
                     Pair<Boolean, RuleData> matchRuleData = matchRule(exchange, rules);
                     ruleData = matchRuleData.getRight();
                     if (matchRuleData.getLeft()) {
@@ -312,6 +313,7 @@ public abstract class AbstractShenyuPlugin implements ShenyuPlugin {
         RuleData ruleData = null;
         ShenyuTrieNode shenyuTrieNode = trie.match(path, selectorData.getId());
         if (Objects.nonNull(shenyuTrieNode)) {
+            LOG.info("{} rule match path from shenyu trie", named());
             List<RuleData> ruleDataList = shenyuTrieNode.getPathRuleCache().get(selectorData.getId());
             if (CollectionUtils.isNotEmpty(ruleDataList)) {
                 Pair<Boolean, RuleData> ruleDataPair = matchRule(exchange, ruleDataList);

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/MatchDataCache.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/MatchDataCache.java
@@ -84,7 +84,7 @@ public final class MatchDataCache {
      */
     public void cacheSelectorData(final String path, final SelectorData selectorData, final int initialCapacity, final long maximumSize) {
         MapUtils.computeIfAbsent(SELECTOR_DATA_MAP, selectorData.getPluginName(), map ->
-                new WindowTinyLFUMap<>(initialCapacity, maximumSize, Boolean.TRUE)).put(path, selectorData);
+                new WindowTinyLFUMap<>(initialCapacity, maximumSize, Boolean.FALSE)).put(path, selectorData);
     }
 
     /**
@@ -109,7 +109,7 @@ public final class MatchDataCache {
      */
     public void cacheRuleData(final String path, final RuleData ruleData, final int initialCapacity, final long maximumSize) {
         MapUtils.computeIfAbsent(RULE_DATA_MAP, ruleData.getPluginName(), map ->
-                new WindowTinyLFUMap<>(initialCapacity, maximumSize, Boolean.TRUE)).put(path, ruleData);
+                new WindowTinyLFUMap<>(initialCapacity, maximumSize, Boolean.FALSE)).put(path, ruleData);
     }
     
     /**

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/MatchDataCacheTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/MatchDataCacheTest.java
@@ -52,7 +52,7 @@ public final class MatchDataCacheTest {
     public void testObtainSelectorData() throws NoSuchFieldException, IllegalAccessException {
         SelectorData firstSelectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).sort(1).build();
         ConcurrentHashMap<String, WindowTinyLFUMap<String, SelectorData>> selectorMap = getFieldByName(selectorMapStr);
-        selectorMap.put(mockPluginName1, new WindowTinyLFUMap<>(100, 100, Boolean.TRUE));
+        selectorMap.put(mockPluginName1, new WindowTinyLFUMap<>(100, 100, Boolean.FALSE));
         selectorMap.get(mockPluginName1).put(path1, firstSelectorData);
         SelectorData firstSelectorDataCache = MatchDataCache.getInstance().obtainSelectorData(mockPluginName1, path1);
         assertEquals(firstSelectorData, firstSelectorDataCache);
@@ -90,7 +90,7 @@ public final class MatchDataCacheTest {
     public void testObtainRuleData() throws NoSuchFieldException, IllegalAccessException {
         RuleData cacheRuleData = RuleData.builder().id("1").pluginName(mockPluginName1).sort(1).build();
         ConcurrentHashMap<String, WindowTinyLFUMap<String, RuleData>> ruleMap = getFieldByName(ruleMapStr);
-        ruleMap.put(mockPluginName1, new WindowTinyLFUMap<>(100, 100, Boolean.TRUE));
+        ruleMap.put(mockPluginName1, new WindowTinyLFUMap<>(100, 100, Boolean.FALSE));
         ruleMap.get(mockPluginName1).put(path1, cacheRuleData);
         RuleData firstRuleDataCache = MatchDataCache.getInstance().obtainRuleData(mockPluginName1, path1);
         assertEquals(cacheRuleData, firstRuleDataCache);


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

tasklist:
* [x] optimze shenyu trie match speeding.
* [x] fix error cache usage, weakKey-cache is not useful for shenyu, because caffeine use System.indentityHashcode generate hashcode that means use `==` judge objects equality, for example:
```java
Map<String, Object> strongMap = new WindowTinyLFUMap<>(100, 100, Boolean.FALSE);  
strongMap.put(new String("abc"), 1);  
strongMap.put(new String("abc"), 1);  assert strongMap.get("abc") != null;    
Map<String, Object> strongMap = new WindowTinyLFUMap<>(100, 100, Boolean.TRUE);  
strongMap.put(new String("abc"), 1);  
strongMap.put(new String("abc"), 1);  assert strongMap.get("abc") == null;
```

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
