### PR TITLE
[type: fix] fix missing log in container

### DIFF
--- a/shenyu-bootstrap/pom.xml
+++ b/shenyu-bootstrap/pom.xml
@@ -335,6 +335,12 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo-dependencies-zookeeper</artifactId>
             <version>${apache.dubbo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
             <type>pom</type>
         </dependency>
         <!-- Dubbo zookeeper registry dependency end -->


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
When run shenyu-bootstrap in docker, the log file will miss.

The images is build from latest code in master or pull from github packeages(https://github.com/apache/shenyu/pkgs/container/shenyu%2Fbootstrap)
```shell
 ✘ zhukunshuai@zhukunsaideAir2  ~  docker pull ghcr.io/apache/shenyu/bootstrap:114f1db623a7829c0fed03722bd5bae293587c68
114f1db623a7829c0fed03722bd5bae293587c68: Pulling from apache/shenyu/bootstrap
0362ad1dd800: Already exists
571218f61883: Already exists
62afd1dfc9c3: Already exists
000fc2a40b7f: Pull complete
e923cc9c6361: Pull complete
2ac991a0c4b1: Pull complete
8c72b52de2af: Pull complete
55bdea5bce7d: Pull complete
c43cef8224c0: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:7ed93005f50f1030c753a81743b3d4af66a06c281a80d6506b9a0135f4403191
Status: Downloaded newer image for ghcr.io/apache/shenyu/bootstrap:114f1db623a7829c0fed03722bd5bae293587c68
ghcr.io/apache/shenyu/bootstrap:114f1db623a7829c0fed03722bd5bae293587c68
 zhukunshuai@zhukunsaideAir2  ~  docker run ghcr.io/apache/shenyu/bootstrap:114f1db623a7829c0fed03722bd5bae293587c68
Use default jvm options:  -server -Xmx2g -Xms2g -Xmn1g -Xss512k -XX:+DisableExplicitGC   -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods  -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly  -XX:CMSInitiatingOccupancyFraction=70
Starting the Apache ShenYu Bootstrap ...
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/shenyu-bootstrap/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/shenyu-bootstrap/lib/tencentcloud-cls-sdk-java-1.0.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/shenyu-bootstrap/lib/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
```
I found that after exclude slf4j-log4j12 of dubbo-dependencies-zookeeper, we can see the log, but the reason is unknown.

I tried the previous image, and this problem suddenly appeared about a month ago. Probably a conflict from a PR.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
