### PR TITLE
bugfix api document module update api detail error

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ApiServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ApiServiceImpl.java
@@ -113,6 +113,7 @@ public class ApiServiceImpl implements ApiService {
                     .id(UUIDUtils.getInstance().generateShortUuid())
                     .apiId(apiDO.getId())
                     .tagId(tagId)
+                    .dateCreated(currentTime)
                     .dateUpdated(currentTime)
                     .build()).collect(Collectors.toList());
                 tagRelationMapper.deleteByApiId(apiDO.getId());


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

bugfix can not update api detail on api document module.
exception below happen when update api detail.

```
Caused by: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: NULL not allowed for column "DATE_CREATED"; SQL statement:
INSERT INTO tag_relation
        (id,date_created,date_updated,api_id,tag_id)VALUES (?,?,?,?,?) [23502-200]
```

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
