### PR TITLE
[type:fix]fix SofaServiceEventListenerTest.testBuildMetaDataDTO

### DIFF
--- a/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/MetaDataRegisterDTO.java
+++ b/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/MetaDataRegisterDTO.java
@@ -66,22 +66,22 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     /**
      * Instantiates a new Meta data register dto.
      *
-     * @param appName the app name
-     * @param contextPath the context path
-     * @param path the path
-     * @param pathDesc the path desc
-     * @param rpcType the rpc type
-     * @param serviceName the service name
-     * @param methodName the method name
-     * @param ruleName the rule name
-     * @param parameterTypes the parameter types
-     * @param rpcExt the rpc ext
-     * @param enabled the enabled
-     * @param host the host
-     * @param port the port
-     * @param pluginNames the plugin names
+     * @param appName          the app name
+     * @param contextPath      the context path
+     * @param path             the path
+     * @param pathDesc         the path desc
+     * @param rpcType          the rpc type
+     * @param serviceName      the service name
+     * @param methodName       the method name
+     * @param ruleName         the rule name
+     * @param parameterTypes   the parameter types
+     * @param rpcExt           the rpc ext
+     * @param enabled          the enabled
+     * @param host             the host
+     * @param port             the port
+     * @param pluginNames      the plugin names
      * @param registerMetaData the register meta data
-     * @param addPrefixed the prefix forward status
+     * @param addPrefixed      the prefix forward status
      */
     public MetaDataRegisterDTO(final String appName, final String contextPath,
                                final String path, final String pathDesc,
@@ -109,7 +109,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
         this.timeMillis = System.currentTimeMillis();
         this.addPrefixed = addPrefixed;
     }
-    
+
     /**
      * Instantiates a new Meta data register dto.
      */
@@ -135,7 +135,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
         timeMillis = System.currentTimeMillis();
         addPrefixed = builder.addPrefixed;
     }
-    
+
     /**
      * builder.
      *
@@ -149,7 +149,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public DataType getType() {
         return DataType.META_DATA;
     }
-    
+
     /**
      * getAppName.
      *
@@ -158,7 +158,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getAppName() {
         return appName;
     }
-    
+
     /**
      * setAppName.
      *
@@ -167,7 +167,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setAppName(final String appName) {
         this.appName = appName;
     }
-    
+
     /**
      * getContextPath.
      *
@@ -176,7 +176,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getContextPath() {
         return contextPath;
     }
-    
+
     /**
      * setContextPath.
      *
@@ -185,7 +185,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setContextPath(final String contextPath) {
         this.contextPath = contextPath;
     }
-    
+
     /**
      * getPath.
      *
@@ -194,7 +194,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getPath() {
         return path;
     }
-    
+
     /**
      * setPath.
      *
@@ -203,7 +203,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setPath(final String path) {
         this.path = path;
     }
-    
+
     /**
      * getPathDesc.
      *
@@ -212,7 +212,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getPathDesc() {
         return pathDesc;
     }
-    
+
     /**
      * setPath.
      *
@@ -221,7 +221,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setPathDesc(final String pathDesc) {
         this.pathDesc = pathDesc;
     }
-    
+
     /**
      * getRpcType.
      *
@@ -230,7 +230,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getRpcType() {
         return rpcType;
     }
-    
+
     /**
      * setPath.
      *
@@ -239,7 +239,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setRpcType(final String rpcType) {
         this.rpcType = rpcType;
     }
-    
+
     /**
      * getServiceName.
      *
@@ -248,7 +248,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getServiceName() {
         return serviceName;
     }
-    
+
     /**
      * setPath.
      *
@@ -257,7 +257,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setServiceName(final String serviceName) {
         this.serviceName = serviceName;
     }
-    
+
     /**
      * getMethodName.
      *
@@ -266,7 +266,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getMethodName() {
         return methodName;
     }
-    
+
     /**
      * setPath.
      *
@@ -275,7 +275,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setMethodName(final String methodName) {
         this.methodName = methodName;
     }
-    
+
     /**
      * getRuleName.
      *
@@ -284,7 +284,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getRuleName() {
         return ruleName;
     }
-    
+
     /**
      * setPath.
      *
@@ -293,7 +293,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setRuleName(final String ruleName) {
         this.ruleName = ruleName;
     }
-    
+
     /**
      * getParameterTypes.
      *
@@ -302,7 +302,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getParameterTypes() {
         return parameterTypes;
     }
-    
+
     /**
      * setPath.
      *
@@ -311,7 +311,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setParameterTypes(final String parameterTypes) {
         this.parameterTypes = parameterTypes;
     }
-    
+
     /**
      * getRpcExt.
      *
@@ -320,7 +320,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getRpcExt() {
         return rpcExt;
     }
-    
+
     /**
      * setPath.
      *
@@ -329,7 +329,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setRpcExt(final String rpcExt) {
         this.rpcExt = rpcExt;
     }
-    
+
     /**
      * isEnabled.
      *
@@ -338,7 +338,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public boolean isEnabled() {
         return enabled;
     }
-    
+
     /**
      * setPath.
      *
@@ -347,7 +347,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
     }
-    
+
     /**
      * getHost.
      *
@@ -356,7 +356,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public String getHost() {
         return host;
     }
-    
+
     /**
      * setPath.
      *
@@ -365,7 +365,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setHost(final String host) {
         this.host = host;
     }
-    
+
     /**
      * getPort.
      *
@@ -374,7 +374,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public Integer getPort() {
         return port;
     }
-    
+
     /**
      * setPort.
      *
@@ -383,7 +383,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setPort(final Integer port) {
         this.port = port;
     }
-    
+
     /**
      * getPluginNames.
      *
@@ -392,7 +392,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public List<String> getPluginNames() {
         return pluginNames;
     }
-    
+
     /**
      * setPluginNames.
      *
@@ -401,7 +401,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public void setPluginNames(final List<String> pluginNames) {
         this.pluginNames = pluginNames;
     }
-    
+
     /**
      * isRegisterMetaData.
      *
@@ -410,7 +410,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public boolean isRegisterMetaData() {
         return registerMetaData;
     }
-    
+
     /**
      * setRegisterMetaData.
      *
@@ -472,7 +472,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
                 && Objects.equals(parameterTypes, that.parameterTypes) && Objects.equals(rpcExt, that.rpcExt)
                 && Objects.equals(enabled, that.enabled) && Objects.equals(host, that.host)
                 && Objects.equals(port, that.port) && Objects.equals(pluginNames, that.pluginNames)
-                && Objects.equals(registerMetaData, that.registerMetaData) && Objects.equals(timeMillis, that.timeMillis)
+                && Objects.equals(registerMetaData, that.registerMetaData)
                 && Objects.equals(addPrefixed, that.addPrefixed);
     }
 
@@ -485,36 +485,36 @@ public class MetaDataRegisterDTO implements DataTypeParent {
 
     @Override
     public String toString() {
-        return "MetaDataRegisterDTO{" 
-                + "appName='" 
+        return "MetaDataRegisterDTO{"
+                + "appName='"
                 + appName
-                + ", contextPath='" 
+                + ", contextPath='"
                 + contextPath
                 + ", path='"
                 + path
-                + ", pathDesc='" 
+                + ", pathDesc='"
                 + pathDesc
-                + ", rpcType='" 
+                + ", rpcType='"
                 + rpcType
-                + ", serviceName='" 
+                + ", serviceName='"
                 + serviceName
-                + ", methodName='" 
+                + ", methodName='"
                 + methodName
                 + ", ruleName='"
                 + ruleName
-                + ", parameterTypes='" 
+                + ", parameterTypes='"
                 + parameterTypes
-                + ", rpcExt='" 
+                + ", rpcExt='"
                 + rpcExt
-                + ", enabled=" 
-                + enabled 
-                + ", host='" 
+                + ", enabled="
+                + enabled
+                + ", host='"
                 + host
-                + ", port=" 
-                + port 
-                + ", pluginNames=" 
+                + ", port="
+                + port
+                + ", pluginNames="
                 + pluginNames
-                + ", registerMetaData=" 
+                + ", registerMetaData="
                 + registerMetaData
                 + ", timeMillis="
                 + timeMillis
@@ -522,7 +522,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
                 + addPrefixed
                 + '}';
     }
-    
+
     /**
      * The type Builder.
      */
@@ -564,7 +564,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
 
         private Builder() {
         }
-    
+
         /**
          * appName.
          *
@@ -575,7 +575,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.appName = appName;
             return this;
         }
-    
+
         /**
          * contextPath.
          *
@@ -586,7 +586,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.contextPath = contextPath;
             return this;
         }
-    
+
         /**
          * path.
          *
@@ -597,7 +597,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.path = path;
             return this;
         }
-    
+
         /**
          * pathDesc.
          *
@@ -608,7 +608,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.pathDesc = pathDesc;
             return this;
         }
-    
+
         /**
          * rpcType.
          *
@@ -619,7 +619,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.rpcType = rpcType;
             return this;
         }
-    
+
         /**
          * serviceName.
          *
@@ -630,7 +630,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.serviceName = serviceName;
             return this;
         }
-    
+
         /**
          * methodName.
          *
@@ -641,7 +641,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.methodName = methodName;
             return this;
         }
-    
+
         /**
          * ruleName.
          *
@@ -652,7 +652,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.ruleName = ruleName;
             return this;
         }
-    
+
         /**
          * parameterTypes.
          *
@@ -663,7 +663,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.parameterTypes = parameterTypes;
             return this;
         }
-    
+
         /**
          * rpcExt.
          *
@@ -674,7 +674,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.rpcExt = rpcExt;
             return this;
         }
-    
+
         /**
          * enabled.
          *
@@ -685,7 +685,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.enabled = enabled;
             return this;
         }
-    
+
         /**
          * appName.
          *
@@ -696,7 +696,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.host = host;
             return this;
         }
-    
+
         /**
          * port.
          *
@@ -707,7 +707,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.port = port;
             return this;
         }
-    
+
         /**
          * pluginNames.
          *
@@ -718,7 +718,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
             this.pluginNames = pluginNames;
             return this;
         }
-    
+
         /**
          * registerMetaData.
          *

--- a/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/MetaDataRegisterDTO.java
+++ b/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/MetaDataRegisterDTO.java
@@ -480,7 +480,7 @@ public class MetaDataRegisterDTO implements DataTypeParent {
     public int hashCode() {
         return Objects.hash(appName, contextPath, path, pathDesc, rpcType, serviceName, methodName,
                 ruleName, parameterTypes, rpcExt, enabled, host, port, pluginNames,
-                registerMetaData, timeMillis, addPrefixed);
+                registerMetaData, addPrefixed);
     }
 
     @Override


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

I think the `SofaServiceEventListenerTest.testBuildMetaDataDTO` method has a problem.

Sometimes the expected one's timeMillis is diffrent from the actual's ,Because of the difference of creation time

![image](https://github.com/apache/shenyu/assets/42602026/669f1b92-3eba-4d1d-b583-11b34902e927)

![5cf5a5971672a56fcf3cd68a29f71c2](https://github.com/apache/shenyu/assets/42602026/b6e5b80c-dd57-4219-a12b-21e5aba87c2b)

![image](https://github.com/apache/shenyu/assets/42602026/361e7a2e-85e1-49d1-8fda-a6a87d614e32)


![image](https://github.com/apache/shenyu/assets/42602026/dd2b226a-fbe3-4ae9-9d46-b126e4cb93e5)


So, Removes comparing timeMillis  in MetaDataRegisterDTO#equals
