### PR TITLE
add checkstyle plugin into e2e module.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DefaultDiscoveryProcessor.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DefaultDiscoveryProcessor.java
@@ -221,8 +221,7 @@ public class DefaultDiscoveryProcessor implements DiscoveryProcessor, Applicatio
     private String buildProxySelectorKey(final String listenerNode) {
         return StringUtils.isNotBlank(listenerNode) ? listenerNode : DEFAULT_LISTENER_NODE;
     }
-
-
+    
     /**
      * getDiscoveryDataChangedEventListener.
      *

--- a/shenyu-e2e/pom.xml
+++ b/shenyu-e2e/pom.xml
@@ -23,7 +23,6 @@
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>21</version>
-        <relativePath>./pom.xml</relativePath>
     </parent>
     <groupId>org.apache.shenyu</groupId>
     <artifactId>shenyu-e2e</artifactId>
@@ -56,6 +55,7 @@
         <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
         <spring-boot.version>2.7.13</spring-boot.version>
         <spring-framework.version>5.3.28</spring-framework.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
     </properties>
 
     <modules>
@@ -273,6 +273,27 @@
                     </consoleOutputReporter>
                     <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <configuration>
+                    <configLocation>/../script/shenyu_checkstyle.xml</configLocation>
+                    <headerLocation>/../script/checkstyle-header.txt</headerLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <excludes>**/transfer/**/*</excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/shenyu-e2e/pom.xml
+++ b/shenyu-e2e/pom.xml
@@ -23,6 +23,7 @@
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
         <version>21</version>
+        <relativePath>./pom.xml</relativePath>
     </parent>
     <groupId>org.apache.shenyu</groupId>
     <artifactId>shenyu-e2e</artifactId>


### PR DESCRIPTION
The example module and the e2e module are single projects under shenyu, the e2e module needs to add `checkstyle plugin` too. If not, `mvn checkstyle:check` rule is not as the shenyu project rule.

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
