### PR TITLE
[ISSUE #4850] fix apollo as registry, client metadata and uri cannot be synchronized to admin 

### DIFF
--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-apollo/src/main/java/org/apache/shenyu/register/client/apollo/ApolloClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-apollo/src/main/java/org/apache/shenyu/register/client/apollo/ApolloClientRegisterRepository.java
@@ -19,7 +19,6 @@ package org.apache.shenyu.register.client.apollo;
 
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import org.apache.shenyu.common.constant.Constants;
-import org.apache.shenyu.common.exception.ShenyuException;
 import org.apache.shenyu.common.utils.ContextPathUtils;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.common.utils.LogUtils;
@@ -32,8 +31,9 @@ import org.apache.shenyu.spi.Join;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentLinkedQueue;
+
 
 /**
  * apollo register center client.
@@ -42,8 +42,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class ApolloClientRegisterRepository implements ShenyuClientRegisterRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApolloClientRegisterRepository.class);
-
-    private final ConcurrentLinkedQueue<String> metadataCache = new ConcurrentLinkedQueue<>();
 
     private ApolloClient apolloClient;
 
@@ -70,9 +68,8 @@ public class ApolloClientRegisterRepository implements ShenyuClientRegisterRepos
 
     @Override
     public void persistInterface(final MetaDataRegisterDTO metadata) {
-        String rpcType = metadata.getRpcType();
-        String contextPath = ContextPathUtils.buildRealNode(metadata.getContextPath(), metadata.getAppName());
-        registerConfig(rpcType, contextPath, metadata);
+        registerMetadata(metadata);
+        LogUtils.info(LOGGER, "{} apollo client register metadata success: {}", metadata.getRpcType(), metadata);
     }
 
     @Override
@@ -87,8 +84,8 @@ public class ApolloClientRegisterRepository implements ShenyuClientRegisterRepos
                              final String contextPath,
                              final URIRegisterDTO registerDTO) {
         String uriNodeName = buildURINodeName(registerDTO);
-        String uriPath = RegisterPathConstants.buildURIParentKey(rpcType, contextPath);
-        String realNode = RegisterPathConstants.buildNodeName(uriPath, uriNodeName);
+        String uriPath = RegisterPathConstants.buildURIParentPath(rpcType, contextPath);
+        String realNode = RegisterPathConstants.buildRealNode(uriPath, uriNodeName);
         apolloClient.createOrUpdateItem(realNode, GsonUtils.getInstance().toJson(registerDTO), "register uri");
         apolloClient.publishNamespace("publish config", "");
         LOGGER.info("register uri data success: {}", realNode);
@@ -100,16 +97,25 @@ public class ApolloClientRegisterRepository implements ShenyuClientRegisterRepos
         return String.join(Constants.COLONS, host, Integer.toString(port));
     }
 
-    private synchronized void registerConfig(final String rpcType,
-                                             final String contextPath,
-                                             final MetaDataRegisterDTO metadata) {
-        metadataCache.add(GsonUtils.getInstance().toJson(metadata));
-        String configName = RegisterPathConstants.buildServiceConfigPath(rpcType, contextPath);
-        try {
-            this.apolloClient.createOrUpdateItem(configName, GsonUtils.getInstance().toJson(metadataCache), "register config");
-            this.apolloClient.publishNamespace("publish config", "");
-        } catch (Exception e) {
-            throw new ShenyuException(e);
+    private void registerMetadata(final MetaDataRegisterDTO metadata) {
+        String rpcType = metadata.getRpcType();
+        String contextPath = ContextPathUtils.buildRealNode(metadata.getContextPath(), metadata.getAppName());
+        String metadataNodeName = RegisterPathConstants.buildNodeName(metadata.getServiceName(), metadata.getMethodName());
+        String metaDataPath = RegisterPathConstants.buildMetaDataParentPath(rpcType, contextPath);
+        String realNode = RegisterPathConstants.buildRealNode(metaDataPath, metadataNodeName);
+
+        String oldValue = apolloClient.getItemValue(realNode);
+        // no change in metadata, no need to update
+        if (oldValue != null) {
+            MetaDataRegisterDTO oldMetaData = GsonUtils.getInstance().fromJson(oldValue, MetaDataRegisterDTO.class);
+            if (Objects.equals(oldMetaData, metadata)) {
+                return;
+            }
         }
+        // update metadata
+        String metadataJson = GsonUtils.getInstance().toJson(metadata);
+        this.apolloClient.createOrUpdateItem(realNode, metadataJson, "register config");
+        this.apolloClient.publishNamespace("publish config", "");
     }
+
 }

--- a/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
+++ b/shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/path/RegisterPathConstants.java
@@ -18,7 +18,7 @@
 package org.apache.shenyu.register.common.path;
 
 /**
- * zookeeper register center.
+ *  register center path constants.
  */
 public class RegisterPathConstants {
 
@@ -35,9 +35,19 @@ public class RegisterPathConstants {
     public static final String REGISTER_METADATA_INSTANCE_PATH = "/shenyu/register/metadata/*/*/*";
 
     /**
-     * root path of zookeeper register center.
+     * root path of  register center.
      */
     public static final String ROOT_PATH = "/shenyu/register";
+
+    /**
+     * root path of uri register.
+     */
+    public static final String REGISTER_URI_INSTANCE_ROOT_PATH = ROOT_PATH + "/uri";
+
+    /**
+     * root path of metadata register.
+     */
+    public static final String REGISTER_METADATA_INSTANCE_ROOT_PATH = ROOT_PATH + "/metadata";
 
     /**
      * constants of separator.
@@ -56,7 +66,7 @@ public class RegisterPathConstants {
      * @return path string
      */
     public static String buildMetaDataContextPathParent(final String rpcType) {
-        return String.join(SEPARATOR, ROOT_PATH, "metadata", rpcType);
+        return String.join(SEPARATOR, REGISTER_METADATA_INSTANCE_ROOT_PATH, rpcType);
     }
     
     /**
@@ -67,7 +77,7 @@ public class RegisterPathConstants {
      * @return path string
      */
     public static String buildMetaDataParentPath(final String rpcType, final String contextPath) {
-        return String.join(SEPARATOR, ROOT_PATH, "metadata", rpcType, contextPath);
+        return String.join(SEPARATOR, REGISTER_METADATA_INSTANCE_ROOT_PATH, rpcType, contextPath);
     }
     
     /**
@@ -78,7 +88,7 @@ public class RegisterPathConstants {
      * @return the string
      */
     public static String buildURIContextPathParent(final String rpcType) {
-        return String.join(SEPARATOR, ROOT_PATH, "uri", rpcType);
+        return String.join(SEPARATOR, REGISTER_URI_INSTANCE_ROOT_PATH, rpcType);
     }
     
     /**
@@ -90,7 +100,7 @@ public class RegisterPathConstants {
      * @return the string
      */
     public static String buildURIParentPath(final String rpcType, final String contextPath) {
-        return String.join(SEPARATOR, ROOT_PATH, "uri", rpcType, contextPath);
+        return String.join(SEPARATOR, REGISTER_URI_INSTANCE_ROOT_PATH, rpcType, contextPath);
     }
     
     /**
@@ -166,28 +176,4 @@ public class RegisterPathConstants {
         return String.join(DOT_SEPARATOR, serviceName, methodName);
     }
 
-    /**
-     * Build apollo config uri parent path string.
-     * build child path of "shenyu.register.uri.{rpcType}.{contextPath}".
-     *
-     * @param rpcType the rpc type
-     * @param contextPath the context path
-     * @return the string
-     */
-    public static String buildURIParentKey(final String rpcType, final String contextPath) {
-        return String.join(DOT_SEPARATOR, "shenyu.register", "uri", rpcType, contextPath);
-    }
-
-
-    /**
-     * Build apollo config metadata parent path string.
-     * build child path of "shenyu.register.metadata.{rpcType}.{contextPath}".
-     *
-     * @param rpcType the rpc type
-     * @param contextPath the context path
-     * @return the string
-     */
-    public static String buildMetadataParentKey(final String rpcType, final String contextPath) {
-        return String.join(DOT_SEPARATOR, "shenyu.register", "metadata", rpcType, contextPath);
-    }
 }


### PR DESCRIPTION
1. unified client registration metadata and admin read metadata key
2. unified the data format of admin and client
3. when admin starts, perform a read operation from apollo
4. The registration of metadata is optimized. When the meta data does not change, the metadata write operation is not performed
5. removed useless code