### PR TITLE
[type: fix] fix client shutdown close method call twice

### DIFF
--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHook.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHook.java
@@ -55,7 +55,7 @@ public class ShenyuClientShutdownHook {
 
     public ShenyuClientShutdownHook(final ShenyuClientRegisterRepository repository, final ShenyuRegisterCenterConfig config) {
         String name = String.join("-", hookNamePrefix, String.valueOf(hookId.incrementAndGet()));
-        Runtime.getRuntime().addShutdownHook(new Thread(repository::close, name));
+        Runtime.getRuntime().addShutdownHook(new Thread(repository::closeRepository, name));
         LOG.info("Add hook {}", name);
         ShenyuClientShutdownHook.props = config.getProps();
     }
@@ -63,12 +63,12 @@ public class ShenyuClientShutdownHook {
     /**
      * Add shenyu client shutdown hook.
      *
-     * @param result ShenyuClientRegisterRepository
+     * @param repository ShenyuClientRegisterRepository
      * @param props  Properties
      */
-    public static void set(final ShenyuClientRegisterRepository result, final Properties props) {
+    public static void set(final ShenyuClientRegisterRepository repository, final Properties props) {
         String name = String.join("-", hookNamePrefix, String.valueOf(hookId.incrementAndGet()));
-        Runtime.getRuntime().addShutdownHook(new Thread(result::close, name));
+        Runtime.getRuntime().addShutdownHook(new Thread(repository::closeRepository, name));
         LOG.info("Add hook {}", name);
         ShenyuClientShutdownHook.props = props;
     }

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
@@ -69,6 +69,8 @@ public interface ShenyuClientRegisterRepository {
     
     /**
      * closeRepository.
+     * If the close method is used, Spring will call it by default when the bean is destroyed,
+     * So its method name is closeRepository to avoid being called by default when the bean is destroyed.
      */
     default void closeRepository() {
     }

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
@@ -68,7 +68,7 @@ public interface ShenyuClientRegisterRepository {
     }
     
     /**
-     * Close.
+     * closeRepository.
      */
     default void closeRepository() {
     }

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java
@@ -70,6 +70,6 @@ public interface ShenyuClientRegisterRepository {
     /**
      * Close.
      */
-    default void close() {
+    default void closeRepository() {
     }
 }

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-consul/src/main/java/org/apache/shenyu/register/client/consul/ConsulClientRegisterRepository.java
@@ -150,7 +150,7 @@ public class ConsulClientRegisterRepository implements ShenyuClientRegisterRepos
     }
 
     @Override
-    public void close() {
+    public void closeRepository() {
         consulClient.agentServiceDeregister(this.service.getId());
     }
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/src/main/java/org/apache/shenyu/register/client/etcd/EtcdClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/src/main/java/org/apache/shenyu/register/client/etcd/EtcdClientRegisterRepository.java
@@ -61,7 +61,7 @@ public class EtcdClientRegisterRepository implements ShenyuClientRegisterReposit
     }
 
     @Override
-    public void close() {
+    public void closeRepository() {
         client.close();
     }
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/src/test/java/org/apache/shenyu/register/client/etcd/EtcdClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-etcd/src/test/java/org/apache/shenyu/register/client/etcd/EtcdClientRegisterRepositoryTest.java
@@ -98,7 +98,7 @@ public class EtcdClientRegisterRepositoryTest {
         String metadataPath = "/shenyu/register/metadata/http/context/context-ruleName";
         assertTrue(etcdBroker.containsKey(metadataPath));
         assertEquals(etcdBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-        repository.close();
+        repository.closeRepository();
     }
     
     @Test
@@ -131,7 +131,7 @@ public class EtcdClientRegisterRepositoryTest {
         String metadataPath = "/shenyu/register/metadata/grpc/context/testService.testMethod";
         assertTrue(etcdBroker.containsKey(metadataPath));
         assertEquals(etcdBroker.get(metadataPath), GsonUtils.getInstance().toJson(data));
-        repository.close();
+        repository.closeRepository();
     }
 
     @Test

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/main/java/org/apache/shenyu/register/client/http/HttpClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/main/java/org/apache/shenyu/register/client/http/HttpClientRegisterRepository.java
@@ -140,7 +140,7 @@ public class HttpClientRegisterRepository extends FailbackRegistryRepository {
     }
 
     @Override
-    public void close() {
+    public void closeRepository() {
         if (Objects.nonNull(uriRegisterDTO)) {
             uriRegisterDTO.setEventType(EventType.DELETED);
             doRegister(uriRegisterDTO, Constants.URI_PATH, Constants.URI);

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/src/main/java/org/apache/shenyu/register/client/nacos/NacosClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/src/main/java/org/apache/shenyu/register/client/nacos/NacosClientRegisterRepository.java
@@ -92,7 +92,7 @@ public class NacosClientRegisterRepository implements ShenyuClientRegisterReposi
     }
 
     @Override
-    public void close() {
+    public void closeRepository() {
         try {
             configService.shutDown();
             namingService.shutDown();

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/src/test/java/org/apache/shenyu/register/client/nacos/NacosClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-nacos/src/test/java/org/apache/shenyu/register/client/nacos/NacosClientRegisterRepositoryTest.java
@@ -112,8 +112,8 @@ public class NacosClientRegisterRepositoryTest {
     }
 
     @Test
-    public void testClose() throws NacosException {
-        repository.close();
+    public void testCloseRepository() throws NacosException {
+        repository.closeRepository();
         verify(configService, times(1)).shutDown();
         verify(namingService, times(1)).shutDown();
     }
@@ -178,11 +178,11 @@ public class NacosClientRegisterRepositoryTest {
         namingFactoryMockedStatic.when(() -> NamingFactory.createNamingService(any(Properties.class))).thenReturn(mock(NamingService.class));
         this.repository = new NacosClientRegisterRepository(config);
         Assertions.assertDoesNotThrow(() -> this.repository.init(config));
-        Assertions.assertDoesNotThrow(() -> this.repository.close());
+        Assertions.assertDoesNotThrow(() -> this.repository.closeRepository());
         doThrow(NacosException.class).when(configService).shutDown();
         configFactoryMockedStatic.when(() -> ConfigFactory.createConfigService(any(Properties.class))).thenThrow(NacosException.class);
         // hit error
-        Assertions.assertDoesNotThrow(() -> this.repository.close());
+        Assertions.assertDoesNotThrow(() -> this.repository.closeRepository());
         Assertions.assertThrows(ShenyuException.class, () -> this.repository.init(config));
         configFactoryMockedStatic.close();
         namingFactoryMockedStatic.close();

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/main/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepository.java
@@ -121,7 +121,7 @@ public class ZookeeperClientRegisterRepository implements ShenyuClientRegisterRe
     }
 
     @Override
-    public void close() {
+    public void closeRepository() {
         this.client.close();
     }
 

--- a/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
+++ b/shenyu-register-center/shenyu-register-client/shenyu-register-client-zookeeper/src/test/java/org/apache/shenyu/register/client/zookeeper/ZookeeperClientRegisterRepositoryTest.java
@@ -78,7 +78,7 @@ public class ZookeeperClientRegisterRepositoryTest {
                 connectionStateListener.stateChanged(null, ConnectionState.RECONNECTED);
             });
             Assertions.assertDoesNotThrow(() -> new ZookeeperClientRegisterRepository());
-            repository.close();
+            repository.closeRepository();
         }
     }
 }


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

The client's close will be called twice when it is closed.
Because of Spring When the bean is destroyed, it will proactively call the `close` or `shutdown` methods. At the same time, Shenyu also defined ShenyuClientShutdownHook. Therefore, renaming the `close` method to ` closeRepository` solves the problem of being called twice.

![image](https://github.com/apache/shenyu/assets/12622645/b8e25fe8-6597-4e33-81a6-932d8ffec91d)


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
