### PR TITLE
Fixed several bugs about motan rpc

### DIFF
--- a/db/init/mysql/schema.sql
+++ b/db/init/mysql/schema.sql
@@ -789,7 +789,7 @@ INSERT INTO `plugin` VALUES ('13', 'tars', '{\"multiSelectorHandle\":\"1\",\"mul
 INSERT INTO `plugin` VALUES ('14', 'contextPath', NULL, 'HttpProcess', 80, 1, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
 INSERT INTO `plugin` VALUES ('15', 'grpc', '{\"multiSelectorHandle\":\"1\",\"multiRuleHandle\":\"0\",\"threadpool\":\"shared\"}', 'Proxy', 310, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
 INSERT INTO `plugin` VALUES ('16', 'redirect', NULL, 'HttpProcess', 110, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
-INSERT INTO `plugin` VALUES ('17', 'motan', '{\"register\":\"127.0.0.1:2181\",\"corethreads\":0,\"threads\":2147483647,\"queues\":0,\"threadpool\":\"shared\"}', 'Proxy', 310, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
+INSERT INTO `plugin` VALUES ('17', 'motan', '{\"registerProtocol\":\"direct\",\"registerAddress\":\"127.0.0.1:8002\",\"corethreads\":0,\"threads\":2147483647,\"queues\":0,\"threadpool\":\"shared\"}', 'Proxy', 310, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
 INSERT INTO `plugin` VALUES ('18', 'loggingConsole', NULL, 'Logging', 160, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
 INSERT INTO `plugin` VALUES ('19', 'jwt', '{\"secretKey\":\"key\"}', 'Authentication', 30, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
 INSERT INTO `plugin` VALUES ('2', 'waf', '{\"model\":\"black\"}', 'Authentication', 50, 0, '2022-05-25 18:02:53', '2022-05-25 18:02:53',null);
@@ -963,7 +963,7 @@ INSERT INTO `plugin_handle` VALUES ('1529402613204172830', '26', 'loadBalance', 
 INSERT INTO `plugin_handle` VALUES ('1529402613204172831', '26', 'retry', 'retryCount', 1, 2, 1, NULL, '2022-05-25 18:02:53', '2022-05-25 18:02:53');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172832', '26', 'timeout', 'timeout', 1, 2, 2, '{\"defaultValue\":\"3000\",\"rule\":\"\"}', '2022-05-25 18:02:53', '2022-05-25 18:02:53');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172833', '26', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0, NULL, '2022-05-25 18:02:53', '2022-05-25 18:02:53');
-INSERT INTO `plugin_handle` VALUES ('1529402613204172834', '17', 'register', 'register', 2, 3, 0, NULL, '2022-05-25 18:02:53', '2022-05-25 18:02:53');
+INSERT INTO `plugin_handle` VALUES ('1529402613204172834', '17', 'registerProtocol', 'registerProtocol', 2, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"direct\",\"placeholder\":\"registerProtocol\",\"rule\":\"\"}', '2022-05-25 18:02:53', '2022-05-25 18:02:53');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172835', '17', 'corethreads', 'corethreads', 1, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"0\",\"placeholder\":\"corethreads\",\"rule\":\"\"}', '2022-05-25 18:02:53', '2022-05-25 18:02:53');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172836', '17', 'threads', 'threads', 1, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"2147483647\",\"placeholder\":\"threads\",\"rule\":\"\"}', '2022-05-25 18:02:53', '2022-05-25 18:02:53');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172837', '17', 'queues', 'queues', 1, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"0\",\"placeholder\":\"queues\",\"rule\":\"\"}', '2022-05-25 18:02:53', '2022-05-25 18:02:53');
@@ -1116,6 +1116,9 @@ INSERT INTO `plugin_handle` VALUES ('1529402613204172959', '41', 'corethreads', 
 INSERT INTO `plugin_handle` VALUES ('1529402613204172960', '41', 'threads', 'threads', 1, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"2147483647\",\"placeholder\":\"threads\",\"rule\":\"\"}', '2023-01-10 10:08:01.158', '2023-01-10 10:08:01.158');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172961', '41', 'queues', 'queues', 1, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"0\",\"placeholder\":\"queues\",\"rule\":\"\"}', '2023-01-10 10:08:01.158', '2023-01-10 10:08:01.158');
 INSERT INTO `plugin_handle` VALUES ('1529402613204172962', '41', 'threadpool', 'threadpool', 3, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"shared\",\"placeholder\":\"threadpool\",\"rule\":\"\"}', '2023-01-10 10:08:01.158', '2023-01-10 10:08:01.158');
+
+INSERT INTO `plugin_handle` VALUES ('1529402613204172963', '17', 'registerAddress', 'registerAddress', 2, 3, 0, '{\"required\":\"0\",\"defaultValue\":\"127.0.0.1:8002\",\"placeholder\":\"registerAddress\",\"rule\":\"\"}', '2023-01-10 10:08:01.158', '2023-01-10 10:08:01.158'););
+
 -- ----------------------------
 -- Table structure for resource
 -- ----------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <apollo.version>2.1.0</apollo.version>
         <shiro.version>1.8.0</shiro.version>
         <jwt.version>3.12.0</jwt.version>
-        <motan.version>1.2.0</motan.version>
+        <motan.version>1.2.1</motan.version>
         <spring-boot.version>2.6.8</spring-boot.version>
         <aspectjweaver.version>1.9.6</aspectjweaver.version>
         <h2.version>1.4.200</h2.version>

--- a/shenyu-admin/src/main/resources/sql-script/h2/schema.sql
+++ b/shenyu-admin/src/main/resources/sql-script/h2/schema.sql
@@ -521,7 +521,7 @@ INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`) 
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `enabled`) VALUES ('14', 'contextPath', 'HttpProcess', 80,'1');
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`) VALUES ('15', 'grpc', 'Proxy', 310,'{"multiSelectorHandle":"1","multiRuleHandle":"0","threadpool":"shared"}','0');
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `enabled`) VALUES ('16', 'redirect', 'HttpProcess', 110,'0');
-INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`) VALUES ('17', 'motan', 'Proxy', 310,'{"register":"127.0.0.1:2181","corethreads":0,"threads":2147483647,"queues":0,"threadpool":"shared"}','0');
+INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`) VALUES ('17', 'motan', 'Proxy', 310,'{"registerProtocol":"direct","registerAddress":"127.0.0.1:8002","corethreads":0,"threads":2147483647,"queues":0,"threadpool":"shared"}','0');
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `enabled`) VALUES ('18', 'loggingConsole', 'Logging', 160, '0');
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `config`, `enabled`) VALUES ('19', 'jwt', 'Authentication', 30, '{"secretKey":"key"}', '0');
 INSERT IGNORE INTO `plugin` (`id`, `name`, `role`, `sort`, `enabled`) VALUES ('20', 'request', 'HttpProcess', 120, '0');
@@ -668,7 +668,7 @@ INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`) VALUES ('1529402613204172831', '26', 'retry', 'retryCount', 1, 2, 1);
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172832', '26', 'timeout', 'timeout', 1, 2, 2, '{"defaultValue":"3000","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`) VALUES ('1529402613204172833', '26', 'multiSelectorHandle', 'multiSelectorHandle', 3, 3, 0);
-INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`) VALUES ('1529402613204172834', '17', 'register', 'register', 2, 3, 0);
+INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172834', '17', 'registerProtocol', 'registerProtocol', 2, 3, 0, '{"required":"0","defaultValue":"direct","placeholder":"registerProtocol","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172835', '17', 'corethreads', 'corethreads', 1, 3, 0, '{"required":"0","defaultValue":"0","placeholder":"corethreads","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172836', '17', 'threads', 'threads', 1, 3, 0, '{"required":"0","defaultValue":"2147483647","placeholder":"threads","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172837', '17', 'queues', 'queues', 1, 3, 0, '{"required":"0","defaultValue":"0","placeholder":"queues","rule":""}');
@@ -826,7 +826,10 @@ INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172960', '41', 'threads', 'threads', 1, 3, 0, '{"required":"0","defaultValue":"2147483647","placeholder":"threads","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172961', '41', 'queues', 'queues', 1, 3, 0, '{"required":"0","defaultValue":"0","placeholder":"queues","rule":""}');
 INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172962', '41', 'threadpool', 'threadpool', 3, 3, 0, '{"required":"0","defaultValue":"shared","placeholder":"threadpool","rule":""}');
-/** insert resource for resource */
+
+INSERT IGNORE INTO plugin_handle (`id`, `plugin_id`,`field`,`label`,`data_type`,`type`,`sort`,`ext_obj`) VALUES ('1529402613204172963', '17', 'registerAddress', 'registerAddress', 2, 3, 0,'{"required":"0","defaultValue":"127.0.0.1:8002","placeholder":"registerAddress","rule":""}');
+
+    /** insert resource for resource */
 INSERT IGNORE INTO `resource` (`id`, `parent_id`, `title`, `name`, `url`, `component`, `resource_type`, `sort`, `icon`, `is_leaf`, `is_route`, `perms`, `status`) VALUES('1346775491550474240','','SHENYU.MENU.PLUGIN.LIST','plug','/plug','PluginList','0','0','dashboard','0','0','','1');
 
 INSERT IGNORE INTO `resource` (`id`, `parent_id`, `title`, `name`, `url`, `component`, `resource_type`, `sort`, `icon`, `is_leaf`, `is_route`, `perms`, `status`) VALUES('1357956838021890048','','SHENYU.MENU.CONFIG.MANAGMENT','config','/config','config','0','1','api','0','0','','1');
@@ -992,15 +995,15 @@ CREATE TABLE IF NOT EXISTS `tag_relation`
 -- ----------------------------
 CREATE TABLE `discovery`
 (
-    `id`           varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'primary key id',
-    `name`         varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the discovery name',
-    `type`         varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'local,zookeeper,etcd,consul,nacos',
-    `server_list`  varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  COMMENT 'register server url (,)',
-    `listener_node` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  COMMENT 'register server listener to node',
-    `props`     text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the discovery pops (json) ',
+    `id`           varchar(128)   NOT NULL COMMENT 'primary key id',
+    `name`         varchar(255)   NOT NULL COMMENT 'the discovery name',
+    `type`         varchar(64)   NOT NULL COMMENT 'local,zookeeper,etcd,consul,nacos',
+    `server_list`  varchar(255)    COMMENT 'register server url (,)',
+    `listener_node` varchar(255)    COMMENT 'register server listener to node',
+    `props`     text   COMMENT 'the discovery pops (json) ',
     `date_created` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'create time',
     `date_updated` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'update time',
-    PRIMARY KEY (`id`) USING BTREE
+    PRIMARY KEY (`id`)
 );
 
 -- ----------------------------
@@ -1008,16 +1011,16 @@ CREATE TABLE `discovery`
 -- ----------------------------
 CREATE TABLE `discovery_upstream`
 (
-    `id`           varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'primary key id',
-    `discovery_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the discovery id',
-    `protocol`     varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  COMMENT 'for http, https, tcp, ws',
-    `url`          varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'ip:port',
+    `id`           varchar(128)   NOT NULL COMMENT 'primary key id',
+    `discovery_id` varchar(128)   NOT NULL COMMENT 'the discovery id',
+    `protocol`     varchar(64)    COMMENT 'for http, https, tcp, ws',
+    `url`          varchar(64)   NOT NULL COMMENT 'ip:port',
     `status`      int(0) NOT NULL COMMENT 'type (0, healthy, 1 unhealthy)',
     `weight`      int(0) NOT NULL COMMENT 'the weight for lists',
-    `props`      text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the other field (json)',
+    `props`      text   COMMENT 'the other field (json)',
     `date_created` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'create time',
     `date_updated` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'update time',
-    PRIMARY KEY (`id`) USING BTREE
+    PRIMARY KEY (`id`)
 );
 
 -- ----------------------------
@@ -1025,15 +1028,15 @@ CREATE TABLE `discovery_upstream`
 -- ----------------------------
 CREATE TABLE `proxy_selector`
 (
-    `id`           varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'primary key id',
-    `name`         varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the proxy name',
-    `plugin_name`  varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the plugin name',
-    `type`         varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'proxy type for tcp, upd, ws',
+    `id`           varchar(128)   NOT NULL COMMENT 'primary key id',
+    `name`         varchar(255)   NOT NULL COMMENT 'the proxy name',
+    `plugin_name`  varchar(255)   NOT NULL COMMENT 'the plugin name',
+    `type`         varchar(64)   NOT NULL COMMENT 'proxy type for tcp, upd, ws',
     `forward_port` int(0) NOT NULL COMMENT 'the proxy forward port',
-    `props`      text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci COMMENT 'the other field (json)',
+    `props`      text   COMMENT 'the other field (json)',
     `date_created` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'create time',
     `date_updated` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'update time',
-    PRIMARY KEY (`id`) USING BTREE
+    PRIMARY KEY (`id`)
 );
 
 -- ----------------------------
@@ -1041,13 +1044,13 @@ CREATE TABLE `proxy_selector`
 -- ----------------------------
 CREATE TABLE `discovery_rel`
 (
-    `id`           varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'primary key id',
-    `level`        varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'plugin or selector',
-    `discovery_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the discovery id',
-    `service_id` varchar(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'the selector id or proxy selector id',
+    `id`           varchar(128)   NOT NULL COMMENT 'primary key id',
+    `level`        varchar(64)   NOT NULL COMMENT 'plugin or selector',
+    `discovery_id` varchar(128)   NOT NULL COMMENT 'the discovery id',
+    `service_id` varchar(128)   NOT NULL COMMENT 'the selector id or proxy selector id',
     `date_created` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'create time',
     `date_updated` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'update time',
-    PRIMARY KEY (`id`) USING BTREE
+    PRIMARY KEY (`id`)
 );
 
 

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfig.java
@@ -27,7 +27,9 @@ public class MotanRegisterConfig implements Serializable {
 
     private static final long serialVersionUID = 2488053756247710408L;
 
-    private String register;
+    private String registerProtocol;
+
+    private String registerAddress;
 
     private String threadpool;
 
@@ -55,23 +57,6 @@ public class MotanRegisterConfig implements Serializable {
         this.threadpool = threadpool;
     }
 
-    /**
-     * get register.
-     *
-     * @return register
-     */
-    public String getRegister() {
-        return register;
-    }
-
-    /**
-     * set register.
-     *
-     * @param register register
-     */
-    public void setRegister(final String register) {
-        this.register = register;
-    }
 
     /**
      * get corethreads.
@@ -127,6 +112,22 @@ public class MotanRegisterConfig implements Serializable {
         this.queues = queues;
     }
 
+    public String getRegisterProtocol() {
+        return registerProtocol;
+    }
+
+    public void setRegisterProtocol(String registerProtocol) {
+        this.registerProtocol = registerProtocol;
+    }
+
+    public String getRegisterAddress() {
+        return registerAddress;
+    }
+
+    public void setRegisterAddress(String registerAddress) {
+        this.registerAddress = registerAddress;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -136,21 +137,24 @@ public class MotanRegisterConfig implements Serializable {
             return false;
         }
         MotanRegisterConfig that = (MotanRegisterConfig) o;
-        return Objects.equals(register, that.register) && Objects.equals(threadpool, that.threadpool)
+        return Objects.equals(registerProtocol, that.registerProtocol) && Objects.equals(registerAddress, that.registerAddress) && Objects.equals(threadpool, that.threadpool)
                 && Objects.equals(corethreads, that.corethreads) && Objects.equals(threads, that.threads)
                 && Objects.equals(queues, that.queues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(register, threadpool, corethreads, threads, queues);
+        return Objects.hash(registerProtocol,registerAddress, threadpool, corethreads, threads, queues);
     }
 
     @Override
     public String toString() {
         return "MotanRegisterConfig{"
-                + "register='"
-                + register
+                + "registerProtocol='"
+                + registerProtocol
+                + '\''
+                + ", registerAddress='"
+                + registerAddress
                 + '\''
                 + ", threadpool='"
                 + threadpool

--- a/shenyu-common/src/test/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfigTest.java
+++ b/shenyu-common/src/test/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfigTest.java
@@ -32,12 +32,14 @@ public class MotanRegisterConfigTest {
     @Test
     public void testGetterSetter() {
         MotanRegisterConfig config = new MotanRegisterConfig();
-        config.setRegister("reg");
+        config.setRegisterAddress("reg");
+        config.setRegisterProtocol("zk");
         config.setCorethreads(10);
         config.setThreads(10);
         config.setQueues(2);
         
-        assertThat(config.getRegister(), is("reg"));
+        assertThat(config.getRegisterAddress(), is("reg"));
+        assertThat(config.getRegisterProtocol(), is("zk"));
         assertThat(config.getCorethreads(), is(10));
         assertThat(config.getThreads(), is(10));
         assertThat(config.getQueues(), is(2));

--- a/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/java/org/apache/shenyu/examples/motan/service/impl/MotanDemoServiceImpl.java
+++ b/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/java/org/apache/shenyu/examples/motan/service/impl/MotanDemoServiceImpl.java
@@ -47,6 +47,7 @@ public class MotanDemoServiceImpl implements MotanDemoService {
     @ShenyuMotanClient(value = "/timeout")
     @ApiDoc(desc = "timeout")
     public String testTimeOut(final long seconds) {
+        System.out.println("demo testTimeOut in....");
         try {
             Thread.sleep(seconds * 1000);
         } catch (InterruptedException e) {

--- a/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml
+++ b/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml
@@ -43,8 +43,8 @@ shenyu:
 
 motan:
   registry:
-    protocol: zookeeper
-    address: 127.0.0.1:2181
+    protocol: local
+    address: 127.0.0.1:8002
 
 logging:
   level:

--- a/shenyu-plugin/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyService.java
+++ b/shenyu-plugin/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyService.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.plugin.motan.proxy;
 
 import com.weibo.api.motan.config.RefererConfig;
+import com.weibo.api.motan.proxy.CommonClient;
 import com.weibo.api.motan.proxy.CommonHandler;
 import com.weibo.api.motan.rpc.ResponseFuture;
 import com.weibo.api.motan.rpc.RpcContext;
@@ -41,6 +42,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -78,12 +80,12 @@ public class MotanProxyService {
         Optional.ofNullable(rpcContext).map(context -> context.get(PluginEnum.MOTAN.getName())).ifPresent(context -> {
             context.forEach((k, v) -> RpcContext.getContext().setRpcAttachment(k, v));
         });
-        RefererConfig<CommonHandler> reference = ApplicationConfigCache.getInstance().get(metaData.getPath());
+        RefererConfig<CommonClient> reference = ApplicationConfigCache.getInstance().get(metaData.getPath());
         if (Objects.isNull(reference) || StringUtils.isEmpty(reference.getServiceInterface())) {
             ApplicationConfigCache.getInstance().invalidate(metaData.getPath());
             reference = ApplicationConfigCache.getInstance().initRef(metaData);
         }
-        CommonHandler commonHandler = reference.getRef();
+        CommonClient commonClient = reference.getRef();
         ApplicationConfigCache.MotanParamInfo motanParamInfo = ApplicationConfigCache.PARAM_MAP.get(metaData.getMethodName());
         Object[] params;
         if (Objects.isNull(motanParamInfo)) {
@@ -94,13 +96,14 @@ public class MotanProxyService {
             Map<String, Object> bodyMap = GsonUtils.getInstance().convertToMap(body);
             ParamCheckUtils.checkParamsLength(bodyMap.size(), motanParamInfo.getParamNames().length);
             for (int i = 0; i < num; i++) {
-                params[i] = bodyMap.get(motanParamInfo.getParamNames()[i]).toString();
+                //Fix the bug by dylan,Use primitive type。Otherwise, the generalization call will fail
+                params[i] = bodyMap.get(motanParamInfo.getParamNames()[i]);
             }
         }
         ResponseFuture responseFuture;
         //CHECKSTYLE:OFF IllegalCatch
         try {
-            responseFuture = (ResponseFuture) commonHandler.asyncCall(metaData.getMethodName(), params, Object.class);
+            responseFuture = (ResponseFuture) commonClient.asyncCall(metaData.getMethodName(), params, Object.class);
         } catch (Throwable e) {
             LOG.error("Exception caught in MotanProxyService#genericInvoker.", e);
             return null;


### PR DESCRIPTION
1. Upgraded motan support to the latest stable version
2. Fixed an issue where motan generalization calls failed when arguments were java primitive types or custom types
3. Fixed the motan registry hard coding issue and supported the configuration extension
4. Fixed the schema.sql syntax problem in h2 database scenario
