### PR TITLE
[type: test] Fix health check for zookeeper:3.8.0 in E2E

### DIFF
--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/docker-compose.mysql.yml
@@ -24,7 +24,7 @@ services:
     expose:
       - 2181
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/commands/stat"]
+      test: ["CMD-SHELL", "echo srvr | nc localhost 2181"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/docker-compose.mysql.yml
@@ -54,11 +54,11 @@ services:
       - "9095:9095"
     depends_on:
       mysql:
-        condition: service_started
+        condition: service_healthy
       nacos:
-        condition: service_started
+        condition: service_healthy
       zookeeper:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - ../../target/test-classes/admin-application.yml:/opt/shenyu-admin/conf/application.yml
       - /tmp/shenyu-e2e/mysql/mysql-connector.jar:/opt/shenyu-admin/ext-lib/mysql-connector.jar

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/docker-compose.mysql.yml
@@ -24,7 +24,7 @@ services:
     expose:
       - 2181
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/commands/stat"]
+      test: ["CMD-SHELL", "echo srvr | nc localhost 2181"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/docker-compose.mysql.yml
@@ -54,11 +54,11 @@ services:
       - "9095:9095"
     depends_on:
       mysql:
-        condition: service_started
+        condition: service_healthy
       nacos:
-        condition: service_started
+        condition: service_healthy
       zookeeper:
-        condition: service_started
+        condition: service_healthy
     environment:
       - SPRING_PROFILES_ACTIVE=mysql
       - spring.datasource.username=shenyue2e

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/docker-compose.mysql.yml
@@ -54,11 +54,11 @@ services:
       - "9095:9095"
     depends_on:
       zookeeper:
-        condition: service_started
+        condition: service_healthy
       nacos:
-        condition: service_started
+        condition: service_healthy
       mysql:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - ../../target/test-classes/admin-application.yml:/opt/shenyu-admin/conf/application.yml
       - /tmp/shenyu-e2e/mysql/mysql-connector.jar:/opt/shenyu-admin/ext-lib/mysql-connector.jar

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/docker-compose.mysql.yml
@@ -24,7 +24,7 @@ services:
     expose:
       - 2181
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/commands/stat"]
+      test: ["CMD-SHELL", "echo srvr | nc localhost 2181"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/docker-compose.mysql.yml
@@ -24,7 +24,7 @@ services:
     expose:
       - 2181
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/commands/stat"]
+      test: ["CMD-SHELL", "echo srvr | nc localhost 2181"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/docker-compose.mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/docker-compose.mysql.yml
@@ -77,11 +77,11 @@ services:
       start_period: 20s
     depends_on:
       mysql:
-        condition: service_started
+        condition: service_healthy
       nacos:
-        condition: service_started
+        condition: service_healthy
       zookeeper:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - ../../target/test-classes/admin-application.yml:/opt/shenyu-admin/conf/application.yml
       - /tmp/shenyu-e2e/mysql/mysql-connector.jar:/opt/shenyu-admin/ext-lib/mysql-connector.jar


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->
Related to #4934.
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

There is no `curl` but `nc` in `zookeeper:3.8.0`.

```
$ docker run --rm -d zookeeper:3.8.0                   
e086edb76143feb588e9fc7d71b5dc2633f674cad1a8d2569e991119ece126d5

$ docker ps 
CONTAINER ID   IMAGE             COMMAND                  CREATED         STATUS         PORTS                                    NAMES
e086edb76143   zookeeper:3.8.0   "/docker-entrypoint.…"   3 seconds ago   Up 3 seconds   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp   compassionate_beaver

$ docker exec -i -t e086edb76143 bash
root@e086edb76143:/apache-zookeeper-3.8.0-bin# curl 
bash: curl: command not found
root@e086edb76143:/apache-zookeeper-3.8.0-bin# echo srvr | nc localhost 2181
Zookeeper version: 3.8.0-5a02a05eddb59aee6ac762f7ea82e92a68eb9c0f, built on 2022-02-25 08:49 UTC
Latency min/avg/max: 0/0.0/0
Received: 1
Sent: 0
Connections: 1
Outstanding: 0
Zxid: 0x0
Mode: standalone
Node count: 5
root@e086edb76143:/apache-zookeeper-3.8.0-bin# 
```
