### PR TITLE
[type: build] Bump apache-rat-plugin to 0.15 to eliminate thread safe warning in parallel build

### DIFF
--- a/shenyu-e2e/pom.xml
+++ b/shenyu-e2e/pom.xml
@@ -53,7 +53,7 @@
         <jackson.version>2.13.3</jackson.version>
         <rest-assured.version>5.2.0</rest-assured.version>
         <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
-        <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
+        <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
         <spring-boot.version>2.7.13</spring-boot.version>
         <spring-framework.version>5.3.28</spring-framework.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

When running `./mvnw clean install -T1C`, the following warning is present.

```
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in shenyu:
[WARNING] org.apache.rat:apache-rat-plugin:0.13
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
