### PR TITLE
[ type:fix ] fix set-java v3 version string

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 8
           distribution: 'temurin'
           cache: maven
 


### PR DESCRIPTION
fix set-java v3 version string
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
