### PR TITLE
shenyu admin register itself and others can call admin api through gateway

### DIFF
--- a/shenyu-admin/pom.xml
+++ b/shenyu-admin/pom.xml
@@ -313,6 +313,12 @@
             <artifactId>shenyu-discovery-zookeeper</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.shenyu</groupId>
+            <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/RegisterCenterConfiguration.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/RegisterCenterConfiguration.java
@@ -22,7 +22,6 @@ import org.apache.shenyu.admin.service.register.ShenyuClientRegisterService;
 import org.apache.shenyu.register.client.server.api.ShenyuClientServerRegisterRepository;
 import org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig;
 import org.apache.shenyu.spi.ExtensionLoader;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,17 +35,6 @@ import java.util.stream.Collectors;
  */
 @Configuration
 public class RegisterCenterConfiguration {
-
-    /**
-     * Shenyu register center config shenyu register center config.
-     *
-     * @return the shenyu register center config
-     */
-    @Bean
-    @ConfigurationProperties(prefix = "shenyu.register")
-    public ShenyuRegisterCenterConfig shenyuRegisterCenterConfig() {
-        return new ShenyuRegisterCenterConfig();
-    }
     
     /**
      * Shenyu client server register repository server register repository.

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AlertReportController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AlertReportController.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.admin.controller;
 
+import org.apache.shenyu.client.springmvc.annotation.ShenyuSpringMvcClient;
 import org.apache.shenyu.common.dto.AlarmContent;
 import org.apache.shenyu.admin.model.result.ShenyuAdminResult;
 import org.apache.shenyu.admin.service.AlertDispatchService;
@@ -36,6 +37,7 @@ import javax.validation.Valid;
 @Validated
 @RestController
 @RequestMapping("/alert/report")
+@ShenyuSpringMvcClient("/alert/report/**")
 public class AlertReportController {
     
     @Autowired

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/PullSwaggerDocServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/PullSwaggerDocServiceImpl.java
@@ -114,7 +114,7 @@ public class PullSwaggerDocServiceImpl implements PullSwaggerDocService {
             );
             tagExt.setRefreshTime(newRefreshTime);
         } catch (Exception e) {
-            LOG.error("add api document fail. clusterName={} url={} error={}", instance.getClusterName(), url, e);
+            LOG.error("add api document fail. clusterName={} url={} error={}", instance.getClusterName(), url, e.getMessage());
         } finally {
             tagExt.setDocLock(null);
             //Save the time of the last updated document and the newMd5 of apidoc.

--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -55,7 +55,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -63,7 +63,14 @@ shenyu:
       zombieCheckThreads: 10
       zombieCheckTimes: 5
       scheduledTime: 10
-      nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
+    
   sync:
     websocket:
       enabled: true

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/RegisterCenterConfigurationTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/RegisterCenterConfigurationTest.java
@@ -28,7 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,11 +40,6 @@ public class RegisterCenterConfigurationTest {
 
     @InjectMocks
     private RegisterCenterConfiguration registerCenterConfiguration;
-
-    @Test
-    public void testShenyuRegisterCenterConfig() {
-        assertEquals(ShenyuRegisterCenterConfig.class, registerCenterConfiguration.shenyuRegisterCenterConfig().getClass());
-    }
 
     @Test
     public void testShenyuServerRegisterRepository() {

--- a/shenyu-bootstrap/src/main/resources/application.yml
+++ b/shenyu-bootstrap/src/main/resources/application.yml
@@ -288,7 +288,9 @@ shenyu:
       - /health_check
   alert:
     enabled: true
+    # the shenyu admin servers or gateway path switch one to config
     admins: localhost:9095
+#    gateway: localhost:9195/shenyu/admin/alert/report
   extPlugin:
     path:
     enabled: true

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java
@@ -1980,7 +1980,9 @@ public class ShenyuConfig {
     public static class AlertConfig {
         private Boolean enabled = Boolean.TRUE;
         
-        private String admins = "localhost:9095";
+        private String admins;
+        
+        private String gateway;
         
         /**
          * get shenyu spring cloud cache status.
@@ -2013,6 +2015,23 @@ public class ShenyuConfig {
          */
         public void setAdmins(final String admins) {
             this.admins = admins;
+        }
+
+        /**
+         * Get shenyu gateway alert report url path.
+         * eg: localhost:9195/shenyu/admin/alert/report
+         * @return gateway alert report url
+         */
+        public String getGateway() {
+            return gateway;
+        }
+
+        /**
+         * Set shenyu gateway alert report url.
+         * @param gateway gateway alert report url
+         */
+        public void setGateway(final String gateway) {
+            this.gateway = gateway;
         }
     }
 }

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/admin-application.yml
@@ -52,8 +52,9 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-alibaba-dubbo/src/test/resources/bootstrap-application.yml
@@ -157,7 +157,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/src/test/resources/bootstrap-application.yml
@@ -157,7 +157,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-brpc/src/test/resources/bootstrap-application.yml
@@ -277,7 +277,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/src/test/resources/bootstrap-application.yml
@@ -277,7 +277,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/resources/bootstrap-application.yml
@@ -157,7 +157,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/src/test/resources/bootstrap-application.yml
@@ -277,7 +277,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/admin-application.yml
@@ -53,7 +53,7 @@ mybatis:
 shenyu:
   register:
     registerType: http #http #zookeeper #etcd #nacos #consul
-    serverLists: #localhost:2181 #http://localhost:2379 #localhost:8848
+    serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
       sessionTimeout: 5000
       connectionTimeout: 2000
@@ -62,6 +62,13 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
+      username: admin
+      password: 123456
+  client:
+    http:
+      props:
+        contextPath: /shenyu/admin
+        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/admin-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/admin-application.yml
@@ -52,6 +52,7 @@ mybatis:
 
 shenyu:
   register:
+    enabled: false
     registerType: http #http #zookeeper #etcd #nacos #consul
     serverLists: http://localhost:9095 #localhost:2181 #http://localhost:2379 #localhost:8848
     props:
@@ -62,13 +63,6 @@ shenyu:
       zombieCheckTimes: 5
       scheduledTime: 10
       nacosNameSpace: ShenyuRegisterCenter
-      username: admin
-      password: 123456
-  client:
-    http:
-      props:
-        contextPath: /shenyu/admin
-        appName: ShenYuAdmin
   sync:
     websocket:
       enabled: true

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/bootstrap-application.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/resources/bootstrap-application.yml
@@ -157,7 +157,8 @@ shenyu:
       - /health_check
   alert:
     enabled: true
-    reportUrl: http://admin:9095/alert/report
+    # the shenyu admin servers or gateway path switch one to config
+    admins: localhost:9095
   extPlugin:
     path:
     enabled: true

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/alert/AlarmServiceImpl.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/alert/AlarmServiceImpl.java
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -47,16 +47,22 @@ public class AlarmServiceImpl implements AlarmService {
     
     private final boolean enabled;
 
-    public AlarmServiceImpl(final RestTemplate restTemplate, final String admins, final boolean enabled) {
+    public AlarmServiceImpl(final RestTemplate restTemplate, final String admins, final String gateway, final boolean enabled) {
         this.enabled = enabled;
         this.restTemplate = restTemplate;
+        this.adminReportUrls = new LinkedList<>();
         String scheme = System.getProperty("scheme", "http");
         String[] urls = StringUtils.split(admins, ",");
-        for (int index = 0; index < urls.length; index++) {
-            urls[index] = UriUtils.appendScheme(urls[index], scheme);
-            urls[index] = urls[index] + PATH;
+        if (urls != null && urls.length > 0) {
+            for (int index = 0; index < urls.length; index++) {
+                urls[index] = UriUtils.appendScheme(urls[index], scheme);
+                urls[index] = urls[index] + PATH;
+                adminReportUrls.add(urls[index]);
+            }
         }
-        adminReportUrls = Arrays.asList(urls);
+        if (!StringUtils.isEmpty(gateway)) {
+            adminReportUrls.add(UriUtils.appendScheme(gateway, scheme));
+        }
     }
     
     @Override

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java
@@ -315,6 +315,6 @@ public class ShenyuConfiguration {
     @Bean
     public AlarmService shenyuAlarmService(final ShenyuConfig shenyuConfig, final RestTemplate restTemplate) {
         ShenyuConfig.AlertConfig alertConfig = shenyuConfig.getAlert();
-        return new AlarmServiceImpl(restTemplate, alertConfig.getAdmins(), alertConfig.getEnabled());
+        return new AlarmServiceImpl(restTemplate, alertConfig.getAdmins(), alertConfig.getGateway(), alertConfig.getEnabled());
     }
 }


### PR DESCRIPTION
<!-- Describe your PR here; eg. Fixes #issueNo -->

- shenyu admin register itself and others can call admin api through gateway divide plugin
- alert report support config admin cluster register gateway api path

https://github.com/apache/shenyu/pull/5197 this support:  alert report support config admin cluster multi servers

```
shenyu
  alert:
    enabled: true
    # the shenyu admin servers or gateway path switch one to config
    admins: localhost:9095
    # the shenyu admin servers or gateway path switch one to config
    gateway: localhost:9195/shenyu/admin/alert/report
```

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
