### PR TITLE
[type:refactor]:Set the maximum time to wait for the k8s cluster to start up

### DIFF
--- a/.github/workflows/integrated-test-k8s-ingress.yml
+++ b/.github/workflows/integrated-test-k8s-ingress.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Wait for k8s Cluster Start up
         if: steps.filter.outputs.changed == 'true'
+        timeout-minutes: 15
         run: |
           bash ./shenyu-integrated-test/${{ matrix.case }}/script/healthcheck.sh
 


### PR DESCRIPTION
fix this bug
<img width="846" alt="1a72bbf5ed54a894aa59184b181799b" src="https://github.com/apache/shenyu/assets/40480634/43ca7dbf-d729-4506-a2b2-f856295d49a8">

<img width="1103" alt="b30a84f384bf124a249fc126b07d48e" src="https://github.com/apache/shenyu/assets/40480634/c3bc2060-caff-437d-8457-ca000ca22223">


Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
