### PR TITLE
[type:fix]  Set the netty allocator to unpooled

### DIFF
--- a/shenyu-bootstrap/src/main/resources/application.yml
+++ b/shenyu-bootstrap/src/main/resources/application.yml
@@ -118,7 +118,7 @@ shenyu:
         writeBufferLowWaterMark: 32768
         writeSpinCount: 16
         autoRead: false
-        allocType: "pooled"
+        allocType: "unpooled"
         messageSizeEstimator: 8
         singleEventExecutorPerGroup: true
       socketChannel:
@@ -135,7 +135,7 @@ shenyu:
         writeBufferLowWaterMark: 32768
         writeSpinCount: 16
         autoRead: false
-        allocType: "pooled"
+        allocType: "unpooled"
         messageSizeEstimator: 8
         singleEventExecutorPerGroup: true
       sni:


### PR DESCRIPTION
To avoid memory leaks, set the netty allocator to unpooled.

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
