### PR TITLE
[type:fix] fix bug when refresh config

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/config/ElasticSearchLogCollectConfig.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/config/ElasticSearchLogCollectConfig.java
@@ -207,8 +207,8 @@ public class ElasticSearchLogCollectConfig {
                     && Objects.equals(getPort(), that.getPort())
                     && Objects.equals(getSampleRate(), that.getSampleRate())
                     && Objects.equals(getBufferQueueSize(), that.getBufferQueueSize())
-                    && Objects.equals(getMaxResponseBody(), that.getMaxRequestBody())
-                    && Objects.equals(getMaxRequestBody(), that.getMaxResponseBody())
+                    && Objects.equals(getMaxRequestBody(), that.getMaxRequestBody())
+                    && Objects.equals(getMaxResponseBody(), that.getMaxResponseBody())
                     && Objects.equals(getIndexName(), that.getIndexName());
         }
 

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/src/main/java/org/apache/shenyu/plugin/huawei/lts/config/HuaweiLogCollectConfig.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/src/main/java/org/apache/shenyu/plugin/huawei/lts/config/HuaweiLogCollectConfig.java
@@ -459,7 +459,7 @@ public class HuaweiLogCollectConfig {
                     && Objects.equals(getLogStreamId(), that.getLogStreamId())
                     && Objects.equals(getAccessKeyId(), that.getAccessKeyId())
                     && Objects.equals(getAccessKeySecret(), that.getAccessKeySecret())
-                    && Objects.equals(getRegionName(), that.getTotalSizeInBytes())
+                    && Objects.equals(getRegionName(), that.getRegionName())
                     && Objects.equals(getTotalSizeInBytes(), that.getTotalSizeInBytes())
                     && Objects.equals(getMaxBlockMs(), that.getMaxBlockMs())
                     && Objects.equals(getIoThreadCount(), that.getIoThreadCount())

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/config/KafkaLogCollectConfig.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/config/KafkaLogCollectConfig.java
@@ -234,8 +234,8 @@ public class KafkaLogCollectConfig {
                     && Objects.equals(getProducerGroup(), that.getProducerGroup())
                     && Objects.equals(getSampleRate(), that.getSampleRate())
                     && Objects.equals(getBufferQueueSize(), that.getBufferQueueSize())
-                    && Objects.equals(getMaxResponseBody(), that.getMaxRequestBody())
-                    && Objects.equals(getMaxRequestBody(), that.getMaxResponseBody());
+                    && Objects.equals(getMaxRequestBody(), that.getMaxRequestBody())
+                    && Objects.equals(getMaxResponseBody(), that.getMaxResponseBody());
         }
 
         @Override

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/src/main/java/org/apache/shenyu/plugin/logging/pulsar/config/PulsarLogCollectConfig.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/src/main/java/org/apache/shenyu/plugin/logging/pulsar/config/PulsarLogCollectConfig.java
@@ -123,8 +123,8 @@ public class PulsarLogCollectConfig {
                     && Objects.equals(getServiceUrl(), that.getServiceUrl())
                     && Objects.equals(getSampleRate(), that.getSampleRate())
                     && Objects.equals(getBufferQueueSize(), that.getBufferQueueSize())
-                    && Objects.equals(getMaxResponseBody(), that.getMaxRequestBody())
-                    && Objects.equals(getMaxRequestBody(), that.getMaxResponseBody());
+                    && Objects.equals(getMaxRequestBody(), that.getMaxRequestBody())
+                    && Objects.equals(getMaxResponseBody(), that.getMaxResponseBody());
         }
 
         @Override

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/src/main/java/org/apache/shenyu/plugin/logging/rocketmq/config/RocketMQLogCollectConfig.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/src/main/java/org/apache/shenyu/plugin/logging/rocketmq/config/RocketMQLogCollectConfig.java
@@ -196,8 +196,8 @@ public class RocketMQLogCollectConfig {
                     && Objects.equals(getSecretKey(), that.getSecretKey())
                     && Objects.equals(getSampleRate(), that.getSampleRate())
                     && Objects.equals(getBufferQueueSize(), that.getBufferQueueSize())
-                    && Objects.equals(getMaxResponseBody(), that.getMaxRequestBody())
-                    && Objects.equals(getMaxRequestBody(), that.getMaxResponseBody());
+                    && Objects.equals(getMaxRequestBody(), that.getMaxRequestBody())
+                    && Objects.equals(getMaxResponseBody(), that.getMaxResponseBody());
         }
 
         @Override


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.


The config repeat refresh and the `logCollector` repeat start when logging config is not updated.

Call code in `AbstractLogPluginDataHandler`
<img width="1064" alt="image" src="https://github.com/apache/shenyu/assets/143072873/8e8d5a38-c9e0-4275-b713-c7ee802807c3">

