### PR TITLE
[type:fix][ISSUE #5100] Redis cluster mode，fix rate limiter[concurrent、slidingwindow] redis key

### DIFF
--- a/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/ConcurrentRateLimiterAlgorithm.java
+++ b/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/ConcurrentRateLimiterAlgorithm.java
@@ -47,8 +47,9 @@ public class ConcurrentRateLimiterAlgorithm extends AbstractRateLimiterAlgorithm
 
     @Override
     public List<String> getKeys(final String id) {
-        String tokenKey = getKeyName() + ".{" + id + "}.tokens";
-        String requestKey = UUIDUtils.getInstance().generateShortUuid();
+        String hashKeyPart = ".{" + id + "}";
+        String tokenKey = getKeyName() + hashKeyPart +".tokens";
+        String requestKey = UUIDUtils.getInstance().generateShortUuid() + hashKeyPart + ".request";
         return Arrays.asList(tokenKey, requestKey);
     }
 

--- a/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/ConcurrentRateLimiterAlgorithm.java
+++ b/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/ConcurrentRateLimiterAlgorithm.java
@@ -48,7 +48,7 @@ public class ConcurrentRateLimiterAlgorithm extends AbstractRateLimiterAlgorithm
     @Override
     public List<String> getKeys(final String id) {
         String hashKeyPart = ".{" + id + "}";
-        String tokenKey = getKeyName() + hashKeyPart +".tokens";
+        String tokenKey = getKeyName() + hashKeyPart + ".tokens";
         String requestKey = UUIDUtils.getInstance().generateShortUuid() + hashKeyPart + ".request";
         return Arrays.asList(tokenKey, requestKey);
     }

--- a/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/SlidingWindowRateLimiterAlgorithm.java
+++ b/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/algorithm/SlidingWindowRateLimiterAlgorithm.java
@@ -41,6 +41,9 @@ public class SlidingWindowRateLimiterAlgorithm extends AbstractRateLimiterAlgori
 
     @Override
     public List<String> getKeys(final String id) {
-        return Arrays.asList((getKeyName() + ".{" + id) + "}.tokens", UUIDUtils.getInstance().generateShortUuid());
+        String hashKeyPart = ".{" + id + "}";
+        String tokenKey = getKeyName() + hashKeyPart + ".tokens";
+        String timestampKey = UUIDUtils.getInstance().generateShortUuid() + hashKeyPart + ".timestamp";
+        return Arrays.asList(tokenKey, timestampKey);
     }
 }

--- a/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/scripts/sliding_window_request_rate_limiter.lua
+++ b/shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/scripts/sliding_window_request_rate_limiter.lua
@@ -49,7 +49,7 @@ end
 --redis.log(redis.LOG_WARNING, "allowed_num " .. allowed_num)
 
 redis.call('zremrangebyscore', tokens_key, 0, now - window_size / window_time)
-redis.call('expire', tokens_key, window_size)
+redis.call('expire', tokens_key, math.ceil(window_size))
 
 return { allowed_num, remain_request }
 


### PR DESCRIPTION
fix issue #5100 
in redis cluster mode，Concurrent、SlidingWindow Algorithm，The second key  add  '{id}'.
SlidingWindow lua expire time may be a decimal
