### PR TITLE
[ISSUE #5416]Optimize logic to avoid "orElse" execution，Update VersionTwoExtractor.java

### DIFF
--- a/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/extractor/VersionTwoExtractor.java
+++ b/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/extractor/VersionTwoExtractor.java
@@ -37,7 +37,7 @@ public class VersionTwoExtractor implements SignParameterExtractor {
 
         // use ShenYu-Authorization to avoid conflict with another Authorization
         String token = Optional.ofNullable(httpRequest.getHeaders().getFirst(Constants.SHENYU_AUTHORIZATION))
-                .orElse(httpRequest.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+                .orElseGet(() -> getDefaultToken(httpRequest));
 
         if (StringUtils.isEmpty(token) || !token.contains(".")) {
             return new SignParameters();
@@ -59,4 +59,9 @@ public class VersionTwoExtractor implements SignParameterExtractor {
 
         return signParameters;
     }
+    
+    private String getDefaultToken(HttpRequest httpRequest) {
+        return httpRequest.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+    }
+    
 }

--- a/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/extractor/VersionTwoExtractor.java
+++ b/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/extractor/VersionTwoExtractor.java
@@ -60,7 +60,7 @@ public class VersionTwoExtractor implements SignParameterExtractor {
         return signParameters;
     }
     
-    private String getDefaultToken(HttpRequest httpRequest) {
+    private String getDefaultToken(final HttpRequest httpRequest) {
         return httpRequest.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
     }
     


### PR DESCRIPTION
Optimize logic to avoid "orElse" execution：
“.orElse(httpRequest.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));”
