### PR TITLE
[BUG] update app_key in db

### DIFF
--- a/shenyu-admin/src/main/resources/mappers/app-auth-sqlmap.xml
+++ b/shenyu-admin/src/main/resources/mappers/app-auth-sqlmap.xml
@@ -219,6 +219,7 @@
     <update id="update" parameterType="org.apache.shenyu.admin.model.entity.AppAuthDO">
         UPDATE app_auth
            SET
+               app_key = #{appKey, jdbcType=VARCHAR},
                app_secret = #{appSecret, jdbcType=VARCHAR},
                phone = #{phone, jdbcType=VARCHAR},
                user_id = #{userId, jdbcType=VARCHAR},
@@ -231,6 +232,9 @@
     <update id="updateSelective" parameterType="org.apache.shenyu.admin.model.entity.AppAuthDO">
         UPDATE app_auth
         <set>
+            <if test="appKey != null">
+                app_key = #{appKey, jdbcType=VARCHAR},
+            </if>
             <if test="appSecret != null">
                 app_secret = #{appSecret, jdbcType=VARCHAR},
             </if>


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

In `org.apache.shenyu.admin.service.impl.AppAuthServiceImpl#buildByEntity`, we update the `appKey` to register center, but not save it to DB.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
