### PR TITLE
[type:fix] Fix Plugin Edit Page Issue by Correcting Plugin ID Query and Updating Data Type

### DIFF
--- a/db/init/oracle/schema.sql
+++ b/db/init/oracle/schema.sql
@@ -2776,7 +2776,7 @@ INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX (namespace(id)) */ INTO `namespace` (`id`,
 CREATE TABLE plugin_ns_rel (
                                id VARCHAR2(128) COLLATE utf8mb4_unicode_ci NOT NULL,
                                namespace_id VARCHAR2(50) COLLATE utf8mb4_unicode_ci NOT NULL,
-                               plugin_id NUMBER(11) NOT NULL,
+                               plugin_id VARCHAR2(128) COLLATE utf8mb4_unicode_ci NOT NULL,
                                config CLOB COLLATE utf8mb4_unicode_ci,
                                sort NUMBER(11),
                                enabled NUMBER(4,0) NOT NULL DEFAULT 0 CHECK (enabled IN (0, 1)),

--- a/db/upgrade/2.6.1-upgrade-2.7.0-mysql.sql
+++ b/db/upgrade/2.6.1-upgrade-2.7.0-mysql.sql
@@ -88,7 +88,7 @@ INSERT INTO `shenyu`.`namespace` (`id`, `namespace_id`, `name`, `description`, `
 CREATE TABLE `plugin_ns_rel` (
                                  `id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'primary key id',
                                  `namespace_id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'namespace id',
-                                 `plugin_id` int(11) NOT NULL COMMENT 'plugin id',
+                                 `plugin_id` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'plugin id',
                                  `config` text COLLATE utf8mb4_unicode_ci COMMENT 'plugin configuration',
                                  `sort` int(11) DEFAULT NULL COMMENT 'sort',
                                  `enabled` tinyint(4) NOT NULL DEFAULT '0' COMMENT 'whether to open (0, not open, 1 open)',

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/NamespacePluginController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/NamespacePluginController.java
@@ -106,7 +106,7 @@ public class NamespacePluginController implements PagedController<NamespacePlugi
      * @param pluginId    pluginId.
      * @return {@linkplain ShenyuAdminResult}
      */
-    @GetMapping("/pluginId={pluginId}&namespaceId={namespaceId}")
+    @GetMapping("/{pluginId}/{namespaceId}")
     @RequiresPermissions("system:plugin:edit")
     public ShenyuAdminResult detailPlugin(@PathVariable("namespaceId")
                                           @Existed(message = "namespace is not existed", provider = NamespaceMapper.class) final String namespaceId,

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/NamespacePluginController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/NamespacePluginController.java
@@ -17,6 +17,8 @@
 
 package org.apache.shenyu.admin.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.admin.aspect.annotation.RestApi;
 import org.apache.shenyu.admin.mapper.NamespaceMapper;
@@ -47,8 +49,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -103,16 +103,16 @@ public class NamespacePluginController implements PagedController<NamespacePlugi
      * detail plugin of namespace.
      *
      * @param namespaceId namespace id.
-     * @param id          id.
+     * @param pluginId    pluginId.
      * @return {@linkplain ShenyuAdminResult}
      */
-    @GetMapping("/id={id}&namespaceId={namespaceId}")
+    @GetMapping("/pluginId={pluginId}&namespaceId={namespaceId}")
     @RequiresPermissions("system:plugin:edit")
     public ShenyuAdminResult detailPlugin(@PathVariable("namespaceId")
                                           @Existed(message = "namespace is not existed", provider = NamespaceMapper.class) final String namespaceId,
-                                          @PathVariable("id")
-                                          @Existed(message = "id is not existed", provider = NamespacePluginRelMapper.class) final String id) {
-        NamespacePluginVO namespacePluginVO = namespacePluginService.findById(id, namespaceId);
+                                          @PathVariable("pluginId")
+                                          @Existed(message = "pluginId is not existed", provider = NamespacePluginRelMapper.class) final String pluginId) {
+        NamespacePluginVO namespacePluginVO = namespacePluginService.findByPluginId(pluginId, namespaceId);
         return ShenyuAdminResult.success(ShenyuResultMessage.DETAIL_SUCCESS, namespacePluginVO);
     }
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/NamespacePluginRelMapper.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/NamespacePluginRelMapper.java
@@ -39,11 +39,11 @@ public interface NamespacePluginRelMapper extends ExistProvider {
     /**
      * existed.
      *
-     * @param id id
+     * @param pluginId pluginId
      * @return existed
      */
     @Override
-    Boolean existed(@Param("id") Serializable id);
+    Boolean existed(@Param("pluginId") Serializable pluginId);
 
 
     /**

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/NamespacePluginService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/NamespacePluginService.java
@@ -53,13 +53,13 @@ public interface NamespacePluginService extends PageService<NamespacePluginQuery
     String delete(List<String> ids, String namespaceId);
 
     /**
-     * find plugin namespace by id.
+     * find plugin namespace by pluginId.
      *
-     * @param id    pk.
+     * @param pluginId    the pluginId.
      * @param namespaceId the namespaceId
      * @return {@linkplain PluginVO}
      */
-    NamespacePluginVO findById(String id, String namespaceId);
+    NamespacePluginVO findByPluginId(String pluginId, String namespaceId);
 
     /**
      * find page of plugin namespace by query.

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/NamespacePluginServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/NamespacePluginServiceImpl.java
@@ -96,8 +96,8 @@ public class NamespacePluginServiceImpl implements NamespacePluginService {
     }
 
     @Override
-    public NamespacePluginVO findById(final String id, final String namespaceId) {
-        return this.namespacePluginRelMapper.selectByPluginIdAndNamespaceId(id, namespaceId);
+    public NamespacePluginVO findByPluginId(final String pluginId, final String namespaceId) {
+        return this.namespacePluginRelMapper.selectByPluginIdAndNamespaceId(pluginId, namespaceId);
     }
 
     @Override

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SyncDataServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SyncDataServiceImpl.java
@@ -127,7 +127,7 @@ public class SyncDataServiceImpl implements SyncDataService {
 
     @Override
     public boolean syncPluginData(final String pluginId, final String namespaceId) {
-        NamespacePluginVO namespacePluginVO = namespacePluginService.findById(pluginId, namespaceId);
+        NamespacePluginVO namespacePluginVO = namespacePluginService.findByPluginId(pluginId, namespaceId);
         eventPublisher.publishEvent(new DataChangedEvent(ConfigGroupEnum.PLUGIN, DataEventTypeEnum.UPDATE,
                 Collections.singletonList(PluginTransfer.INSTANCE.mapToData(namespacePluginVO))));
 

--- a/shenyu-admin/src/main/resources/mappers/NamespacePluginRelMapper.xml
+++ b/shenyu-admin/src/main/resources/mappers/NamespacePluginRelMapper.xml
@@ -43,7 +43,7 @@
     <select id="existed" resultType="java.lang.Boolean">
         SELECT true
         FROM plugin_ns_rel
-        WHERE id = #{id} limit 1
+        WHERE plugin_id = #{pluginId} limit 1
     </select>
 
 

--- a/shenyu-admin/src/main/resources/sql-script/h2/schema.sql
+++ b/shenyu-admin/src/main/resources/sql-script/h2/schema.sql
@@ -1264,7 +1264,7 @@ INSERT IGNORE INTO `namespace` (`id`, `namespace_id`, `name`, `description`, `da
 CREATE TABLE IF NOT EXISTS `plugin_ns_rel` (
                                                `id` VARCHAR(128) NOT NULL COMMENT 'primary key id',
     `namespace_id` VARCHAR(50) NOT NULL COMMENT 'namespace id',
-    `plugin_id` INT NOT NULL COMMENT 'plugin id',
+    `plugin_id` varchar(128) NOT NULL COMMENT 'plugin id',
     `config` TEXT COMMENT 'plugin configuration',
     `sort` INT DEFAULT NULL COMMENT 'sort',
     `enabled` TINYINT NOT NULL DEFAULT 0 COMMENT 'whether to open (0, not open, 1 open)',

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SyncDataServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SyncDataServiceTest.java
@@ -108,7 +108,7 @@ public final class SyncDataServiceTest {
     public void syncPluginDataTest() {
         PluginVO pluginVO = buildPluginVO();
         NamespacePluginVO namespacePluginVO = new NamespacePluginVO();
-        given(this.namespacePluginService.findById(pluginVO.getId(), SYS_DEFAULT_NAMESPACE_ID)).willReturn(namespacePluginVO);
+        given(this.namespacePluginService.findByPluginId(pluginVO.getId(), SYS_DEFAULT_NAMESPACE_ID)).willReturn(namespacePluginVO);
         SelectorData selectorData = buildSelectorData();
         given(this.selectorService.findByPluginIdAndNamespaceId(pluginVO.getId(), SYS_DEFAULT_NAMESPACE_ID)).willReturn(Collections.singletonList(selectorData));
 


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
Fixes #5621 

Fixes the issue where the plugin edit page fails to load due to an incorrect query in the `GET /namespacePlugin/id={id}&namespaceId={namespaceId}` endpoint. The query used `pluginId = {id}`, which resulted in no data being returned.

**Changes Made:**
- **Refactored**: `org.apache.shenyu.admin.service.NamespacePluginService#findById` to `findByPluginId`.
- **Updated**: The frontend request for "namespacePlugin/fetchItem" to use `pluginId` instead of `id`.
- **Modified**: The `plugin_id` field in the `plugin_ns_rel` table from a numeric type to `VARCHAR(128)` to prevent type mismatch errors.
- **Updated**: `org.apache.shenyu.admin.mapper.NamespacePluginRelMapper#existed` to align with the changes in how plugin IDs are handled.

Note that bulk operations such as delete and enable/disable still use `id` as the query condition. This PR may have implications for recent changes in the namespace feature. CC: @xcsnx

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.