### PR TITLE
Fix metaData disable not filter

### DIFF
--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/MetaDataCache.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/MetaDataCache.java
@@ -124,7 +124,7 @@ public final class MetaDataCache {
                 .orElseGet(() -> {
                     final MetaData value = META_DATA_MAP.values()
                             .stream()
-                            .filter(data -> PathMatchUtils.match(data.getPath(), path))
+                            .filter(data -> data.getEnabled() && PathMatchUtils.match(data.getPath(), path))
                             .findFirst()
                             .orElse(null);
                     final String metaPath = Optional.ofNullable(value)


### PR DESCRIPTION

when metaData have disable item
uri path match need filter disable metaData

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
