### PR TITLE
[type:fix] fix ListUtil->merge exception

### DIFF
--- a/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ListUtil.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/utils/ListUtil.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.common.utils;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -185,8 +186,7 @@ public final class ListUtil {
      * @return list1
      */
     public static <T> List<T> merge(final List<T> list1, final List<T> list2) {
-        list1.addAll(list2);
-        return list1;
+        return ListUtils.union(list1, list2);
     }
     
     /**


### PR DESCRIPTION
"org.apache.shenyu.common.utils.ListUtil#of"  this method return UnmodifiableRandomAccessList
so, "org.apache.shenyu.common.utils.ListUtil#merge" addAll will throw UnsupportedOperationException

question:
when use waf plugin, and rule condition have many,  bootstrap restart, admin will exception
<img width="838" alt="image" src="https://github.com/user-attachments/assets/a924c54b-dd4f-4ddb-82d3-55fe5b19c5f7">


- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
