### PR TITLE
[Fix] fix data-permission namespace problem

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/NamespaceDTO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/NamespaceDTO.java
@@ -19,6 +19,8 @@ package org.apache.shenyu.admin.model.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
 import java.io.Serializable;
 
 /**
@@ -36,14 +38,14 @@ public class NamespaceDTO implements Serializable {
     /**
      * namespace name.
      */
-    @Max(value = 255, message = "The maximum length is 255")
+    @Length(max = 255, message = "The maximum length is 255")
     @NotNull(message = "namespace name not null")
     private String name;
 
     /**
      * namespace description.
      */
-    @Max(value = 255, message = "The maximum length is 255")
+    @Length(max = 255, message = "The maximum length is 255")
     @NotNull(message = "namespace description not null")
     private String description;
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/NamespaceDTO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/NamespaceDTO.java
@@ -17,7 +17,6 @@
 
 package org.apache.shenyu.admin.model.dto;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DataPermissionServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DataPermissionServiceImpl.java
@@ -166,7 +166,7 @@ public class DataPermissionServiceImpl implements DataPermissionService {
             List<String> selectorIds = selectorDOStreamSupplier.get().map(SelectorDO::getId).collect(Collectors.toList());
 
             Set<String> hasDataPermissionSelectorIds = new HashSet<>();
-            if (!selectorIds.isEmpty()){
+            if (!selectorIds.isEmpty()) {
                 hasDataPermissionSelectorIds.addAll(dataPermissionMapper.selectDataIds(selectorIds,
                         userId, AdminDataPermissionTypeEnum.SELECTOR.ordinal()));
             }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DataPermissionServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DataPermissionServiceImpl.java
@@ -164,10 +164,13 @@ public class DataPermissionServiceImpl implements DataPermissionService {
         if (totalCount > 0) {
             Supplier<Stream<SelectorDO>> selectorDOStreamSupplier = () -> selectorMapper.selectByQuery(selectorQuery).stream();
             List<String> selectorIds = selectorDOStreamSupplier.get().map(SelectorDO::getId).collect(Collectors.toList());
-            
-            Set<String> hasDataPermissionSelectorIds = new HashSet<>(dataPermissionMapper.selectDataIds(selectorIds,
-                    userId, AdminDataPermissionTypeEnum.SELECTOR.ordinal()));
-            
+
+            Set<String> hasDataPermissionSelectorIds = new HashSet<>();
+            if (!selectorIds.isEmpty()){
+                hasDataPermissionSelectorIds.addAll(dataPermissionMapper.selectDataIds(selectorIds,
+                        userId, AdminDataPermissionTypeEnum.SELECTOR.ordinal()));
+            }
+
             selectorList = selectorDOStreamSupplier.get().map(selectorDO -> {
                 boolean isChecked = hasDataPermissionSelectorIds.contains(selectorDO.getId());
                 return DataPermissionPageVO.buildPageVOBySelector(selectorDO, isChecked);


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

1. "Use `@Length(max =` to validate the length of a String instead of `@Max(value =` because `@Max` only verifies numbers."

2. "Do not query `dataPermission` when `selectorIds` is empty." 

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
