### PR TITLE
[type:fix] Delete proxy.selector and discovery  nacos config when delete the divide selector.

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/AbstractDiscoveryProcessor.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/AbstractDiscoveryProcessor.java
@@ -135,6 +135,17 @@ public abstract class AbstractDiscoveryProcessor implements DiscoveryProcessor, 
     }
 
     @Override
+    public void removeSelectorUpstream(final ProxySelectorDTO proxySelectorDTO) {
+        DiscoverySyncData discoverySyncData = new DiscoverySyncData();
+        discoverySyncData.setPluginName(proxySelectorDTO.getPluginName());
+        discoverySyncData.setSelectorId(proxySelectorDTO.getId());
+        discoverySyncData.setSelectorName(proxySelectorDTO.getName());
+        discoverySyncData.setNamespaceId(proxySelectorDTO.getNamespaceId());
+        DataChangedEvent dataChangedEvent = new DataChangedEvent(ConfigGroupEnum.DISCOVER_UPSTREAM, DataEventTypeEnum.DELETE, Collections.singletonList(discoverySyncData));
+        eventPublisher.publishEvent(dataChangedEvent);
+    }
+
+    @Override
     public void changeUpstream(final ProxySelectorDTO proxySelectorDTO, final List<DiscoveryUpstreamDTO> upstreamDTOS) {
         DiscoverySyncData discoverySyncData = new DiscoverySyncData();
         discoverySyncData.setPluginName(proxySelectorDTO.getPluginName());

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DiscoveryProcessor.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DiscoveryProcessor.java
@@ -76,4 +76,11 @@ public interface DiscoveryProcessor {
      */
     void fetchAll(DiscoveryHandlerDTO discoveryHandlerDTO, ProxySelectorDTO proxySelectorDTO);
 
+    /**
+     * remove selector upstream.
+     *
+     * @param proxySelectorDTO    proxySelectorDTO
+     */
+    void removeSelectorUpstream(ProxySelectorDTO proxySelectorDTO);
+
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/LocalDiscoveryProcessor.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/LocalDiscoveryProcessor.java
@@ -81,6 +81,17 @@ public class LocalDiscoveryProcessor implements DiscoveryProcessor, ApplicationE
     }
 
     @Override
+    public void removeSelectorUpstream(final ProxySelectorDTO proxySelectorDTO) {
+        DiscoverySyncData discoverySyncData = new DiscoverySyncData();
+        discoverySyncData.setPluginName(proxySelectorDTO.getPluginName());
+        discoverySyncData.setSelectorId(proxySelectorDTO.getId());
+        discoverySyncData.setSelectorName(proxySelectorDTO.getName());
+        discoverySyncData.setNamespaceId(proxySelectorDTO.getNamespaceId());
+        DataChangedEvent dataChangedEvent = new DataChangedEvent(ConfigGroupEnum.DISCOVER_UPSTREAM, DataEventTypeEnum.DELETE, Collections.singletonList(discoverySyncData));
+        eventPublisher.publishEvent(dataChangedEvent);
+    }
+
+    @Override
     public void changeUpstream(final ProxySelectorDTO proxySelectorDTO, final List<DiscoveryUpstreamDTO> upstreamDTOS) {
         DiscoverySyncData discoverySyncData = new DiscoverySyncData();
         discoverySyncData.setPluginName(proxySelectorDTO.getPluginName());

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java
@@ -294,12 +294,14 @@ public class SelectorServiceImpl implements SelectorService {
             if (Objects.nonNull(discoveryDO)) {
                 final DiscoveryProcessor discoveryProcessor = discoveryProcessorHolder.chooseProcessor(discoveryDO.getType());
                 ProxySelectorDTO proxySelectorDTO = new ProxySelectorDTO();
+                proxySelectorDTO.setId(selector.getId());
                 proxySelectorDTO.setName(selector.getName());
-                proxySelectorDTO.setPluginName(pluginMap.getOrDefault(selector.getId(), ""));
+                proxySelectorDTO.setPluginName(pluginMap.getOrDefault(selector.getPluginId(), ""));
                 proxySelectorDTO.setNamespaceId(selector.getNamespaceId());
                 discoveryProcessor.removeProxySelector(DiscoveryTransfer.INSTANCE.mapToDTO(discoveryHandlerDO), proxySelectorDTO);
                 if (DiscoveryLevel.SELECTOR.getCode().equals(discoveryDO.getLevel())) {
                     discoveryProcessor.removeDiscovery(discoveryDO);
+                    discoveryProcessor.removeSelectorUpstream(proxySelectorDTO);
                     discoveryMapper.delete(discoveryDO.getId());
                 }
             }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/LocalDiscoveryProcessorTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/LocalDiscoveryProcessorTest.java
@@ -82,6 +82,13 @@ public class LocalDiscoveryProcessorTest {
     }
 
     @Test
+    public void testRemoveSelectorUpstream() {
+        doNothing().when(eventPublisher).publishEvent(any(DataChangedEvent.class));
+        localDiscoveryProcessor.removeSelectorUpstream(new ProxySelectorDTO());
+        verify(eventPublisher).publishEvent(any(DataChangedEvent.class));
+    }
+
+    @Test
     public void testFetchAll() {
         List<DiscoveryUpstreamDO> discoveryUpstreamDOS = new ArrayList<>();
         DiscoveryHandlerDTO discoveryHandlerDTO = new DiscoveryHandlerDTO();


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
Fix the issue #5844. Delete proxy.selector and discovery  nacos config when delete the divide selector.
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
