### PR TITLE
fixed some bug when using http-polling mode

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefresh.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefresh.java
@@ -67,7 +67,7 @@ public class DiscoveryUpstreamDataRefresh extends AbstractDataRefresh<DiscoveryS
 
     @Override
     public ConfigData<?> cacheConfigData() {
-        return GROUP_CACHE.get(ConfigGroupEnum.PROXY_SELECTOR);
+        return GROUP_CACHE.get(ConfigGroupEnum.DISCOVER_UPSTREAM);
     }
 
 }


### PR DESCRIPTION
Resolved the issue where the DISCOVER_UPSTREAM configuration item always failed to synchronize in the http-polling configuration data sync mode;

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
