### PR TITLE
[type:fix] The rule cache can not be deleted in shenyu-bootstrap when use nacos as sync center

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java
@@ -245,9 +245,9 @@ public abstract class AbstractNodeDataSyncService {
     protected void unCacheRuleData(final String removeKey) {
         final RuleData ruleData = new RuleData();
         final String[] ruleKeys = StringUtils.split(removeKey, DefaultNodeConstants.JOIN_POINT);
-        ruleData.setPluginName(ruleKeys[1]);
-        ruleData.setSelectorId(ruleKeys[2]);
-        ruleData.setId(ruleKeys[3]);
+        ruleData.setPluginName(ruleKeys[2]);
+        ruleData.setSelectorId(ruleKeys[3]);
+        ruleData.setId(ruleKeys[4]);
         Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.unRuleSubscribe(ruleData));
         removeListener(removeKey);
     }


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
Fix the issue #5928 . 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
