### PR TITLE
perf(logging): Optimize the performance of log collection

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpRequest.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpRequest.java
@@ -56,11 +56,11 @@ public class LoggingServerHttpRequest<L extends ShenyuRequestLog> extends Server
             }
         }).doFinally(signal -> {
             int size = writer.size();
-            String body = writer.output();
             boolean requestBodyTooLarge = LogCollectConfigUtils.isRequestBodyTooLarge(size);
             if (size == 0 || requestBodyTooLarge) {
                 return;
             }
+            String body = writer.output();
             logInfo.setRequestBody(body);
         });
     }

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpResponse.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpResponse.java
@@ -171,8 +171,8 @@ public class LoggingServerHttpResponse<L extends ShenyuRequestLog> extends Serve
         }
         if (Objects.nonNull(writer)) {
             int size = writer.size();
-            String body = writer.output();
             if (size > 0 && !LogCollectConfigUtils.isResponseBodyTooLarge(size)) {
+                String body = writer.output();
                 logInfo.setResponseBody(body);
             }
         } else {
@@ -261,8 +261,8 @@ public class LoggingServerHttpResponse<L extends ShenyuRequestLog> extends Serve
         }
 
         int size = bytes.length;
-        String body = new String(bytes, StandardCharsets.UTF_8);
         if (size > 0 && !LogCollectConfigUtils.isResponseBodyTooLarge(size)) {
+            String body = new String(bytes, StandardCharsets.UTF_8);
             logInfo.setResponseBody(body);
         }
         // collect log


### PR DESCRIPTION
- Adjust the serialization timing of the request body and response body to avoid unnecessary string operations.
- Perform string conversion only after confirming the need to record logs to reduce resource consumption.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
