### PR TITLE
[feat] Supports generating Elasticsearch indices daily and creating an alias for them.

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.lang.NonNull;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -51,6 +53,8 @@ import java.util.Objects;
 public class ElasticSearchLogCollectClient extends AbstractLogConsumeClient<ElasticSearchLogCollectConfig.ElasticSearchLogConfig, ShenyuRequestLog> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchLogCollectClient.class);
+    
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     private RestClient restClient;
 
@@ -88,11 +92,8 @@ public class ElasticSearchLogCollectClient extends AbstractLogConsumeClient<Elas
         client = new ElasticsearchClient(transport);
         indexName = StringUtils.isNoneBlank(config.getIndexName()) ? config.getIndexName() : GenericLoggingConstant.INDEX;
         LogUtils.info(LOG, "init ElasticSearchLogCollectClient success");
-        // Determine whether the index exists, and create it if it does not exist
-        if (!existsIndex(indexName)) {
-            createIndex(indexName);
-            LogUtils.info(LOG, "create index success");
-        }
+        
+        createOrUpdateIndexAlias(indexName);
     }
 
     /**
@@ -101,6 +102,13 @@ public class ElasticSearchLogCollectClient extends AbstractLogConsumeClient<Elas
      */
     @Override
     public void consume0(@NonNull final List<ShenyuRequestLog> logs) {
+        String actualIndex = getActualIndexName();
+        // Ensure the current day's index exists
+        if (!existsIndex(actualIndex)) {
+            createIndex(actualIndex);
+            createOrUpdateIndexAlias(indexName);
+        }
+        
         List<BulkOperation> bulkOperations = new ArrayList<>();
         logs.forEach(log -> {
             try {
@@ -143,6 +151,41 @@ public class ElasticSearchLogCollectClient extends AbstractLogConsumeClient<Elas
             client.indices().create(c -> c.index(indexName));
         } catch (IOException e) {
             LogUtils.error(LOG, "create index error:", e);
+        }
+    }
+    
+    /**
+     * Get the actual index name for the current date.
+     *
+     * @return the actual index name with date suffix
+     */
+    private String getActualIndexName() {
+        String date = LocalDate.now().format(DATE_FORMAT);
+        return String.format("%s-%s", indexName, date);
+    }
+    
+    /**
+     * Create an index alias that points to all date-based indices.
+     *
+     * @param aliasName the alias name
+     */
+    private void createOrUpdateIndexAlias(final String aliasName) {
+        try {
+            String actualIndex = getActualIndexName();
+            // Create the actual index if it doesn't exist
+            if (!existsIndex(actualIndex)) {
+                createIndex(actualIndex);
+                LogUtils.info(LOG, "Created new date-based index: {}", actualIndex);
+            }
+            
+            // Create or update the alias to point to the current index
+            client.indices().putAlias(r -> r
+                    .index(actualIndex)
+                    .name(aliasName)
+            );
+            LogUtils.info(LOG, "Updated alias {} to point to index {}", aliasName, actualIndex);
+        } catch (Exception e) {
+            LogUtils.error(LOG, "Failed to create/update alias: ", e);
         }
     }
 

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java
@@ -179,10 +179,7 @@ public class ElasticSearchLogCollectClient extends AbstractLogConsumeClient<Elas
             }
             
             // Create or update the alias to point to the current index
-            client.indices().putAlias(r -> r
-                    .index(actualIndex)
-                    .name(aliasName)
-            );
+            client.indices().putAlias(r -> r.index(actualIndex).name(aliasName));
             LogUtils.info(LOG, "Updated alias {} to point to index {}", aliasName, actualIndex);
         } catch (Exception e) {
             LogUtils.error(LOG, "Failed to create/update alias: ", e);


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
Supports generating Elasticsearch indices daily and creating an alias for them.

Writing all log data to a single Elasticsearch index can result in a very large index.  Splitting the index by day and creating an alias allows for reducing the data volume in each individual index and enabling queries through the alias.

for example. today is 2025-03-31. the index name were set to be shenyu-access-logging. the real index to write to will be shenyu-access-logging-2025-03-31. and will create alias for shenyu-access-logging-2025-03-31, so user can search shenyu-access-logging

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
