### PR TITLE
fix AiTokenLimiterPlugin appendResponse

### DIFF
--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java
@@ -50,7 +50,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.annotation.NonNull;
 
-//import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -63,7 +62,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.zip.DataFormatException;
-//import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 
 /**


### PR DESCRIPTION
Question:

In the appendResponse method,
Processing ByteBuffer in chunks leads to the first ByteBuffer having a gzip response header, which is correctly decompressed. Subsequent ByteBuffers are intermediate segments in the compressed stream and no longer contain a header. When taken out separately and decompressed using GZIPInputStream, they cannot identify the beginning and will report an error when constructing the stream or reading data. If subsequent chunks fail to decompress, the original compressed bytes will be written to BodyWriter unchanged. What accumulates in BodyWriter is a garbled binary stream rather than decompressed text. This leads to inaccurate token statistics.

Solution:

By decompressing across chunks in a streaming manner, memory consumption is reduced while gzip data is correctly processed and token counts are accurately tallied.