### PR TITLE
[fix] resolve duplicate header issue for JWT values with dot notation

### DIFF
--- a/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/strategy/DefaultJwtConvertStrategy.java
+++ b/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/strategy/DefaultJwtConvertStrategy.java
@@ -87,8 +87,9 @@ public class DefaultJwtConvertStrategy implements JwtConvertStrategy {
 
             if (converter.getJwtVal().contains(".")) {
                 headers.add(converter.getHeaderVal(), parse(body, converter.getJwtVal().split("\\."), new AtomicInteger(0)));
+            } else {
+                headers.add(converter.getHeaderVal(), String.valueOf(body.get(converter.getJwtVal())));
             }
-            headers.add(converter.getHeaderVal(), String.valueOf(body.get(converter.getJwtVal())));
 
         }
     }


### PR DESCRIPTION

When JWT value contains dot notation (e.g., user.name) to access nested properties, the DefaultJwtConvertStrategy.addHeader() method adds HTTP headers twice.

**Cause:**
```java
if (converter.getJwtVal().contains(".")) {
    headers.add(headerVal, parse(...)); // adds correct value
}
headers.add(headerVal, body.get(jwtVal)); // always executes, adds null
```

**Result:**

Expected: username: `["john"]`
Actual: username: `["john", "null"]`

Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
