### PR TITLE
Fix the issue where the cache is not properly deleted after removing a selector in the Nacos data synchronization method.

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java
@@ -230,8 +230,8 @@ public abstract class AbstractNodeDataSyncService {
     protected void unCacheSelectorData(final String removeKey) {
         final SelectorData selectorData = new SelectorData();
         final String[] ruleKeys = StringUtils.split(removeKey, DefaultNodeConstants.JOIN_POINT);
-        selectorData.setPluginName(ruleKeys[1]);
-        selectorData.setId(ruleKeys[2]);
+        selectorData.setPluginName(ruleKeys[2]);
+        selectorData.setId(ruleKeys[3]);
         Optional.ofNullable(pluginDataSubscriber).ifPresent(e -> e.unSelectorSubscribe(selectorData));
         removeListener(removeKey);
     }


### PR DESCRIPTION
Fixes #6121

I have implemented the fix on the 2.7.0.2 version used in our company and have already deployed it to the production environment.

