### PR TITLE
Fix Order Dependent Test in AiPromptPluginDataHandlerTest

### DIFF
--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandlerTest.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandlerTest.java
@@ -42,7 +42,7 @@ class AiPromptPluginDataHandlerTest {
     private AiPromptPluginDataHandler handler;
 
     @BeforeEach
-    void setUp()throws Exception{
+    void setUp()throws Exception {
         handler = new AiPromptPluginDataHandler();
 
         Field singles = Singleton.class.getDeclaredField("SINGLES");


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
### What is the purpose of the change

AiPromptPluginDataHandler stores AiPromptConfig inside a static cache via:

``` Singleton.INST.single(AiPromptConfig.class, config); ```

Because SINGLES is static and shared across all tests, running:

`testHandlerPluginWithValidData` (polluter), then
`testHandlerPluginWithNullData` (victam),

causes nondeterministic test failures. The second test fails when the leftover state from the first test remains in the global cache.

### The Fix
Clear the actual static SINGLES map directly using reflection before each test in the `@BeforeEach`

---
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
