### PR TITLE
[#6262] Fix OrderlyExecutor resource leak in shenyu-disruptor

### DIFF
--- a/shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/DisruptorProviderManage.java
+++ b/shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/DisruptorProviderManage.java
@@ -130,7 +130,7 @@ public class DisruptorProviderManage<T> {
         disruptor.setDefaultExceptionHandler(new IgnoreExceptionHandler());
         disruptor.start();
         RingBuffer<DataEvent<T>> ringBuffer = disruptor.getRingBuffer();
-        provider = new DisruptorProvider<>(ringBuffer, disruptor, isOrderly);
+        provider = new DisruptorProvider<>(ringBuffer, disruptor, isOrderly, executor);
     }
     
     /**

--- a/shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/provider/DisruptorProvider.java
+++ b/shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/provider/DisruptorProvider.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 
 /**
  * DisruptorProvider.
@@ -41,6 +42,8 @@ public class DisruptorProvider<T> {
     private final Disruptor<DataEvent<T>> disruptor;
     
     private final boolean isOrderly;
+    
+    private final ExecutorService executor;
     
     private final EventTranslatorOneArg<DataEvent<T>, T> translatorOneArg = (event, sequence, t) -> event.setData(t);
     
@@ -62,11 +65,13 @@ public class DisruptorProvider<T> {
      * @param ringBuffer the ring buffer
      * @param disruptor  the disruptor
      * @param isOrderly  the orderly Whether to execute sequentially.
+     * @param executor   the executor service to be managed
      */
-    public DisruptorProvider(final RingBuffer<DataEvent<T>> ringBuffer, final Disruptor<DataEvent<T>> disruptor, final boolean isOrderly) {
+    public DisruptorProvider(final RingBuffer<DataEvent<T>> ringBuffer, final Disruptor<DataEvent<T>> disruptor, final boolean isOrderly, final ExecutorService executor) {
         this.ringBuffer = ringBuffer;
         this.disruptor = disruptor;
         this.isOrderly = isOrderly;
+        this.executor = executor;
     }
 
     /**
@@ -109,6 +114,9 @@ public class DisruptorProvider<T> {
     public void shutdown() {
         if (Objects.nonNull(disruptor)) {
             disruptor.shutdown();
+        }
+        if (Objects.nonNull(executor)) {
+            executor.shutdown();
         }
     }
 }

--- a/shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/provider/DisruptorProviderTest.java
+++ b/shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/provider/DisruptorProviderTest.java
@@ -31,11 +31,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.concurrent.ExecutorService;
+
 class DisruptorProviderTest {
 
     private RingBuffer<DataEvent<String>> mockRingBuffer;
 
     private Disruptor<DataEvent<String>> mockDisruptor;
+
+    private ExecutorService mockExecutor;
 
     private DisruptorProvider<String> disruptorProvider;
 
@@ -44,7 +48,8 @@ class DisruptorProviderTest {
 
         mockRingBuffer = mock(RingBuffer.class);
         mockDisruptor = mock(Disruptor.class);
-        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, false);
+        mockExecutor = mock(ExecutorService.class);
+        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, false, mockExecutor);
     }
 
     @Test
@@ -60,7 +65,7 @@ class DisruptorProviderTest {
     @Test
     void testOnDataThrowsExceptionForOrderlyProvider() {
 
-        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, true);
+        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, true, mockExecutor);
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> disruptorProvider.onData("testData"));
         assertEquals("The current provider is  of orderly type. Please use onOrderlyData() method.", exception.getMessage());
@@ -69,7 +74,7 @@ class DisruptorProviderTest {
     @Test
     void testOnOrderlyData() {
 
-        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, true);
+        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, mockDisruptor, true, mockExecutor);
         String testData = "testData";
         String[] hashArray = {"hash1", "hash2"};
 
@@ -94,12 +99,13 @@ class DisruptorProviderTest {
         disruptorProvider.shutdown();
 
         verify(mockDisruptor).shutdown();
+        verify(mockExecutor).shutdown();
     }
 
     @Test
     void testShutdownWithNullDisruptor() {
 
-        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, null, false);
+        disruptorProvider = new DisruptorProvider<>(mockRingBuffer, null, false, null);
 
         disruptorProvider.shutdown();
 


### PR DESCRIPTION
## Description
Fixes resource leak where OrderlyExecutor thread pool is never shut down, causing thread exhaustion on component restart.
## Changes
- `DisruptorProvider.java`: Added ExecutorService field, updated constructor, shutdown executor in `shutdown()` method
- `DisruptorProviderManage.java`: Pass executor to DisruptorProvider constructor
- `DisruptorProviderTest.java`: Updated tests to verify executor shutdown
## Related Issue
Fixes #6262