### PR TITLE
[fix]: Fix ReactorNettyWebSocketClient builder reuse in WebSocket plugin configuration

### DIFF
--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/main/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/main/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfiguration.java
@@ -78,7 +78,7 @@ public class WebSocketPluginConfiguration {
     @Bean
     public ReactorNettyWebSocketClient reactorNettyWebSocketClient(final ShenyuConfig shenyuConfig,
                                                                    final ObjectProvider<HttpClient> httpClient) {
-        Supplier<WebsocketClientSpec.Builder> builder = WebsocketClientSpec.builder()
+        Supplier<WebsocketClientSpec.Builder> builder = () -> WebsocketClientSpec.builder()
                 .maxFramePayloadLength(shenyuConfig.getWebsocket().getMaxFramePayloadSize() * Constants.BYTES_PER_MB)
                 .handlePing(shenyuConfig.getWebsocket().getEnableProxyPing());
         return new ReactorNettyWebSocketClient(httpClient.getIfAvailable(HttpClient::create), builder);

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/test/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfigurationTest.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/test/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfigurationTest.java
@@ -28,8 +28,12 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
 import org.springframework.web.reactive.socket.server.WebSocketService;
+import reactor.netty.http.client.WebsocketClientSpec;
+
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -76,6 +80,11 @@ public class WebSocketPluginConfigurationTest {
         applicationContextRunner.run(context -> {
                 ReactorNettyWebSocketClient client = context.getBean("reactorNettyWebSocketClient", ReactorNettyWebSocketClient.class);
                 assertNotNull(client);
+                @SuppressWarnings("unchecked")
+                Supplier<WebsocketClientSpec.Builder> builderSupplier =
+                        (Supplier<WebsocketClientSpec.Builder>) ReflectionTestUtils.getField(client, "specBuilderSupplier");
+                assertNotNull(builderSupplier);
+                assertThat(builderSupplier.get()).isNotSameAs(builderSupplier.get());
             }
         );
     }


### PR DESCRIPTION
### Motivation

`WebSocketPluginConfiguration` currently passes a mutable `WebsocketClientSpec.Builder` in a way that may cause builder state to be reused across WebSocket handshakes.

Following the same approach discussed in Spring Cloud Gateway issue #2215 / PR #2216, each handshake should use a fresh builder instance to avoid cross-request state leakage.

### Description

- Updated `WebSocketPluginConfiguration#reactorNettyWebSocketClient` to provide a `Supplier<WebsocketClientSpec.Builder>` that creates a **new builder on each invocation**.
- Extended the existing `testReactorNettyWebSocketClient` (as requested) to verify behavior by checking that the internal builder supplier returns different builder instances across calls.

### Related Links

- https://github.com/spring-cloud/spring-cloud-gateway/issues/2215
- https://github.com/spring-cloud/spring-cloud-gateway/pull/2216