### PR TITLE
Fix duplicate full-mode URI heartbeat registration after repeated refresh

### DIFF
--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java
@@ -150,7 +150,7 @@ public abstract class AbstractContextRefreshedEventListener<T, A extends Annotat
         if (MapUtils.isEmpty(beans)) {
             return;
         }
-        if (!registered.compareAndSet(false, true)) {
+        if (!markRegistered()) {
             return;
         }
         if (isDiscoveryLocalMode) {
@@ -370,6 +370,15 @@ public abstract class AbstractContextRefreshedEventListener<T, A extends Annotat
      */
     public ShenyuClientRegisterEventPublisher getPublisher() {
         return publisher;
+    }
+
+    /**
+     * Mark the listener as registered once.
+     *
+     * @return true when this invocation acquires the registration gate
+     */
+    protected boolean markRegistered() {
+        return registered.compareAndSet(false, true);
     }
 
     /**

--- a/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListener.java
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListener.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener;
 import org.apache.shenyu.client.core.constant.ShenyuClientConstants;
-import org.apache.shenyu.client.core.disruptor.ShenyuClientRegisterEventPublisher;
 import org.apache.shenyu.client.core.utils.PortUtils;
 import org.apache.shenyu.client.springmvc.annotation.ShenyuSpringMvcClient;
 import org.apache.shenyu.common.enums.ApiHttpMethodEnum;
@@ -67,8 +66,6 @@ import java.util.stream.Stream;
 public class SpringMvcClientEventListener extends AbstractContextRefreshedEventListener<Object, ShenyuSpringMvcClient> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringMvcClientEventListener.class);
-
-    private final ShenyuClientRegisterEventPublisher publisher = ShenyuClientRegisterEventPublisher.getInstance();
 
     private final List<Class<? extends Annotation>> mappingAnnotation = new ArrayList<>(3);
 
@@ -121,6 +118,9 @@ public class SpringMvcClientEventListener extends AbstractContextRefreshedEventL
     protected Map<String, Object> getBeans(final ApplicationContext context) {
         // Filter out
         if (Boolean.TRUE.equals(isFull)) {
+            if (!markRegistered()) {
+                return Collections.emptyMap();
+            }
             LOG.info("init spring mvc client success with isFull mode");
             List<String> namespaceIds = super.getNamespace();
             namespaceIds.forEach(namespaceId -> {
@@ -135,7 +135,7 @@ public class SpringMvcClientEventListener extends AbstractContextRefreshedEventL
                         .namespaceId(namespaceId)
                         .build());
                 
-                publisher.publishEvent(buildURIRegisterDTO(context, Collections.emptyMap(), namespaceId));
+                getPublisher().publishEvent(buildURIRegisterDTO(context, Collections.emptyMap(), namespaceId));
             });
             return Collections.emptyMap();
         }

--- a/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.client.springmvc.init;
 
 import org.apache.shenyu.client.core.constant.ShenyuClientConstants;
+import org.apache.shenyu.client.core.disruptor.ShenyuClientRegisterEventPublisher;
 import org.apache.shenyu.client.core.exception.ShenyuClientIllegalArgumentException;
 import org.apache.shenyu.client.core.register.ShenyuClientRegisterRepositoryFactory;
 import org.apache.shenyu.client.springmvc.annotation.ShenyuSpringMvcClient;
@@ -175,6 +176,21 @@ public class SpringMvcClientEventListenerTest {
         init();
         SpringMvcClientEventListener springMvcClientEventListener = buildSpringMvcClientEventListener(false, false);
         Assert.assertThrows(ShenyuException.class, () -> springMvcClientEventListener.onApplicationEvent(contextRefreshedEvent));
+        registerUtilsMockedStatic.close();
+    }
+
+    @Test
+    public void testOnApplicationEventFullModeShouldRegisterOnce() {
+        try (MockedStatic<ShenyuClientRegisterEventPublisher> publisherMockedStatic = mockStatic(ShenyuClientRegisterEventPublisher.class)) {
+            ShenyuClientRegisterEventPublisher publisher = mock(ShenyuClientRegisterEventPublisher.class);
+            publisherMockedStatic.when(ShenyuClientRegisterEventPublisher::getInstance).thenReturn(publisher);
+            SpringMvcClientEventListener springMvcClientEventListener = buildSpringMvcClientEventListener(true, true);
+            ContextRefreshedEvent event = new ContextRefreshedEvent(applicationContext);
+            springMvcClientEventListener.onApplicationEvent(event);
+            springMvcClientEventListener.onApplicationEvent(event);
+            verify(publisher, times(1)).start(any());
+            verify(publisher, times(2)).publishEvent(any());
+        }
         registerUtilsMockedStatic.close();
     }
 

--- a/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/main/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListener.java
+++ b/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/main/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListener.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener;
 import org.apache.shenyu.client.core.constant.ShenyuClientConstants;
-import org.apache.shenyu.client.core.disruptor.ShenyuClientRegisterEventPublisher;
 import org.apache.shenyu.client.core.utils.PortUtils;
 import org.apache.shenyu.client.spring.websocket.annotation.ShenyuServerEndpoint;
 import org.apache.shenyu.client.spring.websocket.annotation.ShenyuSpringWebSocketClient;
@@ -61,8 +60,6 @@ import java.util.Properties;
  * The type Shenyu websocket client event listener.
  */
 public class SpringWebSocketClientEventListener extends AbstractContextRefreshedEventListener<Object, ShenyuSpringWebSocketClient> {
-    
-    private final ShenyuClientRegisterEventPublisher publisher = ShenyuClientRegisterEventPublisher.getInstance();
     
     private final String[] pathAttributeNames = new String[] {"path", "value"};
 
@@ -105,9 +102,12 @@ public class SpringWebSocketClientEventListener extends AbstractContextRefreshed
     protected Map<String, Object> getBeans(final ApplicationContext context) {
         // Filter out is not controller out
         if (Boolean.TRUE.equals(isFull)) {
+            if (!markRegistered()) {
+                return Collections.emptyMap();
+            }
             LOG.info("init spring websocket client success with isFull mode");
             List<String> namespaceIds = super.getNamespace();
-            namespaceIds.forEach(namespaceId -> publisher.publishEvent(buildURIRegisterDTO(context, Collections.emptyMap(), namespaceId)));
+            namespaceIds.forEach(namespaceId -> getPublisher().publishEvent(buildURIRegisterDTO(context, Collections.emptyMap(), namespaceId)));
             return Collections.emptyMap();
         }
         Map<String, Object> endpointBeans = context.getBeansWithAnnotation(ShenyuServerEndpoint.class);

--- a/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/test/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListenerTest.java
+++ b/shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/test/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListenerTest.java
@@ -32,9 +32,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.annotation.Annotation;
@@ -49,7 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,21 +87,7 @@ public class SpringWebSocketClientEventListenerTest {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        Properties properties = mock(Properties.class);
-        when(properties.getProperty("appName")).thenReturn("appName");
-        when(properties.getProperty("contextPath")).thenReturn("contextPath");
-        when(properties.getProperty(ShenyuClientConstants.PORT)).thenReturn("8080");
-        when(properties.getProperty(ShenyuClientConstants.HOST)).thenReturn("127.0.0.1");
-        when(properties.getProperty(ShenyuClientConstants.IP_PORT)).thenReturn("127.0.0.1:8080");
-        
-        ShenyuClientConfig clientConfig = mock(ShenyuClientConfig.class);
-        Map<String, ClientPropertiesConfig> client = new HashMap<>();
-        ClientPropertiesConfig clientPropertiesConfig = new ClientPropertiesConfig();
-        clientPropertiesConfig.setProps(properties);
-        client.put(RpcTypeEnum.WEB_SOCKET.getName(), clientPropertiesConfig);
-        when(clientConfig.getClient()).thenReturn(client);
-        eventListener = new SpringWebSocketClientEventListener(clientConfig, registerRepository);
+        eventListener = buildEventListener(false);
     }
 
     @Test
@@ -176,6 +165,39 @@ public class SpringWebSocketClientEventListenerTest {
         String port = eventListener.getPort();
         assertNotNull(port);
         assertEquals(port, "8080");
+    }
+
+    @Test
+    public void testOnApplicationEventFullModeShouldRegisterOnce() {
+        try (MockedStatic<ShenyuClientRegisterEventPublisher> publisherMockedStatic = mockStatic(ShenyuClientRegisterEventPublisher.class)) {
+            ShenyuClientRegisterEventPublisher mockPublisher = mock(ShenyuClientRegisterEventPublisher.class);
+            publisherMockedStatic.when(ShenyuClientRegisterEventPublisher::getInstance).thenReturn(mockPublisher);
+            SpringWebSocketClientEventListener fullModeEventListener = buildEventListener(true);
+            ContextRefreshedEvent event = new ContextRefreshedEvent(applicationContext);
+            fullModeEventListener.onApplicationEvent(event);
+            fullModeEventListener.onApplicationEvent(event);
+            verify(mockPublisher, times(1)).start(any());
+            verify(mockPublisher, times(1)).publishEvent(any());
+        }
+    }
+
+    private SpringWebSocketClientEventListener buildEventListener(final boolean full) {
+        Properties properties = new Properties();
+        properties.setProperty("appName", "appName");
+        properties.setProperty("contextPath", "contextPath");
+        properties.setProperty(ShenyuClientConstants.PORT, "8080");
+        properties.setProperty(ShenyuClientConstants.HOST, "127.0.0.1");
+        properties.setProperty(ShenyuClientConstants.IP_PORT, "127.0.0.1:8080");
+        properties.setProperty(ShenyuClientConstants.IS_FULL, String.valueOf(full));
+        properties.setProperty(ShenyuClientConstants.DISCOVERY_LOCAL_MODE_KEY, Boolean.TRUE.toString());
+
+        ShenyuClientConfig clientConfig = mock(ShenyuClientConfig.class);
+        Map<String, ClientPropertiesConfig> client = new HashMap<>();
+        ClientPropertiesConfig clientPropertiesConfig = new ClientPropertiesConfig();
+        clientPropertiesConfig.setProps(properties);
+        client.put(RpcTypeEnum.WEB_SOCKET.getName(), clientPropertiesConfig);
+        when(clientConfig.getClient()).thenReturn(client);
+        return new SpringWebSocketClientEventListener(clientConfig, registerRepository);
     }
 
     /**


### PR DESCRIPTION
Fixes duplicate full-mode URI registration when the client receives repeated `ContextRefreshedEvent` callbacks.

## Summary
- route full-mode Spring MVC and WebSocket registration through the shared one-time registration gate
- remove duplicated direct publisher fields from the concrete listeners and reuse the base publisher access
- add regression tests covering repeated refresh events for both full-mode listeners

## Verification
- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

Test command run:
`mvn -pl shenyu-client/shenyu-client-core,shenyu-client/shenyu-client-http/shenyu-client-springmvc,shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket -am -DfailIfNoTests=false -Dtest=ShenyuClientURIExecutorSubscriberTest,SpringMvcClientEventListenerTest,SpringWebSocketClientEventListenerTest test`
