### PR TITLE
fix: skip request body for GET and HEAD requests

### DIFF
--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java
@@ -117,6 +117,10 @@ public abstract class AbstractHttpClientPlugin<R> implements ShenyuPlugin {
     protected abstract Mono<R> doRequest(ServerWebExchange exchange, String httpMethod,
                                          URI uri, Flux<DataBuffer> body);
 
+    protected boolean isRequestBodyRequired(final String httpMethod) {
+        return !"GET".equals(httpMethod) && !"HEAD".equals(httpMethod);
+    }
+
     protected void duplicateHeaders(final ServerWebExchange exchange, final HttpHeaders headers, final UniqueHeaderEnum uniqueHeaderEnum) {
         final String duplicateHeader = exchange.getAttribute(uniqueHeaderEnum.getName());
         if (StringUtils.isEmpty(duplicateHeader)) {

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java
@@ -76,7 +76,16 @@ public class NettyHttpClientPlugin extends AbstractHttpClientPlugin<HttpClientRe
                 headers.add(HttpHeaders.HOST, request.getHeaders().getFirst(HttpHeaders.HOST));
             }
         }).request(HttpMethod.valueOf(httpMethod)).uri(uri.toASCIIString())
-                .send((req, nettyOutbound) -> nettyOutbound.send(body.map(dataBuffer -> ((NettyDataBuffer) dataBuffer).getNativeBuffer())))
+                .send((req, nettyOutbound) -> {
+                    // Do not send a request body for GET/HEAD. Otherwise Reactor Netty may add
+                    // Transfer-Encoding: chunked and cause compatibility issues with some upstream servers.
+                    if (isRequestBodyRequired(httpMethod)) {
+                        return nettyOutbound.send(body.map(dataBuffer ->
+                                ((NettyDataBuffer) dataBuffer).getNativeBuffer()));
+                    } else {
+                        return nettyOutbound;
+                    }
+                })
                 .responseConnection((res, connection) -> {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("NettyHttpClient response: status={}", res.status().code());
@@ -110,7 +119,6 @@ public class NettyHttpClientPlugin extends AbstractHttpClientPlugin<HttpClientRe
                     return Mono.just(res);
                 }));
     }
-
 
     @Override
     public int getOrder() {

--- a/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java
@@ -61,7 +61,8 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ResponseEntity<Flu
         ServerHttpRequest request = exchange.getRequest();
         final HttpHeaders httpHeaders = new HttpHeaders(request.getHeaders());
         this.duplicateHeaders(exchange, httpHeaders, UniqueHeaderEnum.REQ_UNIQUE_HEADER);
-        final WebClient.ResponseSpec responseSpec = webClient.method(HttpMethod.valueOf(httpMethod)).uri(uri)
+        HttpMethod method = HttpMethod.valueOf(httpMethod);
+        WebClient.RequestBodySpec requestBodySpec = webClient.method(method).uri(uri)
                 .headers(headers -> {
                     headers.addAll(exchange.getRequest().getHeaders());
                     headers.remove(HttpHeaders.HOST);
@@ -69,15 +70,20 @@ public class WebClientPlugin extends AbstractHttpClientPlugin<ResponseEntity<Flu
                     if (preserveHost) {
                         headers.add(HttpHeaders.HOST, request.getHeaders().getFirst(HttpHeaders.HOST));
                     }
-                })
-                .body((outputMessage, context) -> {
-                    MediaType mediaType = exchange.getRequest().getHeaders().getContentType();
-                    if (MediaTypeUtils.isByteType(mediaType)) {
-                        return outputMessage.writeWith(body);
-                    }
-                    // fix chinese garbled code
-                    return outputMessage.writeWith(DataBufferUtils.join(body));
-                })
+                });
+        WebClient.RequestHeadersSpec<?> requestHeadersSpec = requestBodySpec;
+        // Do not attach a request body for GET/HEAD to avoid unexpected transfer encoding.
+        if (isRequestBodyRequired(httpMethod)) {
+            requestHeadersSpec = requestBodySpec.body((outputMessage, context) -> {
+                MediaType mediaType = exchange.getRequest().getHeaders().getContentType();
+                if (MediaTypeUtils.isByteType(mediaType)) {
+                    return outputMessage.writeWith(body);
+                }
+                // fix chinese garbled code
+                return outputMessage.writeWith(DataBufferUtils.join(body));
+            });
+        }
+        final WebClient.ResponseSpec responseSpec = requestHeadersSpec
                 .retrieve()
                 // cover DefaultResponseSpec#DEFAULT_STATUS_HANDLER
                 .onRawStatus(httpStatus -> httpStatus >= 400, clientResponse -> Mono.empty());


### PR DESCRIPTION
### Description

This PR prevents the HTTP client plugins from forwarding request bodies for GET and HEAD requests.

Sending a body for GET or HEAD may cause Reactor Netty or WebClient to emit unexpected transfer encoding headers, which can break compatibility with some upstream servers.

### Changes

- Add shared request-body eligibility logic in `AbstractHttpClientPlugin`.
- Reuse the shared logic in `NettyHttpClientPlugin`.
- Reuse the shared logic in `WebClientPlugin`.
- Keep request body forwarding unchanged for non-GET/HEAD methods.

### Tests

- [x] `./mvnw -pl shenyu-plugin/shenyu-plugin-httpclient -am -DskipTests validate`
- [x] `./mvnw -pl shenyu-plugin/shenyu-plugin-httpclient -am test`

### Checklist

- [x] I have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] I submit test cases (unit or integration tests) that back your changes.
- [x] My local test passed `./mvnw -pl shenyu-plugin/shenyu-plugin-httpclient -am test`.
