### PR TITLE
fix: eliminate race condition in UpstreamCheckServiceTest.testReplace

### DIFF
--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -221,8 +221,9 @@ public final class UpstreamCheckServiceTest {
         final DivideUpstream divideUpstream2 = DivideUpstream.builder()
                 .upstreamHost("localhost2")
                 .build();
+        upstreamMap.remove(MOCK_SELECTOR_NAME_2);
         upstreamMap.put(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream)));
-        upstreamCheckService.replace(MOCK_SELECTOR_NAME_2, Collections.singletonList(divideUpstream2));
+        upstreamCheckService.replace(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream2)));
         assertEquals(1, upstreamMap.get(MOCK_SELECTOR_NAME_2).size());
         assertEquals("localhost2", upstreamMap.get(MOCK_SELECTOR_NAME_2).get(0).getUpstreamHost());
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -214,17 +215,13 @@ public final class UpstreamCheckServiceTest {
 
     @Test
     public void testReplace() {
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, ShenyuThreadFactory.create("scheduled-upstream-task", false));
-        ReflectionTestUtils.setField(upstreamCheckService, "executor", executor);
         final DivideUpstream divideUpstream = DivideUpstream.builder()
                 .upstreamHost("localhost")
                 .build();
         final DivideUpstream divideUpstream2 = DivideUpstream.builder()
                 .upstreamHost("localhost2")
                 .build();
-        upstreamCheckService.submit(MOCK_SELECTOR_NAME_2, divideUpstream);
-        assertEquals(1, upstreamMap.get(MOCK_SELECTOR_NAME_2).size());
-        assertEquals("localhost", upstreamMap.get(MOCK_SELECTOR_NAME_2).get(0).getUpstreamHost());
+        upstreamMap.put(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream)));
         upstreamCheckService.replace(MOCK_SELECTOR_NAME_2, Collections.singletonList(divideUpstream2));
         assertEquals(1, upstreamMap.get(MOCK_SELECTOR_NAME_2).size());
         assertEquals("localhost2", upstreamMap.get(MOCK_SELECTOR_NAME_2).get(0).getUpstreamHost());

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -221,8 +221,8 @@ public final class UpstreamCheckServiceTest {
         final DivideUpstream divideUpstream2 = DivideUpstream.builder()
                 .upstreamHost("localhost2")
                 .build();
-        upstreamMap.remove(MOCK_SELECTOR_NAME_2);
-        upstreamMap.put(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream)));
+        UpstreamCheckService.removeByKey(MOCK_SELECTOR_NAME_2);
+        upstreamCheckService.replace(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream)));
         upstreamCheckService.replace(MOCK_SELECTOR_NAME_2, new CopyOnWriteArrayList<>(Collections.singletonList(divideUpstream2)));
         assertEquals(1, upstreamMap.get(MOCK_SELECTOR_NAME_2).size());
         assertEquals("localhost2", upstreamMap.get(MOCK_SELECTOR_NAME_2).get(0).getUpstreamHost());


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
close #6354

By the way, The CI matrix currently tests Java 17, 19, 20, 21. Given JDK is now at 26, non-LTS versions (18, 19, 20) add CI overhead without much value.

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
