### PR TITLE
Fix README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://shenyu.apache.org/docs/" >
+  <a href="https://shenyu.apache.org/docs/">
     <img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN docs" />
   </a>
   <a href="https://shenyu.apache.org/zh/docs/">

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://shenyu.apache.org/docs/index" >
+  <a href="https://shenyu.apache.org/docs/" >
     <img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN docs" />
   </a>
-  <a href="https://shenyu.apache.org/zh/docs/index">
+  <a href="https://shenyu.apache.org/zh/docs/">
     <img src="https://img.shields.io/badge/文档-简体中文-blue.svg" alt="简体中文文档" />
   </a>
 </p>


### PR DESCRIPTION
Fixes broken documentation badge links in README.

### What is changed

This PR updates the English and Chinese documentation badge links in README:

* `https://shenyu.apache.org/docs/index` -> `https://shenyu.apache.org/docs/`
* `https://shenyu.apache.org/zh/docs/index` -> `https://shenyu.apache.org/zh/docs/`

### Why

The previous documentation links point to pages that return `Page Not Found`. 
<img width="2191" height="580" alt="image" src="https://github.com/user-attachments/assets/8ff38ec3-ed9b-4e72-8bd6-4aa8978adeec" />

Updating them to the current documentation homepage URLs ensures users can navigate to the English and Chinese docs correctly from README.
<img width="2406" height="627" alt="image" src="https://github.com/user-attachments/assets/04ed42bf-d5d9-4f10-a963-cfcd9d75a67e" />

### Test

This is a documentation-only change.

* Verified the updated links can be opened successfully in the browser.
* No unit or integration tests are required.
