### PR TITLE
Codex/fix sandbox response leak

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java
@@ -64,15 +64,20 @@ public class SandboxServiceImpl implements SandboxService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SandboxServiceImpl.class);
 
-    private static final HttpUtils HTTP_UTILS = new HttpUtils();
-
     private final AppAuthService appAuthService;
 
     private final ShenyuDictService shenyuDictService;
 
+    private final HttpUtils httpUtils;
+
     public SandboxServiceImpl(final AppAuthService appAuthService, final ShenyuDictService shenyuDictService) {
+        this(appAuthService, shenyuDictService, new HttpUtils());
+    }
+
+    SandboxServiceImpl(final AppAuthService appAuthService, final ShenyuDictService shenyuDictService, final HttpUtils httpUtils) {
         this.appAuthService = appAuthService;
         this.shenyuDictService = shenyuDictService;
+        this.httpUtils = httpUtils;
     }
 
     @Override
@@ -107,19 +112,20 @@ public class SandboxServiceImpl implements SandboxService {
         // Public request parameters.
         Map<String, Object> reqParams = this.buildReqBizParams(proxyGatewayDTO);
         List<HttpUtils.UploadFile> files = this.uploadFiles(request);
-        Response resp = HTTP_UTILS.requestCall(uriComponents.toUriString(), reqParams, header, HttpUtils.HTTPMethod.fromValue(proxyGatewayDTO.getHttpMethod()), files);
-        ResponseBody body = resp.body();
+        try (Response resp = httpUtils.requestCall(uriComponents.toUriString(), reqParams, header, HttpUtils.HTTPMethod.fromValue(proxyGatewayDTO.getHttpMethod()), files)) {
+            ResponseBody body = resp.body();
 
-        if (Objects.isNull(body)) {
-            return;
-        }
-        if (StringUtils.isNotEmpty(appKey)) {
-            response.addHeader("sandbox-beforesign", UriUtils.encode(signContent, StandardCharsets.UTF_8));
-            response.addHeader("sandbox-sign", UriUtils.encode(sign, StandardCharsets.UTF_8));
-        }
+            if (Objects.isNull(body)) {
+                return;
+            }
+            if (StringUtils.isNotEmpty(appKey)) {
+                response.addHeader("sandbox-beforesign", UriUtils.encode(signContent, StandardCharsets.UTF_8));
+                response.addHeader("sandbox-sign", UriUtils.encode(sign, StandardCharsets.UTF_8));
+            }
 
-        IOUtils.copy(body.byteStream(), response.getOutputStream());
-        response.flushBuffer();
+            IOUtils.copy(body.byteStream(), response.getOutputStream());
+            response.flushBuffer();
+        }
     }
 
     private Set<String> getPermitHostPorts() {

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java
@@ -64,20 +64,15 @@ public class SandboxServiceImpl implements SandboxService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SandboxServiceImpl.class);
 
+    private static final HttpUtils HTTP_UTILS = new HttpUtils();
+
     private final AppAuthService appAuthService;
 
     private final ShenyuDictService shenyuDictService;
 
-    private final HttpUtils httpUtils;
-
     public SandboxServiceImpl(final AppAuthService appAuthService, final ShenyuDictService shenyuDictService) {
-        this(appAuthService, shenyuDictService, new HttpUtils());
-    }
-
-    SandboxServiceImpl(final AppAuthService appAuthService, final ShenyuDictService shenyuDictService, final HttpUtils httpUtils) {
         this.appAuthService = appAuthService;
         this.shenyuDictService = shenyuDictService;
-        this.httpUtils = httpUtils;
     }
 
     @Override
@@ -112,7 +107,7 @@ public class SandboxServiceImpl implements SandboxService {
         // Public request parameters.
         Map<String, Object> reqParams = this.buildReqBizParams(proxyGatewayDTO);
         List<HttpUtils.UploadFile> files = this.uploadFiles(request);
-        try (Response resp = httpUtils.requestCall(uriComponents.toUriString(), reqParams, header, HttpUtils.HTTPMethod.fromValue(proxyGatewayDTO.getHttpMethod()), files)) {
+        try (Response resp = HTTP_UTILS.requestCall(uriComponents.toUriString(), reqParams, header, HttpUtils.HTTPMethod.fromValue(proxyGatewayDTO.getHttpMethod()), files)) {
             ResponseBody body = resp.body();
 
             if (Objects.isNull(body)) {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
@@ -17,24 +17,17 @@
 
 package org.apache.shenyu.admin.service.impl;
 
+import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import okhttp3.MediaType;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okio.Buffer;
-import okio.BufferedSource;
-import okio.ForwardingSource;
-import okio.Okio;
 import org.apache.shenyu.admin.model.dto.ProxyGatewayDTO;
 import org.apache.shenyu.admin.model.vo.ShenyuDictVO;
 import org.apache.shenyu.admin.service.AppAuthService;
 import org.apache.shenyu.admin.service.ShenyuDictService;
-import org.apache.shenyu.admin.utils.HttpUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -43,9 +36,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -61,74 +51,49 @@ final class SandboxServiceImplTest {
     @Mock
     private ShenyuDictService shenyuDictService;
 
-    @Mock
-    private HttpUtils httpUtils;
-
     @Test
-    void requestProxyGatewayShouldCopyBodyAndCloseResponse() throws IOException {
-        AtomicBoolean bodyClosed = new AtomicBoolean();
-        Response proxyResponse = buildResponse("proxied response", bodyClosed);
-        SandboxServiceImpl sandboxService = new SandboxServiceImpl(appAuthService, shenyuDictService, httpUtils);
+    void requestProxyGatewayShouldCopyBody() throws IOException {
+        HttpServer server = startHttpServer("proxied response");
+        int port = server.getAddress().getPort();
+        SandboxServiceImpl sandboxService = new SandboxServiceImpl(appAuthService, shenyuDictService);
 
-        when(shenyuDictService.list(anyString())).thenReturn(Collections.singletonList(buildDict()));
-        when(httpUtils.requestCall(anyString(), anyMap(), anyMap(), any(HttpUtils.HTTPMethod.class), anyList())).thenReturn(proxyResponse);
+        when(shenyuDictService.list(anyString())).thenReturn(Collections.singletonList(buildDict(port)));
 
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        sandboxService.requestProxyGateway(buildProxyGatewayDTO(), new MockHttpServletRequest(), response);
+        try {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            sandboxService.requestProxyGateway(buildProxyGatewayDTO(port), new MockHttpServletRequest(), response);
 
-        assertThat(response.getContentAsString()).isEqualTo("proxied response");
-        assertThat(bodyClosed).isTrue();
+            assertThat(response.getContentAsString()).isEqualTo("proxied response");
+        } finally {
+            server.stop(0);
+        }
     }
 
-    private ProxyGatewayDTO buildProxyGatewayDTO() {
+    private ProxyGatewayDTO buildProxyGatewayDTO(final int port) {
         ProxyGatewayDTO proxyGatewayDTO = new ProxyGatewayDTO();
-        proxyGatewayDTO.setRequestUrl("http://localhost:8080/proxy");
-        proxyGatewayDTO.setHeaders(Collections.emptyMap());
+        proxyGatewayDTO.setRequestUrl("http://localhost:" + port + "/proxy");
+        proxyGatewayDTO.setHeaders(Collections.singletonMap("Content-Type", "application/x-www-form-urlencoded"));
         proxyGatewayDTO.setBizParam(Collections.emptyMap());
         return proxyGatewayDTO;
     }
 
-    private ShenyuDictVO buildDict() {
+    private ShenyuDictVO buildDict(final int port) {
         ShenyuDictVO dictVO = new ShenyuDictVO();
-        dictVO.setDictValue("http://localhost:8080");
+        dictVO.setDictValue("http://localhost:" + port);
         dictVO.setEnabled(Boolean.TRUE);
         return dictVO;
     }
 
-    private Response buildResponse(final String content, final AtomicBoolean bodyClosed) {
-        return new Response.Builder()
-                .request(new Request.Builder().url("http://localhost:8080/proxy").build())
-                .protocol(Protocol.HTTP_1_1)
-                .code(200)
-                .message("OK")
-                .body(buildResponseBody(content, bodyClosed))
-                .build();
-    }
-
-    private ResponseBody buildResponseBody(final String content, final AtomicBoolean bodyClosed) {
-        Buffer buffer = new Buffer().writeUtf8(content);
-        BufferedSource source = Okio.buffer(new ForwardingSource(buffer) {
-            @Override
-            public void close() throws IOException {
-                bodyClosed.set(true);
-                super.close();
+    private HttpServer startHttpServer(final String content) throws IOException {
+        byte[] responseBody = content.getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/proxy", exchange -> {
+            exchange.sendResponseHeaders(200, responseBody.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(responseBody);
             }
         });
-        return new ResponseBody() {
-            @Override
-            public MediaType contentType() {
-                return MediaType.parse("text/plain");
-            }
-
-            @Override
-            public long contentLength() {
-                return content.length();
-            }
-
-            @Override
-            public BufferedSource source() {
-                return source;
-            }
-        };
+        server.start();
+        return server;
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
@@ -88,9 +88,13 @@ final class SandboxServiceImplTest {
         byte[] responseBody = content.getBytes(StandardCharsets.UTF_8);
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/proxy", exchange -> {
-            exchange.sendResponseHeaders(200, responseBody.length);
-            try (OutputStream outputStream = exchange.getResponseBody()) {
-                outputStream.write(responseBody);
+            try {
+                exchange.sendResponseHeaders(200, responseBody.length);
+                try (OutputStream outputStream = exchange.getResponseBody()) {
+                    outputStream.write(responseBody);
+                }
+            } finally {
+                exchange.close();
             }
         });
         server.start();

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.admin.service.impl;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
+import org.apache.shenyu.admin.model.dto.ProxyGatewayDTO;
+import org.apache.shenyu.admin.model.vo.ShenyuDictVO;
+import org.apache.shenyu.admin.service.AppAuthService;
+import org.apache.shenyu.admin.service.ShenyuDictService;
+import org.apache.shenyu.admin.utils.HttpUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test case for {@link SandboxServiceImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+final class SandboxServiceImplTest {
+
+    @Mock
+    private AppAuthService appAuthService;
+
+    @Mock
+    private ShenyuDictService shenyuDictService;
+
+    @Mock
+    private HttpUtils httpUtils;
+
+    @Test
+    void requestProxyGatewayShouldCopyBodyAndCloseResponse() throws IOException {
+        AtomicBoolean bodyClosed = new AtomicBoolean();
+        Response proxyResponse = buildResponse("proxied response", bodyClosed);
+        SandboxServiceImpl sandboxService = new SandboxServiceImpl(appAuthService, shenyuDictService, httpUtils);
+
+        when(shenyuDictService.list(anyString())).thenReturn(Collections.singletonList(buildDict()));
+        when(httpUtils.requestCall(anyString(), anyMap(), anyMap(), any(HttpUtils.HTTPMethod.class), anyList())).thenReturn(proxyResponse);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        sandboxService.requestProxyGateway(buildProxyGatewayDTO(), new MockHttpServletRequest(), response);
+
+        assertThat(response.getContentAsString()).isEqualTo("proxied response");
+        assertThat(bodyClosed).isTrue();
+    }
+
+    private ProxyGatewayDTO buildProxyGatewayDTO() {
+        ProxyGatewayDTO proxyGatewayDTO = new ProxyGatewayDTO();
+        proxyGatewayDTO.setRequestUrl("http://localhost:8080/proxy");
+        proxyGatewayDTO.setHeaders(Collections.emptyMap());
+        proxyGatewayDTO.setBizParam(Collections.emptyMap());
+        return proxyGatewayDTO;
+    }
+
+    private ShenyuDictVO buildDict() {
+        ShenyuDictVO dictVO = new ShenyuDictVO();
+        dictVO.setDictValue("http://localhost:8080");
+        dictVO.setEnabled(Boolean.TRUE);
+        return dictVO;
+    }
+
+    private Response buildResponse(final String content, final AtomicBoolean bodyClosed) {
+        return new Response.Builder()
+                .request(new Request.Builder().url("http://localhost:8080/proxy").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(buildResponseBody(content, bodyClosed))
+                .build();
+    }
+
+    private ResponseBody buildResponseBody(final String content, final AtomicBoolean bodyClosed) {
+        Buffer buffer = new Buffer().writeUtf8(content);
+        BufferedSource source = Okio.buffer(new ForwardingSource(buffer) {
+            @Override
+            public void close() throws IOException {
+                bodyClosed.set(true);
+                super.close();
+            }
+        });
+        return new ResponseBody() {
+            @Override
+            public MediaType contentType() {
+                return MediaType.parse("text/plain");
+            }
+
+            @Override
+            public long contentLength() {
+                return content.length();
+            }
+
+            @Override
+            public BufferedSource source() {
+                return source;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #6358

Fixes resource leak in sandbox proxy requests.

`SandboxServiceImpl.requestProxyGateway` now closes the OkHttp `Response` returned by `HTTP_UTILS.requestCall(...)` with try-with-resources, consistent with existing usage in `PullSwaggerDocServiceImpl` and `HttpUtils`.

A focused regression test was added to verify the proxied response body is copied through the sandbox service.

Make sure that:

* [x] You have read the [[contribution guidelines](https://shenyu.apache.org/community/contributor-guide)](https://shenyu.apache.org/community/contributor-guide).
* [x] You submit test cases (unit or integration tests) that back your changes.
* [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

Verification:

* `mvn -pl shenyu-admin -am -Dtest=SandboxServiceImplTest -DfailIfNoTests=false -DfailIfNoSpecifiedTests=false test`