### PR TITLE
Stabilize Sentinel integrated rate-limit assertions

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java
@@ -36,12 +36,15 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class SentinelPluginTest extends AbstractPluginDataInit {
@@ -57,34 +60,63 @@ public final class SentinelPluginTest extends AbstractPluginDataInit {
     }
 
     @Test
-    public void test() throws IOException {
+    public void test() throws IOException, ExecutionException, InterruptedException {
         String selectorAndRulesResult =
                 initSelectorAndRules(PluginEnum.SENTINEL.getName(), "", buildSelectorConditionList(), buildRuleLocalDataList(null));
         assertThat(selectorAndRulesResult, is("success"));
 
         Type returnType = new TypeToken<Map<String, Object>>() {
         }.getType();
-        Map<String, Object> result = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
-        assertNotNull(result);
-        assertEquals("pass", result.get("msg"));
-        result = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
-        assertEquals("You have been restricted, please try again later!", result.get("message"));
+        Future<Map<String, Object>> first = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
+        Future<Map<String, Object>> second = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
+        Map<String, Object> firstResult = first.get();
+        Map<String, Object> secondResult = second.get();
+        Set<String> messages = toMessages(firstResult, secondResult);
+        assertThat(messages.contains("pass"), is(true));
+        assertThat(messages.contains("You have been restricted, please try again later!"), is(true));
     }
 
     @Test
-    public void testFallbackUri() throws IOException {
+    public void testFallbackUri() throws IOException, ExecutionException, InterruptedException {
         String selectorAndRulesResult =
                 initSelectorAndRules(PluginEnum.SENTINEL.getName(), "", buildSelectorConditionList(), buildRuleLocalDataList(TEST_SENTINEL_FALLBACK_PATH));
         assertThat(selectorAndRulesResult, is("success"));
 
         Type returnType = new TypeToken<Map<String, Object>>() {
         }.getType();
-        Map<String, Object> result = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
-        assertNotNull(result);
-        assertEquals("pass", result.get("msg"));
-        Map<String, Object> fallbackRet = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
-        assertEquals(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getCode(), ((Number) fallbackRet.get("code")).intValue());
-        assertEquals(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getMsg(), fallbackRet.get("message"));
+        Future<Map<String, Object>> first = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
+        Future<Map<String, Object>> second = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
+        Map<String, Object> firstResult = first.get();
+        Map<String, Object> secondResult = second.get();
+        Set<String> messages = toMessages(firstResult, secondResult);
+        Set<Integer> codes = toCodes(firstResult, secondResult);
+        assertThat(messages.contains("pass"), is(true));
+        assertThat(codes.contains(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getCode()), is(true));
+        assertThat(messages.contains(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getMsg()), is(true));
+    }
+
+    private static Set<String> toMessages(final Map<String, Object>... results) {
+        Set<String> messages = new HashSet<>();
+        for (Map<String, Object> result : results) {
+            assertNotNull(result);
+            Object msg = result.containsKey("msg") ? result.get("msg") : result.get("message");
+            if (msg instanceof String) {
+                messages.add((String) msg);
+            }
+        }
+        return messages;
+    }
+
+    private static Set<Integer> toCodes(final Map<String, Object>... results) {
+        Set<Integer> codes = new HashSet<>();
+        for (Map<String, Object> result : results) {
+            assertNotNull(result);
+            Object code = result.get("code");
+            if (code instanceof Number) {
+                codes.add(((Number) code).intValue());
+            }
+        }
+        return codes;
     }
 
     private static List<ConditionData> buildSelectorConditionList() {


### PR DESCRIPTION
## Summary
- stabilizes `SentinelPluginTest` by triggering the rate-limit path with concurrent requests
- asserts over observed result sets instead of relying on two sequential requests landing in the same Sentinel QPS window
- targets the `build (shenyu-integrated-test-http)` failure seen after #6361 on master

## Root Cause
The master push for #6361 failed in `build (shenyu-integrated-test-http)` at `Check test result`. The modified Sentinel integration coverage used sequential requests to expect one pass and one limited/fallback response. On a loaded CI runner, those requests can cross Sentinel's one-second QPS window, making the assertion timing-dependent.

## Verification
- `./mvnw -f shenyu-integrated-test/pom.xml -pl shenyu-integrated-test-http -am -DskipTests test-compile`
- `git diff --check`

## Not Tested
- Full local Docker `integrated-test-http` run; the CI-built Docker images and dependent services were not present locally.