### PR TITLE
fix(request): make add operations append existing values

### DIFF
--- a/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
@@ -123,10 +123,10 @@ public class RequestPlugin extends AbstractShenyuPlugin {
             return;
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getAddHeaders())) {
-            shenyuReqHeader.getAddHeaders().entrySet().forEach(s -> this.fillHeader(s, headers));
+            shenyuReqHeader.getAddHeaders().entrySet().forEach(s -> this.addHeader(s, headers));
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getSetHeaders())) {
-            shenyuReqHeader.getSetHeaders().entrySet().forEach(s -> this.fillHeader(s, headers));
+            shenyuReqHeader.getSetHeaders().entrySet().forEach(s -> this.setHeader(s, headers));
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getReplaceHeaderKeys())) {
             shenyuReqHeader.getReplaceHeaderKeys().entrySet().forEach(s -> this.replaceHeaderKey(s, headers));
@@ -145,15 +145,16 @@ public class RequestPlugin extends AbstractShenyuPlugin {
      */
     private MultiValueMap<String, HttpCookie> getCookies(final ServerHttpRequest request, final RequestHandle requestHandle) {
         RequestHandle.ShenyuCookie shenyuCookie = requestHandle.getCookie();
-        MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>(request.getCookies());
+        MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>();
+        cookies.addAll(request.getCookies());
         if (Objects.isNull(shenyuCookie)) {
             return cookies;
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getAddCookies())) {
-            shenyuCookie.getAddCookies().entrySet().forEach(s -> this.fillCookie(s, cookies));
+            shenyuCookie.getAddCookies().entrySet().forEach(s -> this.addCookie(s, cookies));
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getSetCookies())) {
-            shenyuCookie.getSetCookies().entrySet().forEach(s -> this.fillCookie(s, cookies));
+            shenyuCookie.getSetCookies().entrySet().forEach(s -> this.setCookie(s, cookies));
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getReplaceCookieKeys())) {
             shenyuCookie.getReplaceCookieKeys().entrySet().forEach(s -> this.replaceCookieKey(s, cookies));
@@ -173,15 +174,16 @@ public class RequestPlugin extends AbstractShenyuPlugin {
      */
     private MultiValueMap<String, String> getQueryParams(final ServerHttpRequest request, final RequestHandle requestHandle) {
         RequestHandle.ShenyuRequestParameter shenyuReqParameter = requestHandle.getParameter();
-        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(request.getQueryParams());
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.addAll(request.getQueryParams());
         if (Objects.isNull(shenyuReqParameter)) {
             return queryParams;
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getAddParameters())) {
-            shenyuReqParameter.getAddParameters().entrySet().forEach(s -> this.fillParameter(s, queryParams));
+            shenyuReqParameter.getAddParameters().entrySet().forEach(s -> this.addParameter(s, queryParams));
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getSetParameters())) {
-            shenyuReqParameter.getSetParameters().entrySet().forEach(s -> this.fillParameter(s, queryParams));
+            shenyuReqParameter.getSetParameters().entrySet().forEach(s -> this.setParameter(s, queryParams));
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getReplaceParameterKeys())) {
             shenyuReqParameter.getReplaceParameterKeys().entrySet().forEach(s -> this.replaceParameterKey(s, queryParams));
@@ -200,7 +202,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
+    private void addParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
+        queryParams.add(shenyuParam.getKey(), shenyuParam.getValue());
+    }
+
+    private void setParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
         queryParams.set(shenyuParam.getKey(), shenyuParam.getValue());
     }
 
@@ -213,7 +219,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
+    private void addCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
+        cookies.add(shenyuCookie.getKey(), new HttpCookie(shenyuCookie.getKey(), shenyuCookie.getValue()));
+    }
+
+    private void setCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
         cookies.set(shenyuCookie.getKey(), new HttpCookie(shenyuCookie.getKey(), shenyuCookie.getValue()));
     }
 
@@ -225,7 +235,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
+    private void addHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
+        headers.add(shenyuHeader.getKey(), shenyuHeader.getValue());
+    }
+
+    private void setHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
         headers.set(shenyuHeader.getKey(), shenyuHeader.getValue());
     }
 }

--- a/shenyu-plugin/shenyu-plugin-request/src/test/java/org/apache/shenyu/plugin/request/RequestPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-request/src/test/java/org/apache/shenyu/plugin/request/RequestPluginTest.java
@@ -81,12 +81,15 @@ public class RequestPluginTest {
     public void setup() {
         this.exchange = MockServerWebExchange.from(MockServerHttpRequest
                 .get("localhost")
+                .cookie(new HttpCookie("addKey", "oldValue"))
                 .cookie(new HttpCookie("replaceKey", "oldValue"))
                 .cookie(new HttpCookie("removeKey", "value"))
                 .cookie(new HttpCookie("setKey", "oldValue"))
+                .header("addKey", "oldValue")
                 .header("replaceKey", "oldValue")
                 .header("removeKey", "value")
                 .header("setKey", "oldValue")
+                .queryParam("addKey", "oldValue")
                 .queryParam("replaceKey", "oldValue")
                 .queryParam("removeKey", "value")
                 .queryParam("setKey", "oldValue")
@@ -131,21 +134,21 @@ public class RequestPluginTest {
         assertNotNull(request);
         HttpHeaders httpHeaders = request.getHeaders();
         assertNotNull(httpHeaders);
-        assertTrue(checkMapSizeAndEqualVal(httpHeaders, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), httpHeaders.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(httpHeaders, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(httpHeaders, "setKey", "newValue"));
         assertFalse(httpHeaders.containsKey("removeKey"));
         assertTrue(httpHeaders.containsKey(HttpHeaders.COOKIE));
 
         LinkedMultiValueMap<String, String> cookies = getCookieMapFromHeader(httpHeaders);
-        assertTrue(checkMapSizeAndEqualVal(cookies, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), cookies.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(cookies, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(cookies, "setKey", "newValue"));
         assertFalse(cookies.containsKey("removeKey"));
 
         MultiValueMap<String, String> queryParams = request.getQueryParams();
         assertNotNull(queryParams);
-        assertTrue(checkMapSizeAndEqualVal(queryParams, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), queryParams.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(queryParams, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(queryParams, "setKey", "newValue"));
         assertFalse(queryParams.containsKey("removeKey"));
@@ -170,7 +173,10 @@ public class RequestPluginTest {
                 .flatMap(s ->
                         Arrays.stream(s).filter(cookie -> cookie.split("=").length == 2)
                                 .map(cookie -> Pair.of(cookie.split("=")[0].trim(), Lists.newArrayList(cookie.split("=")[1].trim()))))
-                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (k, v) -> k)));
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (current, added) -> {
+                    current.addAll(added);
+                    return current;
+                })));
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR fixes the inconsistency between add* and set* operations in the Request Plugin.

Previously, addParameters, addHeaders, and addCookies internally used set() operations, causing existing values to be overwritten and making them behave the same as their corresponding set* operations.

This behavior is inconsistent with the documented semantics in RequestHandle and the implementation of ModifyResponsePlugin, where:

- add* operations append values.
- set* operations overwrite values.

## Changes

- Use queryParams.add(...) for addParameters.
- Use headers.add(...) for addHeaders.
- Use cookies.add(...) for addCookies.
- Keep existing setParameters, setHeaders, and setCookies behavior unchanged.
- Add/update unit tests covering requests that already contain the target key.

## Tests

- [x] `./mvn -pl shenyu-plugin/shenyu-plugin-request test`



## Checklist

- [x] I have read the contribution guidelines.
- [x] I submit test cases that back my changes.
- [x] My local tests passed.


Fixes #6360
