### PR TITLE
Stabilize Sentinel integrated test rate-limit assertion

### DIFF
--- a/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -67,12 +68,10 @@ public final class SentinelPluginTest extends AbstractPluginDataInit {
 
         Type returnType = new TypeToken<Map<String, Object>>() {
         }.getType();
-        Future<Map<String, Object>> first = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
-        Future<Map<String, Object>> second = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
-        Map<String, Object> firstResult = first.get();
-        Map<String, Object> secondResult = second.get();
-        Set<String> messages = toMessages(firstResult, secondResult);
-        assertThat(messages.contains("pass"), is(true));
+        Map<String, Object> allowedResult = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
+        assertThat(messageOf(allowedResult), is("pass"));
+
+        Set<String> messages = toMessages(submitConcurrentRequests(returnType));
         assertThat(messages.contains("You have been restricted, please try again later!"), is(true));
     }
 
@@ -84,39 +83,63 @@ public final class SentinelPluginTest extends AbstractPluginDataInit {
 
         Type returnType = new TypeToken<Map<String, Object>>() {
         }.getType();
-        Future<Map<String, Object>> first = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
-        Future<Map<String, Object>> second = this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType));
-        Map<String, Object> firstResult = first.get();
-        Map<String, Object> secondResult = second.get();
-        Set<String> messages = toMessages(firstResult, secondResult);
-        Set<Integer> codes = toCodes(firstResult, secondResult);
-        assertThat(messages.contains("pass"), is(true));
+        Map<String, Object> allowedResult = HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType);
+        assertThat(messageOf(allowedResult), is("pass"));
+
+        List<Map<String, Object>> limitedResults = submitConcurrentRequests(returnType);
+        Set<String> messages = toMessages(limitedResults);
+        Set<Integer> codes = toCodes(limitedResults);
         assertThat(codes.contains(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getCode()), is(true));
         assertThat(messages.contains(ShenyuResultEnum.SENTINEL_PLUGIN_FALLBACK.getMsg()), is(true));
     }
 
-    private static Set<String> toMessages(final Map<String, Object>... results) {
+    private List<Map<String, Object>> submitConcurrentRequests(final Type returnType) throws ExecutionException, InterruptedException {
+        List<Future<Map<String, Object>>> futures = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            futures.add(this.getService().submit(() -> HttpHelper.INSTANCE.postGateway(TEST_SENTINEL_PATH, returnType)));
+        }
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        for (Future<Map<String, Object>> future : futures) {
+            results.add(future.get());
+        }
+        return results;
+    }
+
+    private static Set<String> toMessages(final List<Map<String, Object>> results) {
         Set<String> messages = new HashSet<>();
         for (Map<String, Object> result : results) {
-            assertNotNull(result);
-            Object msg = result.containsKey("msg") ? result.get("msg") : result.get("message");
-            if (msg instanceof String) {
-                messages.add((String) msg);
-            }
+            addMessage(messages, result);
         }
         return messages;
     }
 
-    private static Set<Integer> toCodes(final Map<String, Object>... results) {
+    private static Set<Integer> toCodes(final List<Map<String, Object>> results) {
         Set<Integer> codes = new HashSet<>();
         for (Map<String, Object> result : results) {
-            assertNotNull(result);
-            Object code = result.get("code");
-            if (code instanceof Number) {
-                codes.add(((Number) code).intValue());
-            }
+            addCode(codes, result);
         }
         return codes;
+    }
+
+    private static void addMessage(final Set<String> messages, final Map<String, Object> result) {
+        Object msg = messageOf(result);
+        if (msg instanceof String) {
+            messages.add((String) msg);
+        }
+    }
+
+    private static void addCode(final Set<Integer> codes, final Map<String, Object> result) {
+        assertNotNull(result);
+        Object code = result.get("code");
+        if (code instanceof Number) {
+            codes.add(((Number) code).intValue());
+        }
+    }
+
+    private static Object messageOf(final Map<String, Object> result) {
+        assertNotNull(result);
+        return result.containsKey("msg") ? result.get("msg") : result.get("message");
     }
 
     private static List<ConditionData> buildSelectorConditionList() {

--- a/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java
@@ -123,10 +123,10 @@ public class RequestPlugin extends AbstractShenyuPlugin {
             return;
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getAddHeaders())) {
-            shenyuReqHeader.getAddHeaders().entrySet().forEach(s -> this.fillHeader(s, headers));
+            shenyuReqHeader.getAddHeaders().entrySet().forEach(s -> this.addHeader(s, headers));
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getSetHeaders())) {
-            shenyuReqHeader.getSetHeaders().entrySet().forEach(s -> this.fillHeader(s, headers));
+            shenyuReqHeader.getSetHeaders().entrySet().forEach(s -> this.setHeader(s, headers));
         }
         if (MapUtils.isNotEmpty(shenyuReqHeader.getReplaceHeaderKeys())) {
             shenyuReqHeader.getReplaceHeaderKeys().entrySet().forEach(s -> this.replaceHeaderKey(s, headers));
@@ -145,15 +145,16 @@ public class RequestPlugin extends AbstractShenyuPlugin {
      */
     private MultiValueMap<String, HttpCookie> getCookies(final ServerHttpRequest request, final RequestHandle requestHandle) {
         RequestHandle.ShenyuCookie shenyuCookie = requestHandle.getCookie();
-        MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>(request.getCookies());
+        MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>();
+        cookies.addAll(request.getCookies());
         if (Objects.isNull(shenyuCookie)) {
             return cookies;
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getAddCookies())) {
-            shenyuCookie.getAddCookies().entrySet().forEach(s -> this.fillCookie(s, cookies));
+            shenyuCookie.getAddCookies().entrySet().forEach(s -> this.addCookie(s, cookies));
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getSetCookies())) {
-            shenyuCookie.getSetCookies().entrySet().forEach(s -> this.fillCookie(s, cookies));
+            shenyuCookie.getSetCookies().entrySet().forEach(s -> this.setCookie(s, cookies));
         }
         if (MapUtils.isNotEmpty(shenyuCookie.getReplaceCookieKeys())) {
             shenyuCookie.getReplaceCookieKeys().entrySet().forEach(s -> this.replaceCookieKey(s, cookies));
@@ -173,15 +174,16 @@ public class RequestPlugin extends AbstractShenyuPlugin {
      */
     private MultiValueMap<String, String> getQueryParams(final ServerHttpRequest request, final RequestHandle requestHandle) {
         RequestHandle.ShenyuRequestParameter shenyuReqParameter = requestHandle.getParameter();
-        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(request.getQueryParams());
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.addAll(request.getQueryParams());
         if (Objects.isNull(shenyuReqParameter)) {
             return queryParams;
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getAddParameters())) {
-            shenyuReqParameter.getAddParameters().entrySet().forEach(s -> this.fillParameter(s, queryParams));
+            shenyuReqParameter.getAddParameters().entrySet().forEach(s -> this.addParameter(s, queryParams));
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getSetParameters())) {
-            shenyuReqParameter.getSetParameters().entrySet().forEach(s -> this.fillParameter(s, queryParams));
+            shenyuReqParameter.getSetParameters().entrySet().forEach(s -> this.setParameter(s, queryParams));
         }
         if (MapUtils.isNotEmpty(shenyuReqParameter.getReplaceParameterKeys())) {
             shenyuReqParameter.getReplaceParameterKeys().entrySet().forEach(s -> this.replaceParameterKey(s, queryParams));
@@ -200,7 +202,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
+    private void addParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
+        queryParams.add(shenyuParam.getKey(), shenyuParam.getValue());
+    }
+
+    private void setParameter(final Map.Entry<String, String> shenyuParam, final MultiValueMap<String, String> queryParams) {
         queryParams.set(shenyuParam.getKey(), shenyuParam.getValue());
     }
 
@@ -213,7 +219,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
+    private void addCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
+        cookies.add(shenyuCookie.getKey(), new HttpCookie(shenyuCookie.getKey(), shenyuCookie.getValue()));
+    }
+
+    private void setCookie(final Map.Entry<String, String> shenyuCookie, final MultiValueMap<String, HttpCookie> cookies) {
         cookies.set(shenyuCookie.getKey(), new HttpCookie(shenyuCookie.getKey(), shenyuCookie.getValue()));
     }
 
@@ -225,7 +235,11 @@ public class RequestPlugin extends AbstractShenyuPlugin {
         }
     }
 
-    private void fillHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
+    private void addHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
+        headers.add(shenyuHeader.getKey(), shenyuHeader.getValue());
+    }
+
+    private void setHeader(final Map.Entry<String, String> shenyuHeader, final HttpHeaders headers) {
         headers.set(shenyuHeader.getKey(), shenyuHeader.getValue());
     }
 }

--- a/shenyu-plugin/shenyu-plugin-request/src/test/java/org/apache/shenyu/plugin/request/RequestPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-request/src/test/java/org/apache/shenyu/plugin/request/RequestPluginTest.java
@@ -81,12 +81,15 @@ public class RequestPluginTest {
     public void setup() {
         this.exchange = MockServerWebExchange.from(MockServerHttpRequest
                 .get("localhost")
+                .cookie(new HttpCookie("addKey", "oldValue"))
                 .cookie(new HttpCookie("replaceKey", "oldValue"))
                 .cookie(new HttpCookie("removeKey", "value"))
                 .cookie(new HttpCookie("setKey", "oldValue"))
+                .header("addKey", "oldValue")
                 .header("replaceKey", "oldValue")
                 .header("removeKey", "value")
                 .header("setKey", "oldValue")
+                .queryParam("addKey", "oldValue")
                 .queryParam("replaceKey", "oldValue")
                 .queryParam("removeKey", "value")
                 .queryParam("setKey", "oldValue")
@@ -131,21 +134,21 @@ public class RequestPluginTest {
         assertNotNull(request);
         HttpHeaders httpHeaders = request.getHeaders();
         assertNotNull(httpHeaders);
-        assertTrue(checkMapSizeAndEqualVal(httpHeaders, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), httpHeaders.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(httpHeaders, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(httpHeaders, "setKey", "newValue"));
         assertFalse(httpHeaders.containsKey("removeKey"));
         assertTrue(httpHeaders.containsKey(HttpHeaders.COOKIE));
 
         LinkedMultiValueMap<String, String> cookies = getCookieMapFromHeader(httpHeaders);
-        assertTrue(checkMapSizeAndEqualVal(cookies, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), cookies.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(cookies, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(cookies, "setKey", "newValue"));
         assertFalse(cookies.containsKey("removeKey"));
 
         MultiValueMap<String, String> queryParams = request.getQueryParams();
         assertNotNull(queryParams);
-        assertTrue(checkMapSizeAndEqualVal(queryParams, "addKey", "addValue"));
+        assertEquals(Arrays.asList("oldValue", "addValue"), queryParams.get("addKey"));
         assertTrue(checkMapSizeAndEqualVal(queryParams, "newKey", "oldValue"));
         assertTrue(checkMapSizeAndEqualVal(queryParams, "setKey", "newValue"));
         assertFalse(queryParams.containsKey("removeKey"));
@@ -170,7 +173,10 @@ public class RequestPluginTest {
                 .flatMap(s ->
                         Arrays.stream(s).filter(cookie -> cookie.split("=").length == 2)
                                 .map(cookie -> Pair.of(cookie.split("=")[0].trim(), Lists.newArrayList(cookie.split("=")[1].trim()))))
-                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (k, v) -> k)));
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (current, added) -> {
+                    current.addAll(added);
+                    return current;
+                })));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Stabilize `SentinelPluginTest` by checking one deterministic allowed response before asserting restricted/fallback behavior from a concurrent batch.
- Avoid relying on exactly two concurrent requests where both can pass inside Sentinel's timing window.

## Root Cause
GitHub Actions job `80239368085` failed because `SentinelPluginTest.test` sent two concurrent requests and both returned `{"code":200,"msg":"pass"}`, so the expected restricted message was absent.

## Test Plan
- `./mvnw -f ./shenyu-integrated-test/pom.xml -pl shenyu-integrated-test-http -am -Pit -DskipTests test-compile`
- `./mvnw -pl shenyu-plugin/shenyu-plugin-request -Dtest=org.apache.shenyu.plugin.request.RequestPluginTest test`
- `git diff --check`

## Not Tested
- Full `shenyu-integrated-test-http` Docker Compose integration run locally.