### PR TITLE
[ISSUE #5856] Support configurable max-initial-line-length for HTTP request decoder

### DIFF
--- a/shenyu-bootstrap/src/main/resources/application.yml
+++ b/shenyu-bootstrap/src/main/resources/application.yml
@@ -139,6 +139,10 @@ shenyu:
 #          - domain: 'example.com'
 #            keyCertChainFile: '/Users/zhukunshuai/Desktop/cert/example.com+1.pem'
 #            keyFile: '/Users/zhukunshuai/Desktop/cert/example.com+1-key.pem'
+      httpDecoder:
+        maxInitialLineLength: 4096
+        maxHeaderSize: 8192
+        maxChunkSize: 8192
 #  httpclient:
 #    strategy: netty # webClient
 #    connectTimeout: 45000

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/config/NettyHttpProperties.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/config/NettyHttpProperties.java
@@ -40,6 +40,8 @@ public class NettyHttpProperties {
 
     private SniProperties sni = new SniProperties();
 
+    private HttpDecoderProperties httpDecoder = new HttpDecoderProperties();
+
     /**
      * get webServerFactoryEnabled.
      *
@@ -167,6 +169,24 @@ public class NettyHttpProperties {
         this.accessLog = accessLog;
     }
 
+    /**
+     * get httpDecoder properties.
+     *
+     * @return httpDecoder properties
+     */
+    public HttpDecoderProperties getHttpDecoder() {
+        return httpDecoder;
+    }
+
+    /**
+     * set httpDecoder properties.
+     *
+     * @param httpDecoder http decoder properties
+     */
+    public void setHttpDecoder(final HttpDecoderProperties httpDecoder) {
+        this.httpDecoder = httpDecoder;
+    }
+
     public static class ServerSocketChannelProperties extends NettyChannelProperties {
 
         private Integer soBacklog = 128;
@@ -289,6 +309,84 @@ public class NettyHttpProperties {
          */
         public void setAllowHalfClosure(final Boolean allowHalfClosure) {
             this.allowHalfClosure = allowHalfClosure;
+        }
+    }
+
+    /**
+     * Properties for HTTP request decoder configuration.
+     */
+    public static class HttpDecoderProperties {
+
+        /**
+         * The maximum length of the initial line (e.g. "GET / HTTP/1.1").
+         * Default is 4096.
+         */
+        private int maxInitialLineLength = 4096;
+
+        /**
+         * The maximum size of all headers.
+         * Default is 8192.
+         */
+        private int maxHeaderSize = 8192;
+
+        /**
+         * The maximum size of the content of each chunk.
+         * Default is 8192.
+         */
+        private int maxChunkSize = 8192;
+
+        /**
+         * get maxInitialLineLength.
+         *
+         * @return maxInitialLineLength
+         */
+        public int getMaxInitialLineLength() {
+            return maxInitialLineLength;
+        }
+
+        /**
+         * set maxInitialLineLength.
+         *
+         * @param maxInitialLineLength max initial line length
+         */
+        public void setMaxInitialLineLength(final int maxInitialLineLength) {
+            this.maxInitialLineLength = maxInitialLineLength;
+        }
+
+        /**
+         * get maxHeaderSize.
+         *
+         * @return maxHeaderSize
+         */
+        public int getMaxHeaderSize() {
+            return maxHeaderSize;
+        }
+
+        /**
+         * set maxHeaderSize.
+         *
+         * @param maxHeaderSize max header size
+         */
+        public void setMaxHeaderSize(final int maxHeaderSize) {
+            this.maxHeaderSize = maxHeaderSize;
+        }
+
+        /**
+         * get maxChunkSize.
+         *
+         * @return maxChunkSize
+         */
+        public int getMaxChunkSize() {
+            return maxChunkSize;
+        }
+
+        /**
+         * set maxChunkSize.
+         *
+         * @param maxChunkSize max chunk size
+         */
+        public void setMaxChunkSize(final int maxChunkSize) {
+            this.maxChunkSize = maxChunkSize;
         }
     }
 

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfiguration.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfiguration.java
@@ -156,6 +156,16 @@ public class ShenyuNettyWebServerConfiguration {
             return sniProcessor.apply(httpServer)
                     .runOn(LoopResources.create("shenyu-netty", nettyHttpProperties.getSelectCount(), nettyHttpProperties.getWorkerCount(), true))
                     .accessLog(nettyHttpProperties.getAccessLog())
+                    // configure http request decoder
+                    .httpRequestDecoder(spec -> {
+                        NettyHttpProperties.HttpDecoderProperties decoder = nettyHttpProperties.getHttpDecoder();
+                        if (Objects.nonNull(decoder)) {
+                            spec.maxInitialLineLength(decoder.getMaxInitialLineLength());
+                            spec.maxHeaderSize(decoder.getMaxHeaderSize());
+                            spec.maxChunkSize(decoder.getMaxChunkSize());
+                        }
+                        return spec;
+                    })
                     // server socket channel parameters
                     .option(ChannelOption.SO_BACKLOG, nettyHttpProperties.getServerSocketChannel().getSoBacklog())
                     .option(ChannelOption.SO_REUSEADDR, nettyHttpProperties.getServerSocketChannel().isSoReuseAddr())

--- a/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/test/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfigurationTest.java
+++ b/shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/test/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfigurationTest.java
@@ -97,4 +97,39 @@ public class ShenyuNettyWebServerConfigurationTest {
                 assertThat(properties.getSocketChannel().getSingleEventExecutorPerGroup(), is(false));
             });
     }
+
+    @Test
+    public void testHttpDecoderProperties() {
+        applicationContextRunner
+            .withPropertyValues(
+                "shenyu.netty.http.web-server-factory-enabled=false",
+                "shenyu.netty.http.httpDecoder.maxInitialLineLength=8192",
+                "shenyu.netty.http.httpDecoder.maxHeaderSize=16384",
+                "shenyu.netty.http.httpDecoder.maxChunkSize=16384"
+            )
+            .run(context -> {
+                NettyHttpProperties properties = context.getBean("nettyTcpProperties", NettyHttpProperties.class);
+                assertNotNull(properties);
+                assertNotNull(properties.getHttpDecoder());
+                assertThat(properties.getHttpDecoder().getMaxInitialLineLength(), is(8192));
+                assertThat(properties.getHttpDecoder().getMaxHeaderSize(), is(16384));
+                assertThat(properties.getHttpDecoder().getMaxChunkSize(), is(16384));
+            });
+    }
+
+    @Test
+    public void testHttpDecoderDefaultProperties() {
+        applicationContextRunner
+            .withPropertyValues(
+                "shenyu.netty.http.web-server-factory-enabled=false"
+            )
+            .run(context -> {
+                NettyHttpProperties properties = context.getBean("nettyTcpProperties", NettyHttpProperties.class);
+                assertNotNull(properties);
+                assertNotNull(properties.getHttpDecoder());
+                assertThat(properties.getHttpDecoder().getMaxInitialLineLength(), is(4096));
+                assertThat(properties.getHttpDecoder().getMaxHeaderSize(), is(8192));
+                assertThat(properties.getHttpDecoder().getMaxChunkSize(), is(8192));
+            });
+    }
 }


### PR DESCRIPTION
## Description

This PR adds support for configuring the HTTP request decoder properties in ShenYu Gateway, resolving the issue where HTTP requests with long URLs (exceeding 4096 bytes) are rejected.

## Changes

### shenyu-common
- Added `HttpDecoderProperties` inner class to `NettyHttpProperties` with:
  - `maxInitialLineLength` (default: 4096)
  - `maxHeaderSize` (default: 8192)
  - `maxChunkSize` (default: 8192)

### shenyu-spring-boot-starter-gateway
- Modified `ShenyuNettyWebServerConfiguration` to apply httpRequestDecoder settings from configuration
- Added test case for the new httpDecoder properties

### shenyu-bootstrap
- Added example configuration in `application.yml`

## Configuration Example

```yaml
shenyu:
  netty:
    http:
      httpDecoder:
        maxInitialLineLength: 8192
        maxHeaderSize: 16384
        maxChunkSize: 16384
```

## How to Test

1. Configure `shenyu.netty.http.httpDecoder.maxInitialLineLength=8192` in application.yml
2. Send an HTTP request with a URL longer than 4096 bytes
3. The request should be processed successfully instead of being rejected

## Checklist

- [x] Code follows the project's coding style
- [x] Unit tests added
- [x] Configuration example updated
- [x] Backward compatible (uses Netty default values when not configured)

Closes #5856