### PR TITLE
fix: avoid cache miss during websocket reconnection by reversing refresh order (#5580)

### DIFF
--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/BaseDataCache.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/BaseDataCache.java
@@ -24,10 +24,12 @@ import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.dto.SelectorData;
 
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import java.util.Set;
 
 /**
  * The type Base data cache.
@@ -103,7 +105,11 @@ public final class BaseDataCache {
      * @param pluginDataList the plugin data list
      */
     public void cleanPluginDataSelf(final List<PluginData> pluginDataList) {
-        pluginDataList.forEach(this::removePluginData);
+        // Collect the names of all plugins in the new data list
+        Set<String> newPluginNames = new HashSet<>();
+        pluginDataList.forEach(plugin -> newPluginNames.add(plugin.getName()));
+        // Remove plugins from cache that are not present in the new data list
+        PLUGIN_MAP.entrySet().removeIf(entry -> !newPluginNames.contains(entry.getKey()));
     }
     
     /**
@@ -161,7 +167,11 @@ public final class BaseDataCache {
      * @param selectorDataList the selector data list
      */
     public void cleanSelectorDataSelf(final List<SelectorData> selectorDataList) {
-        selectorDataList.forEach(this::removeSelectData);
+        // Collect the plugin names of all selectors in the new data list
+        Set<String> newPluginNames = new HashSet<>();
+        selectorDataList.forEach(selector -> newPluginNames.add(selector.getPluginName()));
+        // Remove selectors from cache that are not present in the new data list
+        SELECTOR_MAP.entrySet().removeIf(entry -> !newPluginNames.contains(entry.getKey()));
     }
     
     /**
@@ -219,7 +229,11 @@ public final class BaseDataCache {
      * @param ruleDataList the rule data list
      */
     public void cleanRuleDataSelf(final List<RuleData> ruleDataList) {
-        ruleDataList.forEach(this::removeRuleData);
+        // Collect the selector ids of all rules in the new data list
+        Set<String> newSelectorIds = new HashSet<>();
+        ruleDataList.forEach(rule -> newSelectorIds.add(rule.getSelectorId()));
+        // Remove rules from cache that are not present in the new data list
+        RULE_MAP.entrySet().removeIf(entry -> !newSelectorIds.contains(entry.getKey()));
     }
     
     /**

--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/BaseDataCache.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/BaseDataCache.java
@@ -35,24 +35,24 @@ import java.util.Set;
  * The type Base data cache.
  */
 public final class BaseDataCache {
-
+    
     private static final BaseDataCache INSTANCE = new BaseDataCache();
-
+    
     /**
      * pluginName -> PluginData.
      */
     private static final ConcurrentMap<String, PluginData> PLUGIN_MAP = Maps.newConcurrentMap();
-
+    
     /**
      * pluginName -> SelectorData.
      */
     private static final ConcurrentMap<String, List<SelectorData>> SELECTOR_MAP = Maps.newConcurrentMap();
-
+    
     /**
      * selectorId -> RuleData.
      */
     private static final ConcurrentMap<String, List<RuleData>> RULE_MAP = Maps.newConcurrentMap();
-
+    
     private BaseDataCache() {
     }
     
@@ -273,7 +273,7 @@ public final class BaseDataCache {
         return RULE_MAP;
     }
     
-
+    
     /**
      *  cache rule data.
      *
@@ -293,7 +293,7 @@ public final class BaseDataCache {
             }
         }
     }
-
+    
     /**
      * cache selector data.
      *

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/BaseDataCacheTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/BaseDataCacheTest.java
@@ -105,13 +105,12 @@ public final class BaseDataCacheTest {
         ConcurrentHashMap<String, PluginData> pluginMap = getFieldByName(pluginMapStr);
         pluginMap.put(mockName1, firstCachedPluginData);
         pluginMap.put(mockName2, secondCachedPluginData);
-        assertNotNull(pluginMap.get(mockName1));
-        assertNotNull(pluginMap.get(mockName2));
 
+        // only mockName1 is in the new list, so mockName2 should be removed
         List<PluginData> pluginDataList = Lists.newArrayList(firstCachedPluginData);
         BaseDataCache.getInstance().cleanPluginDataSelf(pluginDataList);
-        assertNull(pluginMap.get(mockName1));
-        assertNotNull(pluginMap.get(mockName2));
+        assertNotNull(pluginMap.get(mockName1));
+        assertNull(pluginMap.get(mockName2));
     }
 
     @Test
@@ -166,9 +165,10 @@ public final class BaseDataCacheTest {
         selectorMap.put(mockPluginName1, Lists.newArrayList(firstCachedSelectorData));
         selectorMap.put(mockPluginName2, Lists.newArrayList(secondCachedSelectorData));
 
+        // only mockPluginName1 is in the new list, so mockPluginName2 should be removed
         BaseDataCache.getInstance().cleanSelectorDataSelf(Lists.newArrayList(firstCachedSelectorData));
-        assertEquals(Lists.newArrayList(), selectorMap.get(mockPluginName1));
-        assertEquals(Lists.newArrayList(secondCachedSelectorData), selectorMap.get(mockPluginName2));
+        assertNotNull(selectorMap.get(mockPluginName1));
+        assertNull(selectorMap.get(mockPluginName2));
     }
 
     @Test
@@ -224,9 +224,10 @@ public final class BaseDataCacheTest {
         ruleMap.put(mockSelectorId1, Lists.newArrayList(firstCachedRuleData));
         ruleMap.put(mockSelectorId2, Lists.newArrayList(secondCachedRuleData));
 
+        // only mockSelectorId1 is in the new list, so mockSelectorId2 should be removed
         BaseDataCache.getInstance().cleanRuleDataSelf(Lists.newArrayList(firstCachedRuleData));
-        assertEquals(Lists.newArrayList(), ruleMap.get(mockSelectorId1));
-        assertEquals(Lists.newArrayList(secondCachedRuleData), ruleMap.get(mockSelectorId2));
+        assertNotNull(ruleMap.get(mockSelectorId1));
+        assertNull(ruleMap.get(mockSelectorId2));
     }
 
     @Test

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/BaseDataCacheTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/BaseDataCacheTest.java
@@ -36,13 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 @SuppressWarnings("unchecked")
 public final class BaseDataCacheTest {
-
+    
     private final String pluginMapStr = "PLUGIN_MAP";
-
+    
     private final String selectorMapStr = "SELECTOR_MAP";
-
+    
     private final String ruleMapStr = "RULE_MAP";
-
+    
     private final String mockName1 = "MOCK_NAME_1";
     
     private final String mockName2 = "MOCK_NAME_2";
@@ -54,13 +54,13 @@ public final class BaseDataCacheTest {
     private final String mockSelectorId1 = "MOCK_SELECTOR_ID_1";
     
     private final String mockSelectorId2 = "MOCK_SELECTOR_ID_2";
-
+    
     @Test
     public void testGetInstance() {
         BaseDataCache baseDataCache = BaseDataCache.getInstance();
         assertNotNull(baseDataCache);
     }
-
+    
     @Test
     public void testCachePluginData() throws NoSuchFieldException, IllegalAccessException {
         PluginData pluginData = PluginData.builder().name(mockName1).build();
@@ -71,7 +71,7 @@ public final class BaseDataCacheTest {
         assertNotNull(pluginMap.get(mockName1));
         assertEquals(pluginData, pluginMap.get(mockName1));
     }
-
+    
     @Test
     public void testRemovePluginData() throws NoSuchFieldException, IllegalAccessException {
         PluginData pluginData = PluginData.builder().name(mockName1).build();
@@ -82,7 +82,7 @@ public final class BaseDataCacheTest {
         BaseDataCache.getInstance().removePluginData(pluginData);
         assertNull(pluginMap.get(mockName1));
     }
-
+    
     @Test
     public void testCleanPluginData() throws NoSuchFieldException, IllegalAccessException {
         PluginData firstCachedPluginData = PluginData.builder().name(mockName1).build();
@@ -97,7 +97,7 @@ public final class BaseDataCacheTest {
         assertNull(pluginMap.get(mockName1));
         assertNull(pluginMap.get(mockName2));
     }
-
+    
     @Test
     public void testCleanPluginDataSelf() throws NoSuchFieldException, IllegalAccessException {
         PluginData firstCachedPluginData = PluginData.builder().name(mockName1).build();
@@ -112,7 +112,7 @@ public final class BaseDataCacheTest {
         assertNotNull(pluginMap.get(mockName1));
         assertNull(pluginMap.get(mockName2));
     }
-
+    
     @Test
     public void testObtainPluginData() throws NoSuchFieldException, IllegalAccessException {
         PluginData pluginData = PluginData.builder().name(mockName1).build();
@@ -121,7 +121,7 @@ public final class BaseDataCacheTest {
         assertNotNull(pluginMap.get(mockName1));
         assertEquals(pluginData, BaseDataCache.getInstance().obtainPluginData(mockName1));
     }
-
+    
     @Test
     public void testCacheSelectData() throws NoSuchFieldException, IllegalAccessException {
         SelectorData firstCachedSelectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).sort(1).build();
@@ -133,7 +133,7 @@ public final class BaseDataCacheTest {
         BaseDataCache.getInstance().cacheSelectData(secondCachedSelectorData);
         assertEquals(Lists.newArrayList(firstCachedSelectorData, secondCachedSelectorData), selectorMap.get(mockPluginName1));
     }
-
+    
     @Test
     public void testRemoveSelectData() throws NoSuchFieldException, IllegalAccessException {
         SelectorData selectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).build();
@@ -143,7 +143,7 @@ public final class BaseDataCacheTest {
         BaseDataCache.getInstance().removeSelectData(selectorData);
         assertEquals(Lists.newArrayList(), selectorMap.get(mockPluginName1));
     }
-
+    
     @Test
     public void testCleanSelectorData() throws NoSuchFieldException, IllegalAccessException {
         SelectorData firstCachedSelectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).build();
@@ -156,7 +156,7 @@ public final class BaseDataCacheTest {
         assertNull(selectorMap.get(mockPluginName1));
         assertNull(selectorMap.get(mockPluginName2));
     }
-
+    
     @Test
     public void testCleanSelectorDataSelf() throws NoSuchFieldException, IllegalAccessException {
         SelectorData firstCachedSelectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).build();
@@ -170,7 +170,7 @@ public final class BaseDataCacheTest {
         assertNotNull(selectorMap.get(mockPluginName1));
         assertNull(selectorMap.get(mockPluginName2));
     }
-
+    
     @Test
     public void testObtainSelectorData() throws NoSuchFieldException, IllegalAccessException {
         SelectorData selectorData = SelectorData.builder().id("1").pluginName(mockPluginName1).build();
@@ -180,7 +180,7 @@ public final class BaseDataCacheTest {
         List<SelectorData> selectorDataList = BaseDataCache.getInstance().obtainSelectorData(mockPluginName1);
         assertEquals(Lists.newArrayList(selectorData), selectorDataList);
     }
-
+    
     @Test
     public void testCacheRuleData() throws NoSuchFieldException, IllegalAccessException {
         RuleData firstCachedRuleData = RuleData.builder().id("1").selectorId(mockSelectorId1).sort(1).build();
@@ -192,7 +192,7 @@ public final class BaseDataCacheTest {
         BaseDataCache.getInstance().cacheRuleData(secondCachedRuleData);
         assertEquals(Lists.newArrayList(firstCachedRuleData, secondCachedRuleData), ruleMap.get(mockSelectorId1));
     }
-
+    
     @Test
     public void testRemoveRuleData() throws NoSuchFieldException, IllegalAccessException {
         RuleData ruleData = RuleData.builder().id("1").selectorId(mockSelectorId1).build();
@@ -202,7 +202,7 @@ public final class BaseDataCacheTest {
         BaseDataCache.getInstance().removeRuleData(ruleData);
         assertEquals(Lists.newArrayList(), ruleMap.get(mockSelectorId1));
     }
-
+    
     @Test
     public void testCleanRuleData() throws NoSuchFieldException, IllegalAccessException {
         RuleData firstCachedRuleData = RuleData.builder().id("1").selectorId(mockSelectorId1).build();
@@ -215,7 +215,7 @@ public final class BaseDataCacheTest {
         assertNull(ruleMap.get(mockSelectorId1));
         assertNull(ruleMap.get(mockSelectorId2));
     }
-
+    
     @Test
     public void testCleanRuleDataSelf() throws NoSuchFieldException, IllegalAccessException {
         RuleData firstCachedRuleData = RuleData.builder().id("1").selectorId(mockSelectorId1).build();
@@ -229,7 +229,7 @@ public final class BaseDataCacheTest {
         assertNotNull(ruleMap.get(mockSelectorId1));
         assertNull(ruleMap.get(mockSelectorId2));
     }
-
+    
     @Test
     public void testObtainRuleData() throws NoSuchFieldException, IllegalAccessException {
         RuleData ruleData = RuleData.builder().id("1").selectorId(mockSelectorId1).build();
@@ -239,7 +239,7 @@ public final class BaseDataCacheTest {
         List<RuleData> ruleDataList = BaseDataCache.getInstance().obtainRuleData(mockSelectorId1);
         assertEquals(Lists.newArrayList(ruleData), ruleDataList);
     }
-
+    
     @SuppressWarnings("rawtypes")
     private ConcurrentHashMap getFieldByName(final String name) throws NoSuchFieldException, IllegalAccessException {
         BaseDataCache baseDataCache = BaseDataCache.getInstance();

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/PluginDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/PluginDataHandler.java
@@ -41,8 +41,10 @@ public class PluginDataHandler extends AbstractDataHandler<PluginData> {
 
     @Override
     protected void doRefresh(final List<PluginData> dataList) {
-        pluginDataSubscriber.refreshPluginDataSelf(dataList);
+        // Subscribe new data first to avoid cache miss during refresh
         dataList.forEach(pluginDataSubscriber::onSubscribe);
+        // Remove stale plugins that are not present in the new data list
+        pluginDataSubscriber.refreshPluginDataSelf(dataList);
     }
 
     @Override

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/PluginDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/PluginDataHandler.java
@@ -27,18 +27,18 @@ import java.util.List;
  * The type Plugin data handler.
  */
 public class PluginDataHandler extends AbstractDataHandler<PluginData> {
-
+    
     private final PluginDataSubscriber pluginDataSubscriber;
-
+    
     public PluginDataHandler(final PluginDataSubscriber pluginDataSubscriber) {
         this.pluginDataSubscriber = pluginDataSubscriber;
     }
-
+    
     @Override
     public List<PluginData> convert(final String json) {
         return GsonUtils.getInstance().fromList(json, PluginData.class);
     }
-
+    
     @Override
     protected void doRefresh(final List<PluginData> dataList) {
         // Subscribe new data first to avoid cache miss during refresh
@@ -46,15 +46,15 @@ public class PluginDataHandler extends AbstractDataHandler<PluginData> {
         // Remove stale plugins that are not present in the new data list
         pluginDataSubscriber.refreshPluginDataSelf(dataList);
     }
-
+    
     @Override
     protected void doUpdate(final List<PluginData> dataList) {
         dataList.forEach(pluginDataSubscriber::onSubscribe);
     }
-
+    
     @Override
     protected void doDelete(final List<PluginData> dataList) {
         dataList.forEach(pluginDataSubscriber::unSubscribe);
     }
-
+    
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/RuleDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/RuleDataHandler.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.plugin.sync.data.websocket.handler;
 
 import java.util.List;
+
 import org.apache.shenyu.common.dto.RuleData;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
@@ -40,8 +41,10 @@ public class RuleDataHandler extends AbstractDataHandler<RuleData> {
 
     @Override
     protected void doRefresh(final List<RuleData> dataList) {
-        pluginDataSubscriber.refreshRuleDataSelf(dataList);
+        // Subscribe new data first to avoid cache miss during refresh
         dataList.forEach(pluginDataSubscriber::onRuleSubscribe);
+        // Remove stale rules that are not present in the new data list
+        pluginDataSubscriber.refreshRuleDataSelf(dataList);
     }
 
     @Override

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/RuleDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/RuleDataHandler.java
@@ -27,18 +27,18 @@ import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
  * The type rule data handler.
  */
 public class RuleDataHandler extends AbstractDataHandler<RuleData> {
-
+    
     private final PluginDataSubscriber pluginDataSubscriber;
-
+    
     public RuleDataHandler(final PluginDataSubscriber pluginDataSubscriber) {
         this.pluginDataSubscriber = pluginDataSubscriber;
     }
-
+    
     @Override
     public List<RuleData> convert(final String json) {
         return GsonUtils.getInstance().fromList(json, RuleData.class);
     }
-
+    
     @Override
     protected void doRefresh(final List<RuleData> dataList) {
         // Subscribe new data first to avoid cache miss during refresh
@@ -46,12 +46,12 @@ public class RuleDataHandler extends AbstractDataHandler<RuleData> {
         // Remove stale rules that are not present in the new data list
         pluginDataSubscriber.refreshRuleDataSelf(dataList);
     }
-
+    
     @Override
     protected void doUpdate(final List<RuleData> dataList) {
         dataList.forEach(pluginDataSubscriber::onRuleSubscribe);
     }
-
+    
     @Override
     protected void doDelete(final List<RuleData> dataList) {
         dataList.forEach(pluginDataSubscriber::unRuleSubscribe);

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/SelectorDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/SelectorDataHandler.java
@@ -41,8 +41,10 @@ public class SelectorDataHandler extends AbstractDataHandler<SelectorData> {
 
     @Override
     protected void doRefresh(final List<SelectorData> dataList) {
-        pluginDataSubscriber.refreshSelectorDataSelf(dataList);
+        // Subscribe new data first to avoid cache miss during refresh
         dataList.forEach(pluginDataSubscriber::onSelectorSubscribe);
+        // Remove stale selectors that are not present in the new data list
+        pluginDataSubscriber.refreshSelectorDataSelf(dataList);
     }
 
     @Override

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/SelectorDataHandler.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/SelectorDataHandler.java
@@ -27,18 +27,18 @@ import java.util.List;
  * The type Selector data handler.
  */
 public class SelectorDataHandler extends AbstractDataHandler<SelectorData> {
-
+    
     private final PluginDataSubscriber pluginDataSubscriber;
-
+    
     public SelectorDataHandler(final PluginDataSubscriber pluginDataSubscriber) {
         this.pluginDataSubscriber = pluginDataSubscriber;
     }
-
+    
     @Override
     public List<SelectorData> convert(final String json) {
         return GsonUtils.getInstance().fromList(json, SelectorData.class);
     }
-
+    
     @Override
     protected void doRefresh(final List<SelectorData> dataList) {
         // Subscribe new data first to avoid cache miss during refresh
@@ -46,12 +46,12 @@ public class SelectorDataHandler extends AbstractDataHandler<SelectorData> {
         // Remove stale selectors that are not present in the new data list
         pluginDataSubscriber.refreshSelectorDataSelf(dataList);
     }
-
+    
     @Override
     protected void doUpdate(final List<SelectorData> dataList) {
         dataList.forEach(pluginDataSubscriber::onSelectorSubscribe);
     }
-
+    
     @Override
     protected void doDelete(final List<SelectorData> dataList) {
         dataList.forEach(pluginDataSubscriber::unSelectorSubscribe);


### PR DESCRIPTION
### Description
When the WebSocket connection between admin and bootstrap is closed and
reconnected, the bootstrap refreshes its local cache by first clearing
existing data and then reloading from admin one by one. During this
window period, incoming requests cannot find plugin/selector/rule data
in cache and fail with errors.

**Root Cause:**
In `PluginDataHandler`, `SelectorDataHandler`, and `RuleDataHandler`,
`doRefresh()` calls `refreshXxxDataSelf()` before subscribing new data.
`refreshXxxDataSelf()` in turn calls `cleanXxxDataSelf()` in `BaseDataCache`,
which removes all entries present in the new list from the cache, leaving
the cache empty during the reload window.

**Fix:**
1. Reverse the refresh order in `doRefresh()`: subscribe new data first,
   then remove stale entries.
2. Update `cleanPluginDataSelf()`, `cleanSelectorDataSelf()`, and
   `cleanRuleDataSelf()` in `BaseDataCache` to remove entries **not present**
   in the new data list, instead of removing entries that are present.

**Limitation:**
The current fix for `cleanSelectorDataSelf()` and `cleanRuleDataSelf()`
operates at the `pluginName` and `selectorId` granularity respectively.
If a plugin has multiple selectors and only some of them are removed,
the stale selectors under the same `pluginName` key may not be cleaned up.
This edge case is not covered by this fix and may require further improvement.

### Tests
The following existing test methods have been updated to reflect the new
behavior:

- `org.apache.shenyu.plugin.base.cache.BaseDataCacheTest#testCleanPluginDataSelf`
- `org.apache.shenyu.plugin.base.cache.BaseDataCacheTest#testCleanSelectorDataSelf`
- `org.apache.shenyu.plugin.base.cache.BaseDataCacheTest#testCleanRuleDataSelf`

### Checklist
- [x] I have submitted the iCLA
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed