### PR TITLE
fix: add mounts for external libraries in docker-compose to prevent startup issues (missing database connector driver) when using an external database datasource other than H2 (#6389)

### DIFF
--- a/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/docker-compose.yaml
+++ b/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./shenyu-bootstrap/logs/:/opt/shenyu-bootstrap/logs
       - ./shenyu-bootstrap/conf/:/opt/shenyu-bootstrap/conf
+      - ./shenyu-bootstrap/ext-lib/:/opt/shenyu-bootstrap/ext-lib
     depends_on:
       - shenyu-admin
     environment:
@@ -39,6 +40,7 @@ services:
     volumes:
       - ./shenyu-admin/logs/:/opt/shenyu-admin/logs
       - ./shenyu-admin/conf/:/opt/shenyu-admin/conf
+      - ./shenyu-admin/ext-lib/:/opt/shenyu-admin/ext-lib
     ports:
       - "9095:9095"
     healthcheck:


### PR DESCRIPTION

[shenyu-issue-6389-test-log.pdf](https://github.com/user-attachments/files/29036077/shenyu-issue-6389-test-log.pdf)
Fixes #6389, add volume mounts for ext-lib. 
Since it's not a java code isse, I did not run the build phrase, please review the recurrence & test log attached.
#6389 
