### PR TITLE
[ISSUE #6292] Avoid mutating divide upstream for specify-domain

### DIFF
--- a/shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java
+++ b/shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java
@@ -103,13 +103,12 @@ public class DividePlugin extends AbstractShenyuPlugin {
             Object error = ShenyuResultWrap.error(exchange, ShenyuResultEnum.CANNOT_FIND_HEALTHY_UPSTREAM_URL);
             return WebFluxResultUtils.result(exchange, error);
         }
-        // set the http url
+        String domain = upstream.buildDomain();
         List<String> specifyDomains = exchange.getRequest().getHeaders().get(Constants.SPECIFY_DOMAIN);
         if (CollectionUtils.isNotEmpty(specifyDomains)) {
-            upstream.setUrl(specifyDomains.get(0));
+            domain = buildDomain(upstream, specifyDomains.get(0));
         }
         // set domain
-        String domain = upstream.buildDomain();
         exchange.getAttributes().put(Constants.HTTP_DOMAIN, domain);
         // set the http timeout
         exchange.getAttributes().put(Constants.HTTP_TIME_OUT, ruleHandle.getTimeout());
@@ -156,6 +155,14 @@ public class DividePlugin extends AbstractShenyuPlugin {
     
     private DivideRuleHandle buildRuleHandle(final RuleData rule) {
         return DividePluginDataHandler.CACHED_HANDLE.get().obtainHandle(CacheKeyUtils.INST.getKey(rule));
+    }
+
+    private String buildDomain(final Upstream upstream, final String url) {
+        String protocol = upstream.getProtocol();
+        if (StringUtils.isBlank(protocol)) {
+            protocol = "http://";
+        }
+        return protocol + StringUtils.trim(url);
     }
 
     private void responseTrigger(final Upstream upstream) {

--- a/shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/test/java/org/apache/shenyu/plugin/divide/DividePluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/test/java/org/apache/shenyu/plugin/divide/DividePluginTest.java
@@ -178,6 +178,24 @@ public final class DividePluginTest {
         StepVerifier.create(result).expectSubscription().verifyComplete();
     }
 
+    @Test
+    public void doExecuteWithSpecifyDomainShouldNotMutateCachedUpstream() {
+        ServerWebExchange specifyDomainExchange = MockServerWebExchange.from(MockServerHttpRequest.get("localhost")
+                .remoteAddress(new InetSocketAddress(8090))
+                .header(Constants.SPECIFY_DOMAIN, "mock-specified")
+                .build());
+        ShenyuContext context = mock(ShenyuContext.class);
+        specifyDomainExchange.getAttributes().put(Constants.CONTEXT, context);
+        when(chain.execute(specifyDomainExchange)).thenReturn(Mono.empty());
+
+        Mono<Void> result = dividePlugin.doExecute(specifyDomainExchange, chain, selectorData, ruleData);
+        StepVerifier.create(result).expectSubscription().verifyComplete();
+
+        List<Upstream> upstreams = UpstreamCacheManager.getInstance().findUpstreamListBySelectorId(selectorData.getId());
+        assertEquals("http://mock-specified", specifyDomainExchange.getAttribute(Constants.HTTP_DOMAIN));
+        assertEquals("mock-3", upstreams.get(0).getUrl());
+    }
+
     /**
      * Skip.
      */


### PR DESCRIPTION
## Summary
- derive the request domain from the specify-domain header without mutating the selected cached Upstream
- add a DividePlugin regression test that verifies the exchange domain changes while the cached upstream URL remains unchanged

## Verification
- git diff --check
- attempted ./mvnw -pl shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide -Dtest=DividePluginTest -DskipITs test, but the local shell cannot locate a Java runtime

Fixes #6292