### PR TITLE
fix:fix local springmvc client cant register success

### DIFF
--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java
@@ -102,8 +102,6 @@ public abstract class AbstractContextRefreshedEventListener<T, A extends Annotat
 
     private ApplicationContext context;
 
-    private final Boolean isDiscoveryLocalMode;
-    
     /**
      * multiple namespace support.
      */
@@ -138,7 +136,6 @@ public abstract class AbstractContextRefreshedEventListener<T, A extends Annotat
         this.ipAndPort = props.getProperty(ShenyuClientConstants.IP_PORT);
         this.host = props.getProperty(ShenyuClientConstants.HOST);
         this.port = props.getProperty(ShenyuClientConstants.PORT);
-        this.isDiscoveryLocalMode = Boolean.valueOf(props.getProperty(ShenyuClientConstants.DISCOVERY_LOCAL_MODE_KEY));
         publisher.start(shenyuClientRegisterRepository);
     }
 
@@ -152,6 +149,9 @@ public abstract class AbstractContextRefreshedEventListener<T, A extends Annotat
         if (!markRegistered()) {
             return;
         }
+        String discoveryMode = context.getEnvironment()
+                .getProperty("shenyu.discovery.type", ShenyuClientConstants.DISCOVERY_LOCAL_MODE);
+        boolean isDiscoveryLocalMode = ShenyuClientConstants.DISCOVERY_LOCAL_MODE.equals(discoveryMode);
         if (isDiscoveryLocalMode) {
             List<String> namespaceIds = this.getNamespace();
             namespaceIds.forEach(namespaceId -> publisher.publishEvent(buildURIRegisterDTO(context, beans, namespaceId)));

--- a/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java
+++ b/shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java
@@ -95,6 +95,8 @@ public class SpringMvcClientEventListenerTest {
         results.put("springMvcClientTestBean3", springMvcClientTestBean3);
         results.put("springMvcClientTestBean4", springMvcClientTestBean4);
         when(applicationContext.getBeansWithAnnotation(any())).thenReturn(results);
+        when(applicationContext.getEnvironment()).thenReturn(env);
+        when(env.getProperty("shenyu.discovery.type", ShenyuClientConstants.DISCOVERY_LOCAL_MODE)).thenReturn("local");
         contextRefreshedEvent = new ContextRefreshedEvent(applicationContext);
         ShenyuClientConfig shenyuClientConfig = mock(ShenyuClientConfig.class);
         Assert.assertThrows(ShenyuClientIllegalArgumentException.class, () -> new SpringMvcClientEventListener(shenyuClientConfig, mock(ShenyuClientRegisterRepository.class), env));
@@ -199,12 +201,12 @@ public class SpringMvcClientEventListenerTest {
         SpringMvcClientEventListener springMvcClientEventListener = buildSpringMvcClientEventListener(false, false);
 
         Assertions.assertEquals("/order", springMvcClientEventListener.buildApiSuperPath(
-            SpringMvcClientTestBean.class, AnnotatedElementUtils.findMergedAnnotation(SpringMvcClientTestBean.class, ShenyuSpringMvcClient.class)), "super-path");
+                SpringMvcClientTestBean.class, AnnotatedElementUtils.findMergedAnnotation(SpringMvcClientTestBean.class, ShenyuSpringMvcClient.class)), "super-path");
 
         when(env.getProperty("spring.mvc.servlet.path")).thenReturn("/servlet-path");
         when(env.getProperty("server.servlet.context-path")).thenReturn("/servlet-context-path");
         Assertions.assertEquals("/servlet-context-path/servlet-path/order", springMvcClientEventListener.buildApiSuperPath(
-            SpringMvcClientTestBean.class, AnnotatedElementUtils.findMergedAnnotation(SpringMvcClientTestBean.class, ShenyuSpringMvcClient.class)), "super-path");
+                SpringMvcClientTestBean.class, AnnotatedElementUtils.findMergedAnnotation(SpringMvcClientTestBean.class, ShenyuSpringMvcClient.class)), "super-path");
         registerUtilsMockedStatic.close();
     }
 

--- a/shenyu-client/shenyu-client-tars/src/test/java/org/apache/shenyu/client/tars/TarsServiceBeanPostProcessorTest.java
+++ b/shenyu-client/shenyu-client-tars/src/test/java/org/apache/shenyu/client/tars/TarsServiceBeanPostProcessorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.client.tars;
 
+import org.apache.shenyu.client.core.constant.ShenyuClientConstants;
 import org.apache.shenyu.client.core.exception.ShenyuClientIllegalArgumentException;
 import org.apache.shenyu.client.core.register.ShenyuClientRegisterRepositoryFactory;
 import org.apache.shenyu.client.tars.common.annotation.ShenyuTarsClient;
@@ -38,6 +39,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -68,6 +70,9 @@ public final class TarsServiceBeanPostProcessorTest {
     @Mock
     private ApplicationContext applicationContext;
 
+    @Mock
+    private Environment env;
+
     private ContextRefreshedEvent contextRefreshedEvent;
 
     @BeforeEach
@@ -77,6 +82,8 @@ public final class TarsServiceBeanPostProcessorTest {
         results.put("tarsDemoService2", tarsDemoService2);
         results.put("tarsDemoService3", tarsDemoService3);
         when(applicationContext.getBeansWithAnnotation(any())).thenReturn(results);
+        when(applicationContext.getEnvironment()).thenReturn(env);
+        when(env.getProperty("shenyu.discovery.type", ShenyuClientConstants.DISCOVERY_LOCAL_MODE)).thenReturn("local");
         contextRefreshedEvent = new ContextRefreshedEvent(applicationContext);
         
         ShenyuClientConfig shenyuClientConfig = mock(ShenyuClientConfig.class);


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
#6394 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Fix: Local SpringMvc Client Fails to Register
## Symptom
When using local discovery mode (shenyu.discovery.type=local), the SpringMvc client fails to complete URI registration.
## Root Cause
AbstractContextRefreshedEventListener originally declared isDiscoveryLocalMode as a final member field, initialized once in the constructor via props.getProperty(ShenyuClientConstants.DISCOVERY_LOCAL_MODE_KEY). That discoveryLocalMode property, however, is written into props by ShenyuSpringMvcClientConfiguration before it constructs the SpringMvcClientEventListener bean.

Due to a timing race between bean instantiation and the ContextRefreshedEvent firing—AbstractContextRefreshedEventListener#onApplicationEvent may execute before ShenyuSpringMvcClientConfiguration has finished populating props—the discoveryLocalMode property read at construction time is empty, so isDiscoveryLocalMode is always false. As a result, the local-registration branch inside onApplicationEvent is skipped, and the local SpringMvc client never initiates URI registration.
Solution
1. Remove the immutable field; read at event time instead: Deleted the isDiscoveryLocalMode field and its constructor initialization in AbstractContextRefreshedEventListener. Instead, onApplicationEvent now reads shenyu.discovery.type directly from the Spring Environment (defaulting to local) and evaluates the flag on the fly. This fully decouples discovery-mode evaluation from bean-construction / props-population timing, guaranteeing the correct environment config is consulted no matter when the listener callback fires.
2. Keep ShenyuSpringMvcClientConfiguration logic intact: The second commit restores the code that writes discoveryLocalMode into props in the configuration class, keeping the fix minimal—only the core listener changes, leaving other flows that may depend on this prop unaffected.
Test & Checkstyle Fixes
- SpringMvcClientEventListenerTest, TarsServiceBeanPostProcessorTest: Added mocks for applicationContext.getEnvironment() and the shenyu.discovery.type property to align with the new runtime-read logic.
- Fixed indentation of the buildApiSuperPath assertion continuation lines so Checkstyle passes.
Scope
- Core change: AbstractContextRefreshedEventListener.java
- Test changes: SpringMvcClientEventListenerTest.java, TarsServiceBeanPostProcessorTest.java
- Compatibility: Only the read timing changes; the judgment logic and default value (local) remain unchanged, with no impact on non-local discovery modes.



Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
