### PR TITLE
Fix/decouple jwt signing key from user password hash

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
@@ -17,9 +17,15 @@
 
 package org.apache.shenyu.admin.config.properties;
 
+import jakarta.annotation.PostConstruct;
 import org.apache.shenyu.common.constant.AdminConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
 
 /**
  * Jwt Properties.
@@ -28,7 +34,21 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "shenyu.jwt")
 public class JwtProperties {
 
+    private static final Logger LOG = LoggerFactory.getLogger(JwtProperties.class);
+
     private Long expiredSeconds = AdminConstants.THE_ONE_DAY_MILLIS_TIME;
+
+    private String secretKey = AdminConstants.JWT_DEFAULT_SECRET_KEY;
+
+    @PostConstruct
+    private void init() {
+        if (AdminConstants.JWT_DEFAULT_SECRET_KEY.equals(this.secretKey)) {
+            LOG.warn("jwt secretKey is using the default value, which is not secure. Please configure 'shenyu.jwt.secretKey' in your configuration.");
+            byte[] key = new byte[32];
+            new SecureRandom().nextBytes(key);
+            this.secretKey = Base64.getEncoder().encodeToString(key);
+        }
+    }
 
     /**
      * Gets the value of expiredSeconds.
@@ -46,5 +66,13 @@ public class JwtProperties {
      */
     public void setExpiredSeconds(final Long expiredSeconds) {
         this.expiredSeconds = expiredSeconds;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(final String secretKey) {
+        this.secretKey = secretKey;
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
@@ -311,7 +311,7 @@ public class DashboardUserServiceImpl implements DashboardUserService {
                         userDO.setClientId(clientId);
                         dashboardUserMapper.updateSelective(userDO);
                     }
-                    return loginUser.setToken(JwtUtils.generateToken(finalDashboardUserVO.getUserName(), finalDashboardUserVO.getPassword(),
+                    return loginUser.setToken(JwtUtils.generateToken(finalDashboardUserVO.getUserName(), jwtProperties.getSecretKey(),
                             clientId, jwtProperties.getExpiredSeconds())).setExpiredTime(jwtProperties.getExpiredSeconds());
                 })
                 .orElse(null);

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.admin.shiro.config;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.shenyu.admin.config.properties.JwtProperties;
 import org.apache.shenyu.admin.model.custom.UserInfo;
 import org.apache.shenyu.admin.model.vo.DashboardUserVO;
 import org.apache.shenyu.admin.service.DashboardUserService;
@@ -54,9 +55,12 @@ public class ShiroRealm extends AuthorizingRealm {
 
     private final DashboardUserService dashboardUserService;
 
-    public ShiroRealm(final PermissionService permissionService, final DashboardUserService dashboardUserService) {
+    private final JwtProperties jwtProperties;
+
+    public ShiroRealm(final PermissionService permissionService, final DashboardUserService dashboardUserService, final JwtProperties jwtProperties) {
         this.permissionService = permissionService;
         this.dashboardUserService = dashboardUserService;
+        this.jwtProperties = jwtProperties;
     }
 
     @Override
@@ -110,7 +114,7 @@ public class ShiroRealm extends AuthorizingRealm {
             throw new AuthenticationException("clientId is invalid or does not match");
         }
 
-        if (!JwtUtils.verifyToken(token, dashboardUserVO.getPassword())) {
+        if (!JwtUtils.verifyToken(token, jwtProperties.getSecretKey())) {
             throw new AuthenticationException("token is error.");
         }
 

--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -114,6 +114,7 @@ shenyu:
     object-class: person
     login-field: cn
   jwt:
+    secret-key: "defaultSecretKey"
     expired-seconds: 86400000
   cluster:
     enabled: false

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.admin.shiro.config;
 
+import org.apache.shenyu.admin.config.properties.JwtProperties;
 import org.apache.shenyu.admin.model.custom.UserInfo;
 import org.apache.shenyu.admin.model.vo.DashboardUserVO;
 import org.apache.shenyu.admin.service.DashboardUserService;
@@ -54,8 +55,8 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public final class ShiroRealmTest {
     
-    private static final String PASSWORD = "123456";
-    
+    private static final String SECRETKEY = "123456";
+
     @InjectMocks
     private ShiroRealm shiroRealm;
     
@@ -64,6 +65,9 @@ public final class ShiroRealmTest {
     
     @Mock
     private DashboardUserService dashboardUserService;
+
+    @Mock
+    private JwtProperties jwtProperties;
 
     @Test
     public void testSupports() {
@@ -115,7 +119,7 @@ public final class ShiroRealmTest {
 
         AuthenticationException exception3 = assertThrows(AuthenticationException.class, () -> {
             when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
-            when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+            when(jwtProperties.getSecretKey()).thenReturn(SECRETKEY);
             when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
                     + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
@@ -124,7 +128,7 @@ public final class ShiroRealmTest {
         assertNotNull(exception3);
 
         when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
-        when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+        when(jwtProperties.getSecretKey()).thenReturn(SECRETKEY);
         when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                 + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
                 + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/constant/AdminConstants.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/constant/AdminConstants.java
@@ -306,5 +306,7 @@ public final class AdminConstants {
     public static final long FIVE_SECONDS_MILLIS_TIME = 5 * 1000L;
 
     public static final long TEN_SECONDS_MILLIS_TIME = 10 * 1000L;
+
+    public static final String JWT_DEFAULT_SECRET_KEY = "defaultSecretKey";
 }
 


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
#6398 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
decouple jwt signing key from user password hash, 
add secret-key in application.yml to configure the key of jwt secret key, the code will generate a random string as secretKey if user doesn't configure it.
 i don't update JwtUtils.generateToken() and JwtUtils.verifyToken() . the two function receive the argument as secretKey and i think the behavior is correct. So that i change two place that invoke these two funcitons.
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
