### PR TITLE
fix: Decouple JWT signing key from user password hash

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
@@ -17,9 +17,15 @@
 
 package org.apache.shenyu.admin.config.properties;
 
+import jakarta.annotation.PostConstruct;
 import org.apache.shenyu.common.constant.AdminConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
 
 /**
  * Jwt Properties.
@@ -28,7 +34,21 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "shenyu.jwt")
 public class JwtProperties {
 
+    private static final Logger LOG = LoggerFactory.getLogger(JwtProperties.class);
+
     private Long expiredSeconds = AdminConstants.THE_ONE_DAY_MILLIS_TIME;
+
+    private String secretKey = AdminConstants.JWT_DEFAULT_SECRET_KEY;
+
+    @PostConstruct
+    private void init() {
+        if (AdminConstants.JWT_DEFAULT_SECRET_KEY.equals(this.secretKey)) {
+            LOG.warn("jwt secretKey is using the default value, which is not secure. Please configure 'shenyu.jwt.secretKey' in your configuration.");
+            byte[] key = new byte[32];
+            new SecureRandom().nextBytes(key);
+            this.secretKey = Base64.getEncoder().encodeToString(key);
+        }
+    }
 
     /**
      * Gets the value of expiredSeconds.
@@ -46,5 +66,13 @@ public class JwtProperties {
      */
     public void setExpiredSeconds(final Long expiredSeconds) {
         this.expiredSeconds = expiredSeconds;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(final String secretKey) {
+        this.secretKey = secretKey;
     }
 }

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/JwtProperties.java
@@ -18,14 +18,12 @@
 package org.apache.shenyu.admin.config.properties;
 
 import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.constant.AdminConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import java.security.SecureRandom;
-import java.util.Base64;
 
 /**
  * Jwt Properties.
@@ -38,16 +36,19 @@ public class JwtProperties {
 
     private Long expiredSeconds = AdminConstants.THE_ONE_DAY_MILLIS_TIME;
 
-    private String secretKey = AdminConstants.JWT_DEFAULT_SECRET_KEY;
+    private String secretKey;
 
     @PostConstruct
     private void init() {
-        if (AdminConstants.JWT_DEFAULT_SECRET_KEY.equals(this.secretKey)) {
-            LOG.warn("jwt secretKey is using the default value, which is not secure. Please configure 'shenyu.jwt.secretKey' in your configuration.");
-            byte[] key = new byte[32];
-            new SecureRandom().nextBytes(key);
-            this.secretKey = Base64.getEncoder().encodeToString(key);
+        if (StringUtils.isBlank(secretKey) || AdminConstants.JWT_DEFAULT_SECRET_KEY.equals(this.secretKey)) {
+            throw new IllegalStateException("shenyu.jwt.secretKey is not configured. "
+                    + "In a multi-instance Admin cluster, each instance would generate a different key, "
+                    + "causing token verification failures. "
+                    + "Please explicitly configure 'shenyu.jwt.secretKey' in your configuration.");
         }
+        LOG.warn("JWT signing key is now decoupled from user password hash. "
+                + "Existing sessions from previous versions will be invalidated and users will need to re-login. "
+                + "If rolling back, all tokens issued by this version will also become invalid.");
     }
 
     /**

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java
@@ -311,7 +311,7 @@ public class DashboardUserServiceImpl implements DashboardUserService {
                         userDO.setClientId(clientId);
                         dashboardUserMapper.updateSelective(userDO);
                     }
-                    return loginUser.setToken(JwtUtils.generateToken(finalDashboardUserVO.getUserName(), finalDashboardUserVO.getPassword(),
+                    return loginUser.setToken(JwtUtils.generateToken(finalDashboardUserVO.getUserName(), jwtProperties.getSecretKey(),
                             clientId, jwtProperties.getExpiredSeconds())).setExpiredTime(jwtProperties.getExpiredSeconds());
                 })
                 .orElse(null);

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.admin.shiro.config;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.shenyu.admin.config.properties.JwtProperties;
 import org.apache.shenyu.admin.model.custom.UserInfo;
 import org.apache.shenyu.admin.model.vo.DashboardUserVO;
 import org.apache.shenyu.admin.service.DashboardUserService;
@@ -54,9 +55,12 @@ public class ShiroRealm extends AuthorizingRealm {
 
     private final DashboardUserService dashboardUserService;
 
-    public ShiroRealm(final PermissionService permissionService, final DashboardUserService dashboardUserService) {
+    private final JwtProperties jwtProperties;
+
+    public ShiroRealm(final PermissionService permissionService, final DashboardUserService dashboardUserService, final JwtProperties jwtProperties) {
         this.permissionService = permissionService;
         this.dashboardUserService = dashboardUserService;
+        this.jwtProperties = jwtProperties;
     }
 
     @Override
@@ -112,7 +116,7 @@ public class ShiroRealm extends AuthorizingRealm {
             throw new AuthenticationException("clientId is invalid or does not match");
         }
 
-        if (!JwtUtils.verifyToken(token, dashboardUserVO.getPassword())) {
+        if (!JwtUtils.verifyToken(token, jwtProperties.getSecretKey())) {
             throw new AuthenticationException("token is error.");
         }
 

--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -114,6 +114,7 @@ shenyu:
     object-class: person
     login-field: cn
   jwt:
+    secret-key: "defaultSecretKey"
     expired-seconds: 86400000
   cluster:
     enabled: false

--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -115,7 +115,10 @@ shenyu:
     object-class: person
     login-field: cn
   jwt:
-    secret-key: "defaultSecretKey"
+    # secret-key must be explicitly configured, especially in multi-instance Admin clusters.
+    # Each instance must share the same secretKey to avoid token verification failures (random 401s).
+    # Please replace this with your own secure key in production.
+    # secret-key: "your-secret-key-here"
     expired-seconds: 86400000
   cluster:
     enabled: false

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/properties/JwtPropertiesTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/config/properties/JwtPropertiesTest.java
@@ -19,16 +19,37 @@ package org.apache.shenyu.admin.config.properties;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
-/**
- * Test cases for {@link JwtProperties}.
- */
 public class JwtPropertiesTest {
-    
+
     @Test
     public void jwtPropertiesTest() {
         final JwtProperties jwtProperties = new JwtProperties();
         jwtProperties.setExpiredSeconds(0L);
         Assertions.assertEquals(jwtProperties.getExpiredSeconds(), 0L);
+    }
+
+    @Test
+    public void testInitThrowsWhenSecretKeyIsBlank() {
+        final JwtProperties jwtProperties = new JwtProperties();
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> ReflectionTestUtils.invokeMethod(jwtProperties, "init"));
+    }
+
+    @Test
+    public void testInitThrowsWhenSecretKeyIsDefault() {
+        final JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecretKey("defaultSecretKey");
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> ReflectionTestUtils.invokeMethod(jwtProperties, "init"));
+    }
+
+    @Test
+    public void testInitDoesNotThrowWhenSecretKeyIsConfigured() {
+        final JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecretKey("mySecretKey");
+        Assertions.assertDoesNotThrow(
+                () -> ReflectionTestUtils.invokeMethod(jwtProperties, "init"));
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java
@@ -35,6 +35,7 @@ import org.apache.shenyu.admin.model.vo.NamespaceUserRelVO;
 import org.apache.shenyu.admin.service.impl.DashboardUserServiceImpl;
 import org.apache.shenyu.admin.service.publish.UserEventPublisher;
 import org.apache.shenyu.admin.utils.SessionUtil;
+import org.apache.shenyu.admin.utils.JwtUtils;
 import org.apache.shenyu.common.utils.AesUtils;
 import org.apache.shenyu.common.utils.DigestUtils;
 import org.apache.shenyu.common.utils.ListUtil;
@@ -56,6 +57,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -81,6 +84,8 @@ public final class DashboardUserServiceTest {
     private static final String TEST_AES_KEY = "2095132720951327";
 
     private static final String TEST_AES_IV = "6075877187097700";
+
+    private static final String TEST_JWT_SECRET_KEY = "testSecretKey12345678901234567890";
 
     @InjectMocks
     private DashboardUserServiceImpl dashboardUserService;
@@ -210,6 +215,8 @@ public final class DashboardUserServiceTest {
     public void testLogin() {
         ReflectionTestUtils.setField(dashboardUserService, "jwtProperties", jwtProperties);
         ReflectionTestUtils.setField(dashboardUserService, "secretProperties", secretProperties);
+        given(jwtProperties.getSecretKey()).willReturn(TEST_JWT_SECRET_KEY);
+        given(jwtProperties.getExpiredSeconds()).willReturn(86400000L);
         DashboardUserDO dashboardUserDO = createDashboardUserDO();
 
         when(dashboardUserMapper.selectByUserName(eq(TEST_USER_NAME))).thenReturn(dashboardUserDO);
@@ -223,6 +230,8 @@ public final class DashboardUserServiceTest {
         LoginDashboardUserVO loginDashboardUserVO = dashboardUserService.login(TEST_USER_NAME, TEST_PASSWORD, null);
         assertEquals(TEST_USER_NAME, loginDashboardUserVO.getUserName());
         assertEquals(TEST_PASSWORD, loginDashboardUserVO.getPassword());
+        assertTrue(JwtUtils.verifyToken(loginDashboardUserVO.getToken(), TEST_JWT_SECRET_KEY));
+        assertFalse(JwtUtils.verifyToken(loginDashboardUserVO.getToken(), "wrongKey"));
 
         // test loginByDatabase
         ReflectionTestUtils.setField(dashboardUserService, "ldapTemplate", null);
@@ -253,6 +262,8 @@ public final class DashboardUserServiceTest {
     @Test
     public void testLoginMigratesLegacySha512Password() {
         ReflectionTestUtils.setField(dashboardUserService, "jwtProperties", jwtProperties);
+        given(jwtProperties.getSecretKey()).willReturn(TEST_JWT_SECRET_KEY);
+        given(jwtProperties.getExpiredSeconds()).willReturn(86400000L);
         ReflectionTestUtils.setField(dashboardUserService, "ldapTemplate", null);
         DashboardUserDO legacyUser = createDashboardUserDO();
         legacyUser.setPassword(DigestUtils.sha512Hex(TEST_PASSWORD));
@@ -272,6 +283,8 @@ public final class DashboardUserServiceTest {
     @Test
     public void testLoginDoesNotMigrateBcryptPassword() {
         ReflectionTestUtils.setField(dashboardUserService, "jwtProperties", jwtProperties);
+        given(jwtProperties.getSecretKey()).willReturn(TEST_JWT_SECRET_KEY);
+        given(jwtProperties.getExpiredSeconds()).willReturn(86400000L);
         ReflectionTestUtils.setField(dashboardUserService, "ldapTemplate", null);
         DashboardUserDO bcryptUser = createDashboardUserDO();
         bcryptUser.setPassword("$2b$12$VRoSQ/.z8C/ldOO9TBfclesgVQ8BxyQK/4Rg/e.DNCisEd.gSyCBG");

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.admin.shiro.config;
 
+import org.apache.shenyu.admin.config.properties.JwtProperties;
 import org.apache.shenyu.admin.model.custom.UserInfo;
 import org.apache.shenyu.admin.model.vo.DashboardUserVO;
 import org.apache.shenyu.admin.service.DashboardUserService;
@@ -34,10 +35,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-    
+
 import java.util.HashSet;
 import java.util.Set;
-    
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -53,17 +54,20 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public final class ShiroRealmTest {
-    
-    private static final String PASSWORD = "123456";
-    
+
+    private static final String SECRETKEY = "123456";
+
     @InjectMocks
     private ShiroRealm shiroRealm;
-    
+
     @Mock
     private PermissionService permissionService;
-    
+
     @Mock
     private DashboardUserService dashboardUserService;
+
+    @Mock
+    private JwtProperties jwtProperties;
 
     @Test
     public void testSupports() {
@@ -98,8 +102,8 @@ public final class ShiroRealmTest {
 
         AuthenticationException exception1 = assertThrows(AuthenticationException.class, () -> {
             when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
-                    + ".cThIIoDvwdueQB468K5xDc5633seEFoqwxjF_xSJyQQ");
+                    + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
+                    + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
             shiroRealm.doGetAuthenticationInfo(token);
         });
         assertNotNull(exception1);
@@ -108,7 +112,7 @@ public final class ShiroRealmTest {
             when(dashboardUserService.findByUserName(any())).thenReturn(null);
             when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
-                    + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+                    + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
             shiroRealm.doGetAuthenticationInfo(token);
         });
         assertNotNull(exception2);
@@ -118,7 +122,7 @@ public final class ShiroRealmTest {
             when(dashboardUserVO.getEnabled()).thenReturn(false);
             when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
-                    + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+                    + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
             shiroRealm.doGetAuthenticationInfo(token);
         });
         assertNotNull(exception3);
@@ -126,17 +130,17 @@ public final class ShiroRealmTest {
         AuthenticationException exception4 = assertThrows(AuthenticationException.class, () -> {
             when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
             when(dashboardUserVO.getEnabled()).thenReturn(true);
-            when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+            when(jwtProperties.getSecretKey()).thenReturn("wrongKey");
             when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                     + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
-                    + ".vZiLpzbncmNC5KL1idgfapCOTsRC0h_5XnqxaGfcLlM");
+                    + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");
             shiroRealm.doGetAuthenticationInfo(token);
         });
         assertNotNull(exception4);
 
         when(dashboardUserService.findByUserName(any())).thenReturn(dashboardUserVO);
         when(dashboardUserVO.getEnabled()).thenReturn(true);
-        when(dashboardUserVO.getPassword()).thenReturn(PASSWORD);
+        when(jwtProperties.getSecretKey()).thenReturn(SECRETKEY);
         when(token.getCredentials()).thenReturn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                 + ".eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlck5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0"
                 + ".Qlpf6FdKAffgceukbi2BQYdPVf71d4Nwy0YQlkiTQFc");

--- a/shenyu-admin/src/test/resources/application.yml
+++ b/shenyu-admin/src/test/resources/application.yml
@@ -79,6 +79,7 @@ shenyu:
     object-class: person
     login-field: cn
   jwt:
+    secret-key: "testSecretKey12345678901234567890"
     expired-seconds: 86400000
   shiro:
     white-list:

--- a/shenyu-common/src/main/java/org/apache/shenyu/common/constant/AdminConstants.java
+++ b/shenyu-common/src/main/java/org/apache/shenyu/common/constant/AdminConstants.java
@@ -306,5 +306,7 @@ public final class AdminConstants {
     public static final long FIVE_SECONDS_MILLIS_TIME = 5 * 1000L;
 
     public static final long TEN_SECONDS_MILLIS_TIME = 10 * 1000L;
+
+    public static final String JWT_DEFAULT_SECRET_KEY = "defaultSecretKey";
 }
 

--- a/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/docker-compose.yaml
+++ b/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/docker-compose.yaml
@@ -43,6 +43,10 @@ services:
       - ./shenyu-admin/ext-lib/:/opt/shenyu-admin/ext-lib
     ports:
       - "9095:9095"
+    environment:
+      # Required: replace with your own secure key in production.
+      # In a multi-instance Admin cluster, all instances must share the same secretKey.
+      - SHENYU_JWT_SECRETKEY=please-replace-with-your-own-secret-key
     healthcheck:
       test: [ "CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1" ]
       timeout: 2s

--- a/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/install.sh
+++ b/shenyu-dist/shenyu-docker-compose-dist/src/main/resources/install.sh
@@ -81,5 +81,9 @@ echo "Downloading shenyu-bootstrap configuration ..."
 
 printf '\n'
 echo "Next steps? Please modify the configuration in ./shenyu-${version}"
+echo "IMPORTANT: You MUST set 'shenyu.jwt.secretKey' in shenyu-admin/conf/application.yml"
+echo "  or set the environment variable SHENYU_JWT_SECRETKEY in docker-compose.yaml"
+echo "  before starting shenyu-admin, otherwise it will fail to start."
+echo "  In a multi-instance Admin cluster, all instances must share the same secretKey."
 echo "And then, you can run docker-compose"
 echo "For more detail, see https://shenyu.apache.org/docs/index"

--- a/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-h2.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-h2.yml
@@ -32,6 +32,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-mysql.yml
@@ -64,6 +64,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml
@@ -63,6 +63,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/opengauss/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-postgres.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-postgres.yml
@@ -63,6 +63,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/postgres/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-nacos.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-nacos.yml
@@ -103,6 +103,7 @@ services:
       - spring.datasource.url=jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
       - shenyu.sync.nacos.url=http://shenyu-nacos:8848
       - shenyu.sync.nacos.namespace=1c10d748-af86-43b9-8265-75f487d20c6c
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd-eureka.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd-eureka.yml
@@ -82,6 +82,7 @@ services:
       - spring.datasource.password=shenyue2e
       - spring.datasource.url=jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
       - shenyu.sync.etcd.url=http://shenyu-etcd:2379
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd.yml
@@ -82,6 +82,7 @@ services:
       - spring.datasource.password=shenyue2e
       - spring.datasource.url=jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
       - shenyu.sync.etcd.url=http://shenyu-etcd:2379
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http-eureka.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http-eureka.yml
@@ -61,6 +61,7 @@ services:
       - spring.datasource.password=shenyue2e
       - spring.datasource.url=jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
       - shenyu.sync.http.enabled=true
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http.yml
@@ -61,6 +61,7 @@ services:
       - spring.datasource.password=shenyue2e
       - spring.datasource.url=jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
       - shenyu.sync.http.enabled=true
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-jdbc.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-jdbc.yml
@@ -65,6 +65,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:
@@ -98,6 +99,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-zookeeper.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-zookeeper.yml
@@ -84,6 +84,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:
@@ -121,6 +122,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-eureka.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-eureka.yml
@@ -64,6 +64,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket.yml
@@ -64,6 +64,7 @@ services:
       - shenyu.sync.websocket.messageMaxSize=10240
       - shenyu.sync.websocket.allowOrigins=ws://localhost:9095;ws://localhost:9195;
       - shenyu.sync.websocket.token=shenyu-sync-token
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper-eureka.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper-eureka.yml
@@ -80,6 +80,7 @@ services:
       - shenyu.sync.zookeeper.url=shenyu-zookeeper-sync:2181
       - shenyu.sync.zookeeper.sessionTimeoutMilliseconds=5000
       - shenyu.sync.zookeeper.connectionTimeoutMilliseconds=2000
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper.yml
@@ -86,6 +86,7 @@ services:
       # Increase timeouts to prevent rapid reconnection attempts
       - shenyu.sync.zookeeper.sessionTimeoutMilliseconds=30000
       - shenyu.sync.zookeeper.connectionTimeoutMilliseconds=10000
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     volumes:
       - /tmp/shenyu-e2e/mysql/driver:/opt/shenyu-admin/ext-lib
     healthcheck:

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-etcd.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-etcd.yml
@@ -59,6 +59,8 @@ spec:
               value: 'Asia/Beijing'
             - name: SPRING_PROFILES_ACTIVE
               value: mysql, admin-sync-etcd
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           volumeMounts:
             - name: mysql-connector-volume
               mountPath: /opt/shenyu-admin/ext-lib

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-http.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-http.yml
@@ -59,6 +59,8 @@ spec:
               value: 'Asia/Beijing'
             - name: SPRING_PROFILES_ACTIVE
               value: mysql, admin-sync-http
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           volumeMounts:
             - name: mysql-connector-volume
               mountPath: /opt/shenyu-admin/ext-lib

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-nacos.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-nacos.yml
@@ -59,6 +59,8 @@ spec:
               value: 'Asia/Beijing'
             - name: SPRING_PROFILES_ACTIVE
               value: mysql, admin-sync-nacos
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           volumeMounts:
             - name: mysql-connector-volume
               mountPath: /opt/shenyu-admin/ext-lib

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-websocket.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-websocket.yml
@@ -59,6 +59,8 @@ spec:
               value: 'Asia/Beijing'
             - name: SPRING_PROFILES_ACTIVE
               value: mysql, admin-sync-websocket
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           volumeMounts:
             - name: mysql-connector-volume
               mountPath: /opt/shenyu-admin/ext-lib

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-zookeeper.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-admin-zookeeper.yml
@@ -59,6 +59,8 @@ spec:
               value: 'Asia/Beijing'
             - name: SPRING_PROFILES_ACTIVE
               value: mysql, admin-sync-zookeeper
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           volumeMounts:
             - name: mysql-connector-volume
               mountPath: /opt/shenyu-admin/ext-lib

--- a/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-cm.yml
+++ b/shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-cm.yml
@@ -89,6 +89,7 @@ data:
         object-class: person
         login-field: cn
       jwt:
+        secret-key: shenyu-e2e-jwt-secret-key-2024
         expired-seconds: 86400000
       shiro:
         white-list:

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/docker-compose.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-jdbc.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-jdbc.yml
@@ -55,6 +55,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           livenessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -126,6 +128,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           livenessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-zookeeper.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-zookeeper.yml
@@ -58,6 +58,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           livenessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -133,6 +135,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           livenessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-h2.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-h2.yml
@@ -44,6 +44,8 @@ spec:
               value: h2
             - name: shenyu.database.init_script
               value: sql-script/h2/schema.sql
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           ports:
             - containerPort: 9095
           livenessProbe:

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-mysql.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-mysql.yml
@@ -46,6 +46,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:mysql://shenyu-mysql:3306/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai&zeroDateTimeBehavior=convertToNull
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           livenessProbe:
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-opengauss.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-opengauss.yml
@@ -43,6 +43,8 @@ spec:
               value: ShenYuE2E@123
             - name: spring.datasource.url
               value: jdbc:opengauss://shenyu-opengauss:5432/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           ports:
             - containerPort: 9095
           livenessProbe:

--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-postgres.yml
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-postgres.yml
@@ -43,6 +43,8 @@ spec:
               value: shenyue2e
             - name: spring.datasource.url
               value: jdbc:postgresql://shenyu-postgres:5432/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           ports:
             - containerPort: 9095
           livenessProbe:

--- a/shenyu-e2e/shenyu-e2e-engine/src/test/resources/docker-compose.yml
+++ b/shenyu-e2e/shenyu-e2e-engine/src/test/resources/docker-compose.yml
@@ -20,5 +20,7 @@ version: '2.3'
 services:
   admin:
     image: shenyu/admin:latest
+    environment:
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     ports:
       - "19095:9095"

--- a/shenyu-examples/shenyu-examples-http-swagger3/k8s/shenyu-deployment.yml
+++ b/shenyu-examples/shenyu-examples-http-swagger3/k8s/shenyu-deployment.yml
@@ -42,6 +42,8 @@ spec:
               value: h2
             - name: shenyu.database.init_script
               value: sql-script/h2/schema.sql
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           ports:
             - containerPort: 9095
           imagePullPolicy: IfNotPresent

--- a/shenyu-examples/shenyu-examples-http/k8s/shenyu-deployment.yml
+++ b/shenyu-examples/shenyu-examples-http/k8s/shenyu-deployment.yml
@@ -42,6 +42,8 @@ spec:
               value: h2
             - name: shenyu.database.init_script
               value: sql-script/h2/schema.sql
+            - name: SHENYU_JWT_SECRETKEY
+              value: shenyu-e2e-jwt-secret-key-2024
           ports:
             - containerPort: 9095
           imagePullPolicy: IfNotPresent

--- a/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-combination/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-combination/docker-compose.yml
@@ -152,6 +152,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-grpc/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-grpc/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-https/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-https/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: [ "CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1" ]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-rewrite/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-rewrite/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-sdk-http/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sdk-http/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-sofa/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-sofa/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-spring-cloud/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-spring-cloud/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: [ "CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1" ]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-upload-plugin/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-upload-plugin/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: [ "CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1" ]
       timeout: 2s

--- a/shenyu-integrated-test/shenyu-integrated-test-websocket/docker-compose.yml
+++ b/shenyu-integrated-test/shenyu-integrated-test-websocket/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - SPRING_PROFILES_ACTIVE=h2
       - shenyu.sync.websocket.token=shenyu-sync-token
       - shenyu.database.init_script=sql-script/h2/schema.sql
+      - shenyu.jwt.secretKey=shenyu-e2e-jwt-secret-key-2024
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://shenyu-admin:9095/actuator/health | grep UP || exit 1"]
       timeout: 2s


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->
#6398 
<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Changes
- Decouple JWT signing key from user password hash by introducing shenyu.jwt.secretKey configuration
- Admin now requires an explicit shenyu.jwt.secretKey (or env var SHENYU_JWT_SECRETKEY) and refuses to start without one (fail-fast)
- Updated DashboardUserServiceImpl (sign) and ShiroRealm (verify) to use the new key
- Added regression tests: DashboardUserServiceTest now stubs jwtProperties.getSecretKey() and asserts verifyToken(token, key) is true/false
- Added JwtPropertiesTest for blank/default/configured init() cases
- Added startup WARN about session invalidation on upgrade/rollback
- Wired shenyu.jwt.secretKey into all e2e/k8s/integrated-test/docker-compose configurations

Migration Note
Before upgrading, set shenyu.jwt.secretKey in your configuration (or SHENYU_JWT_SECRETKEY env var). All existing sessions will be invalidated on upgrade; users will need to re-login. Rolling back will also invalidate all tokens issued by this version.
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
