### PR TITLE
[ISSUE #6396] Document websocket network isolation requirement.

### DIFF
--- a/shenyu-admin/src/main/resources/application.yml
+++ b/shenyu-admin/src/main/resources/application.yml
@@ -182,6 +182,8 @@ shenyu:
       - /index**
       - /platform/login
       - /platform/secretInfo
+      # /websocket is unauthenticated by design for Admin-Gateway data synchronization.
+      # Keep the Admin port on trusted networks and enforce network-level access controls.
       - /websocket
       - /error
       - /actuator/health


### PR DESCRIPTION
## Description

Adds an explicit warning next to the `/websocket` Shiro anonymous whitelist entry in `shenyu-admin`.

The comment explains that the endpoint is unauthenticated by design for Admin-to-Gateway data synchronization and that operators must keep the Admin port on trusted networks with network-level access controls.

Companion documentation PR: apache/shenyu-website#1125.

## Verification

- Parsed `shenyu-admin/src/main/resources/application.yml` with PyYAML.
- Ran `git diff --check`.
- No runtime behavior is changed; this PR only adds configuration guidance.

Related to #6396.