### PR TITLE
fix: pin docker actions to approved commit SHA for ASF Actions policy

### DIFF
--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -40,16 +40,16 @@ jobs:
           submodules: true
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
@@ -104,7 +104,7 @@ jobs:
           fi
 
       - name: Build and push (admin) (dockerhub)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./shenyu-dist/shenyu-admin-dist
           file: ./shenyu-dist/shenyu-admin-dist/docker/Dockerfile
@@ -116,7 +116,7 @@ jobs:
             apache/shenyu-admin:${{ env.TAG }}
 
       - name: Build and push (bootstrap) (dockerhub)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./shenyu-dist/shenyu-bootstrap-dist
           file: ./shenyu-dist/shenyu-bootstrap-dist/docker/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,17 +43,17 @@ jobs:
           submodules: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Build and push (admin) (ghcr.io)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./shenyu-dist/shenyu-admin-dist
           file: ./shenyu-dist/shenyu-admin-dist/docker/Dockerfile
@@ -120,7 +120,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/admin:${{ env.TAG }}
 
       - name: Build and push (bootstrap) (ghcr.io)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./shenyu-dist/shenyu-bootstrap-dist
           file: ./shenyu-dist/shenyu-bootstrap-dist/docker/Dockerfile


### PR DESCRIPTION
Per the [ASF GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html), third-party actions (outside `apache/*`, `github/*`, `actions/*`) MUST be pinned to an approved commit SHA. The `docker/*` actions were referenced by tag, so the org allowlist rejects the whole workflow before it runs.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
