### PR TITLE
fix: update examples to consume independent shenyu-client-java artifacts    

### DIFF
--- a/shenyu-examples/README.md
+++ b/shenyu-examples/README.md
@@ -1,0 +1,133 @@
+# ShenYu Examples
+
+This module contains example applications that demonstrate how to integrate your services with the Apache ShenYu gateway.
+
+## Client Dependencies
+
+The example modules now consume **independent [shenyu-client-java](https://github.com/apache/shenyu-client-java) artifacts** from Maven Central, rather than depending on in-tree source modules from the main `apache/shenyu` repository.
+
+This reflects the recommended approach for real users: add the ShenYu client library as an external Maven dependency.
+
+### How It Works
+
+The parent POM (`shenyu-examples/pom.xml`) defines a property:
+
+```xml
+<shenyu.client.java.version>2.7.0.3</shenyu.client.java.version>
+```
+
+All `shenyu-client-*` and `shenyu-spring-boot-starter-client-*` dependencies in individual example POMs are managed by this property through the `<dependencyManagement>` section. The version is inherited automatically — individual examples do not specify a `<version>` for these artifacts.
+
+### Which Artifacts Are Consumed Externally
+
+| Client Artifact | Used By |
+|----------------|---------|
+| `shenyu-client-springmvc` | `shenyu-examples-springmvc`, `shenyu-examples-springmvc-tomcat` |
+| `shenyu-spring-boot-starter-client-springmvc` | `shenyu-examples-http`, `shenyu-examples-http-swagger3`, `shenyu-examples-https`, `shenyu-examples-springcloud`, `shenyu-examples-websocket` (native), `shenyu-examples-mcp`, `shenyu-examples-sdk-http`, `shenyu-examples-sdk-feign` |
+| `shenyu-spring-boot-starter-client-grpc` | `shenyu-examples-grpc` |
+| `shenyu-spring-boot-starter-client-apache-dubbo` | `shenyu-examples-apache-dubbo-service`, `shenyu-examples-apache-dubbo-service-annotation` |
+| `shenyu-client-apache-dubbo` | `shenyu-examples-apache-dubbo-service-xml`, `shenyu-examples-sdk-apache-dubbo-provider` |
+| `shenyu-spring-boot-starter-client-tars` | `shenyu-examples-tars` |
+| `shenyu-spring-boot-starter-client-sofa` | `shenyu-examples-sofa-service` |
+| `shenyu-spring-boot-starter-client-spring-websocket` | `shenyu-examples-websocket` (annotation, native, reactive) |
+| `shenyu-spring-boot-starter-client-mcp` | `shenyu-examples-mcp` |
+
+### Internal Example Dependencies
+
+The following dependencies remain internal to this repository (`${project.version}`):
+
+- `shenyu-examples-common` — shared example utilities
+- `shenyu-examples-dubbo-api` — Dubbo API definitions
+- `shenyu-examples-sofa-api` — Sofa API definitions
+- `shenyu-sdk-*` — ShenYu SDK modules (not extracted to shenyu-client-java)
+- `shenyu-spring-boot-starter-sdk-*` — ShenYu SDK starters (not extracted to shenyu-client-java)
+
+## Testing with Unreleased Client Artifacts
+
+When developing or testing changes to the `shenyu-client-java` library, you may need to build the client artifacts locally and use them in these examples.
+
+### Option 1: Override the Version via Command Line
+
+Build the `shenyu-client-java` project locally, install the artifacts to your local Maven repository:
+
+```bash
+git clone https://github.com/apache/shenyu-client-java.git
+cd shenyu-client-java
+mvn clean install -DskipTests
+```
+
+This installs the artifacts with the project's snapshot version (e.g., `2.7.0.1-jdk8-SNAPSHOT`). Then, build the examples using that version:
+
+```bash
+cd shenyu
+mvn clean install -pl shenyu-examples -Dshenyu.client.java.version=2.7.0.1-jdk8-SNAPSHOT
+```
+
+### Option 2: Modify the Property in Parent POM
+
+For a more permanent change during development, edit the `<shenyu.client.java.version>` property in `shenyu-examples/pom.xml`:
+
+```xml
+<shenyu.client.java.version>2.7.0.1-jdk8-SNAPSHOT</shenyu.client.java.version>
+```
+
+> **Note**: When using `-SNAPSHOT` versions, you may need to configure the Apache Snapshot Repository in your `settings.xml` or POM:
+> ```xml
+> <repository>
+>     <id>apache-snapshots</id>
+>     <url>https://repository.apache.org/content/repositories/snapshots/</url>
+>     <snapshots>
+>         <enabled>true</enabled>
+>     </snapshots>
+> </repository>
+> ```
+
+### Option 3: Use Maven `-U` Flag for Latest Snapshots
+
+If the snapshot has been published to the Apache snapshot repository:
+
+```bash
+mvn clean install -pl shenyu-examples -Dshenyu.client.java.version=2.7.0.1-jdk8-SNAPSHOT -U
+```
+
+The `-U` flag forces Maven to check for updated snapshots.
+
+## Verification
+
+After updating the client version, verify that the examples can register with a local ShenYu Admin and Bootstrap.
+
+### Prerequisites
+
+Before running any example, install the shared example utilities to your local Maven repository:
+
+```bash
+cd shenyu-examples
+mvn install -pl shenyu-examples-common -DskipTests
+```
+
+### Run Examples
+
+Run the example from the `shenyu-examples` reactor root using `-pl` so internal dependencies like `shenyu-examples-common` are resolved automatically:
+
+```bash
+cd shenyu-examples
+
+# Spring MVC HTTP example
+mvn spring-boot:run -pl shenyu-examples-springmvc
+
+# Or other protocol examples:
+# mvn spring-boot:run -pl shenyu-examples-grpc
+# mvn spring-boot:run -pl shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service
+# mvn spring-boot:run -pl shenyu-examples-websocket/shenyu-example-spring-annotation-websocket
+# mvn spring-boot:run -pl shenyu-examples-mcp
+```
+
+> **Note**: Running `mvn spring-boot:run` directly from within an individual example directory (e.g., `cd shenyu-examples-springmvc && mvn spring-boot:run`) will fail because `shenyu-examples-common` and the parent POM cannot be resolved outside the reactor. Always use the `-pl` approach from the `shenyu-examples/` root.
+
+### Confirm Registration
+
+After the application starts:
+
+1. Open the ShenYu Admin console (default: `http://localhost:9095`)
+2. Check that the service appears under **Divide** (for HTTP), **Dubbo**, **gRPC**, or the respective plugin list
+3. Verify API calls can be proxied through the ShenYu gateway (default: `http://localhost:9195`)

--- a/shenyu-examples/pom.xml
+++ b/shenyu-examples/pom.xml
@@ -39,6 +39,7 @@
         <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
         <swagger.version>2.6.0</swagger.version>
+        <shenyu.client.java.version>2.7.0.3</shenyu.client.java.version>
     </properties>
 
     <modules>
@@ -65,6 +66,52 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${swagger.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-client-springmvc</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-client-apache-dubbo</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-grpc</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-apache-dubbo</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-tars</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-sofa</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-spring-websocket</artifactId>
+                <version>${shenyu.client.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shenyu</groupId>
+                <artifactId>shenyu-spring-boot-starter-client-mcp</artifactId>
+                <version>${shenyu.client.java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-apache-dubbo</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!--shenyu consul register center -->

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-client-apache-dubbo</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!--shenyu consul register center -->

--- a/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-apache-dubbo</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!--shenyu consul register center -->

--- a/shenyu-examples/shenyu-examples-grpc/pom.xml
+++ b/shenyu-examples/shenyu-examples-grpc/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-grpc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-http-swagger3/pom.xml
+++ b/shenyu-examples/shenyu-examples-http-swagger3/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-http/pom.xml
+++ b/shenyu-examples/shenyu-examples-http/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-https/pom.xml
+++ b/shenyu-examples/shenyu-examples-https/pom.xml
@@ -31,7 +31,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-mcp/pom.xml
+++ b/shenyu-examples/shenyu-examples-mcp/pom.xml
@@ -53,13 +53,11 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-mcp</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-client-apache-dubbo</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml
+++ b/shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml
@@ -217,7 +217,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-sofa</artifactId>
-            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>guava</artifactId>

--- a/shenyu-examples/shenyu-examples-springcloud/pom.xml
+++ b/shenyu-examples/shenyu-examples-springcloud/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <!--spring bootstrap-->
         <dependency>

--- a/shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml
+++ b/shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-springmvc/pom.xml
+++ b/shenyu-examples/shenyu-examples-springmvc/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-tars/pom.xml
+++ b/shenyu-examples/shenyu-examples-tars/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-tars</artifactId>
-            <version>${project.version}</version>
 <!--            <exclusions>-->
 <!--                <exclusion>-->
 <!--                    <artifactId>guava</artifactId>-->

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-spring-websocket</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml
@@ -31,13 +31,11 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-spring-websocket</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-springmvc</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml
+++ b/shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>org.apache.shenyu</groupId>
             <artifactId>shenyu-spring-boot-starter-client-spring-websocket</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Closes #6371

  <!-- Describe your PR here; e.g. Fixes #issueNo -->

  Replace all `${project.version}` references for `shenyu-client-*` and `shenyu-spring-boot-starter-client-*` dependencies with centralized `${shenyu.client.java.version}` property in
  parent POM.

  ### Changes
  - **Parent POM**: Added `<shenyu.client.java.version>2.7.0.3</shenyu.client.java.version>` and `<dependencyManagement>` entries for all 9 client artifacts
  - **21 pom.xml files**: Removed `<version>${project.version}</version>` from 19 client dependency declarations — all now inherit version from parent
  - **README.md**: Fixed Verification section — replaced broken directory-level `mvn spring-boot:run` with reactor-root `mvn spring-boot:run -pl <module>`

  ### Why
  Examples now consume released `shenyu-client-java` artifacts from Maven Central, decoupling from the main repo's source modules — matching the recommended approach for real users.

  <!--
  Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
  -->
  Make sure that:

  - [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
  - [x] You submit test cases (unit or integration tests) that back your changes.
  - [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
