### PR TITLE
Fix the method for verifying the existence of the appkey

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/provider/AppKeyProvider.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/provider/AppKeyProvider.java
@@ -37,6 +37,6 @@ public class AppKeyProvider implements ExistProvider {
     
     @Override
     public Boolean existed(final Serializable key) {
-        return appAuthMapper.existed(key);
+        return appAuthMapper.appKeyExisted(key);
     }
 }


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

https://github.com/apache/shenyu/issues/6422  


The `GET /appAuth/updateSk` endpoint always fails validation with the error `updateSk.appKey: app key not existed`, regardless of whether the provided `appKey` actually exists in the database.

**Root cause:** The `@Existed` validation on the `appKey` parameter uses `AppKeyProvider`, whose `existed()` method calls `appAuthMapper.existed(key)`. However, `AppAuthMapper.existed()` queries the `id` (primary key) column instead of the `app_key` column:

```xml
<!-- Currently used (WRONG) - queries by id -->
<select id="existed" resultType="java.lang.Boolean">
    SELECT true FROM app_auth WHERE id = #{id} LIMIT 1
</select>

<!-- Should use this - queries by app_key -->
<select id="appKeyExisted" resultType="java.lang.Boolean">
    SELECT true FROM app_auth WHERE app_key = #{appKey} LIMIT 1
</select>
```

Since the passed `appKey` value is checked against the `id` column, the query never matches, so the validation always fails.

**Fix:** In `AppKeyProvider.existed()`, call `appAuthMapper.appKeyExisted(key)` instead of `appAuthMapper.existed(key)`.


<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
