### PR TITLE
infra(ci): remove sofa related workflow after sofa support removed

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -247,8 +247,6 @@ jobs:
             script: e2e-springcloud-sync-compose
           - case: shenyu-e2e-case-apache-dubbo
             script: e2e-apache-dubbo-sync-compose
-          - case: shenyu-e2e-case-sofa
-            script: e2e-sofa-sync-compose
           - case: shenyu-e2e-case-grpc
             script: e2e-grpc-sync-compose
           - case: shenyu-e2e-case-websocket

--- a/.github/workflows/integrated-test-k8s-ingress.yml
+++ b/.github/workflows/integrated-test-k8s-ingress.yml
@@ -30,7 +30,6 @@ jobs:
           - shenyu-integrated-test-k8s-ingress-apache-dubbo
           - shenyu-integrated-test-k8s-ingress-websocket
           - shenyu-integrated-test-k8s-ingress-grpc
-    #          - shenyu-integrated-test-k8s-ingress-sofa
     runs-on: ubuntu-latest
     if: github.repository == 'apache/shenyu'
     steps:

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -31,7 +31,6 @@ jobs:
           - shenyu-integrated-test-http
           - shenyu-integrated-test-https
           - shenyu-integrated-test-spring-cloud
-          - shenyu-integrated-test-sofa
           - shenyu-integrated-test-websocket
           - shenyu-integrated-test-rewrite
           - shenyu-integrated-test-combination


### PR DESCRIPTION
PR #6308 has removed all SOFA-related code (client / plugin / examples / integrated-test / e2e modules). However the GitHub CI workflows still referenced the deleted SOFA test cases, which would cause CI jobs to fail because the corresponding modules and scripts no longer exist.


This PR removes the remaining SOFA references from the CI workflows:

- `.github/workflows/integrated-test.yml` — remove matrix case `shenyu-integrated-test-sofa`
- `.github/workflows/e2e-k8s.yml` — remove case `shenyu-e2e-case-sofa` (`e2e-sofa-sync-compose`)
- `.github/workflows/integrated-test-k8s-ingress.yml` — remove the commented-out `shenyu-integrated-test-k8s-ingress-sofa` line


- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
