### PR TITLE
infra(ci): run paths-filter once in a dedicated changes job instead of per matrix runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,31 +26,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        java: [17]
-        os: [ubuntu-latest, windows-latest]
-        include:
-          - java: 17
-            os: ubuntu-latest
-#          - java: 18
-#            os: ubuntu-latest
-          - java: 19
-            os: ubuntu-latest
-          - java: 20
-            os: ubuntu-latest
-          - java: 21
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    if: (github.repository == 'apache/shenyu')
+  changes:
+    if: github.repository == 'apache/shenyu'
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      code_files: ${{ steps.filter.outputs.code_files }}
     steps:
-      - name: Support longpaths
-        if: ${{ matrix.os == 'windows-latest'}}
-        run: git config --system core.longpaths true
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: ./actions/paths-filter
         id: filter
         with:
@@ -80,12 +63,37 @@ jobs:
               - 'mvnw.cmd'
               - '.mvn/**'
               - '.github/workflows/**'
+
+  build:
+    needs: changes
+    strategy:
+      matrix:
+        java: [17]
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - java: 17
+            os: ubuntu-latest
+#          - java: 18
+#            os: ubuntu-latest
+          - java: 19
+            os: ubuntu-latest
+          - java: 20
+            os: ubuntu-latest
+          - java: 21
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    if: github.repository == 'apache/shenyu' && needs.changes.outputs.code == 'true'
+    steps:
+      - name: Support longpaths
+        if: ${{ matrix.os == 'windows-latest'}}
+        run: git config --system core.longpaths true
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Debug - Show matched files
-        if: steps.filter.outputs.code == 'true'
         run: |
-          echo "Matched files: ${{ steps.filter.outputs.code_files }}"
+          echo "Matched files: ${{ needs.changes.outputs.code_files }}"
       - name: Restore ShenYu Maven Repos
-        if: steps.filter.outputs.code == 'true'
         id: restore-maven-cache
         uses: actions/cache/restore@v3
         with:
@@ -94,12 +102,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: ./actions/setup-java-with-retry
-        if: steps.filter.outputs.code == 'true'
         with:
           java-version: ${{ matrix.java }}
           distribution: "temurin"
       - name: Install mvnd
-        if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
           MVND_VERSION=1.0.2
@@ -120,12 +126,10 @@ jobs:
           fi
 
       - name: Verify mvnd installation
-        if: steps.filter.outputs.code == 'true'
         shell: bash
         run: mvnd --version || echo "mvnd version check failed, will use maven wrapper as fallback"
 
       - name: Build with Maven
-        if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -142,7 +146,6 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           token: 2760af6a-3405-4882-9e61-04c5176fecfa
-        if: steps.filter.outputs.code == 'true'
 
   check-license-header:
     name: check-license-header
@@ -162,9 +165,11 @@ jobs:
     name: build
     if: (github.repository == 'apache/shenyu') && always()
     needs:
+      - changes
       - build
     runs-on: ubuntu-latest
     steps:
       - name: checking job status
         run: |
-          [[ "${{ needs.build.result }}" == "success" ]] || exit -1
+          [[ "${{ needs.changes.result }}" == "success" ]] || exit -1
+          [[ "${{ needs.changes.outputs.code }}" != "true" || "${{ needs.build.result }}" == "success" ]] || exit -1

--- a/.github/workflows/integrated-test-k8s-ingress.yml
+++ b/.github/workflows/integrated-test-k8s-ingress.yml
@@ -26,21 +26,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        case:
-          - shenyu-integrated-test-k8s-ingress-http
-          - shenyu-integrated-test-k8s-ingress-apache-dubbo
-          - shenyu-integrated-test-k8s-ingress-websocket
-          - shenyu-integrated-test-k8s-ingress-grpc
-    runs-on: ubuntu-latest
+  changes:
     if: github.repository == 'apache/shenyu'
+    runs-on: ubuntu-latest
+    outputs:
+      k8s_ingress: ${{ steps.filter.outputs['k8s-ingress'] }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-
       - uses: ./actions/paths-filter
         id: filter
         with:
@@ -62,8 +54,23 @@ jobs:
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/PULL_REQUEST_TEMPLATE'
 
+  build:
+    needs: changes
+    strategy:
+      matrix:
+        case:
+          - shenyu-integrated-test-k8s-ingress-http
+          - shenyu-integrated-test-k8s-ingress-apache-dubbo
+          - shenyu-integrated-test-k8s-ingress-websocket
+          - shenyu-integrated-test-k8s-ingress-grpc
+    runs-on: ubuntu-latest
+    if: github.repository == 'apache/shenyu' && needs.changes.outputs.k8s_ingress == 'true'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
       - name: Clean Space
-        if: steps.filter.outputs.k8s-ingress == 'true'
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
@@ -71,7 +78,6 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - uses: ./actions/setup-java-with-retry
-        if: steps.filter.outputs.k8s-ingress == 'true'
         with:
           java-version: 17
           distribution: "temurin"
@@ -85,14 +91,12 @@ jobs:
           go-version: 1.17.x
 
       - name: Install k8s
-        if: steps.filter.outputs.k8s-ingress == 'true'
         run: |
           go install sigs.k8s.io/kind@v0.14.0
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.14/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
           kind create cluster --image=kindest/node:v1.21.1 --config=./shenyu-integrated-test/${{ matrix.case }}/deploy/kind-config.yaml
 
       - name: Install mvnd
-        if: steps.filter.outputs.k8s-ingress == 'true'
         shell: bash
         run: |
           MVND_VERSION=1.0.2
@@ -104,7 +108,6 @@ jobs:
           echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
 
       - name: Build with Maven
-        if: steps.filter.outputs.k8s-ingress == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -116,7 +119,6 @@ jobs:
           fi
 
       - name: Build integrated tests
-        if: steps.filter.outputs.k8s-ingress == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -128,7 +130,6 @@ jobs:
           fi
 
       - name: Build examples
-        if: steps.filter.outputs.k8s-ingress == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -140,19 +141,16 @@ jobs:
           fi
 
       - name: Build k8s Cluster
-        if: steps.filter.outputs.k8s-ingress == 'true'
         run: bash ./shenyu-integrated-test/${{ matrix.case }}/script/build_k8s_cluster.sh
 
       - name: Wait for k8s Cluster Start up
         id: healthcheck
-        if: steps.filter.outputs.k8s-ingress == 'true'
         timeout-minutes: 25
         run: |
           bash ./shenyu-integrated-test/${{ matrix.case }}/script/healthcheck.sh
 
       - name: Run test
         id: test
-        if: steps.filter.outputs.k8s-ingress == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -165,7 +163,7 @@ jobs:
         continue-on-error: true
 
       - name: Cluster Test after Healthcheck
-        if: always() && steps.filter.outputs.k8s-ingress == 'true'
+        if: always()
         run: |
           echo "----------kubectl get all -o wide----------"
           kubectl get all -o wide || true

--- a/.github/workflows/integrated-test-k8s-ingress.yml
+++ b/.github/workflows/integrated-test-k8s-ingress.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           filters: |
             k8s-ingress:
+              - '.github/workflows/integrated-test-k8s-ingress.yml'
               - 'shenyu-integrated-test-k8s-ingress*/**'
               - 'shenyu-*/**'
               - 'pom.xml'

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           filters: |
             integration:
+              - '.github/workflows/integrated-test.yml'
               - 'shenyu-integrated-test/**'
               - 'shenyu-*/**'
               - 'pom.xml'

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -26,37 +26,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        case:
-          - shenyu-integrated-test-apache-dubbo
-          - shenyu-integrated-test-grpc
-          - shenyu-integrated-test-http
-          - shenyu-integrated-test-https
-          - shenyu-integrated-test-spring-cloud
-          - shenyu-integrated-test-websocket
-          - shenyu-integrated-test-rewrite
-          - shenyu-integrated-test-combination
-          - shenyu-integrated-test-sdk-apache-dubbo
-          - shenyu-integrated-test-sdk-http
+  changes:
+    if: github.repository == 'apache/shenyu'
     runs-on: ubuntu-latest
-    if: (github.repository == 'apache/shenyu')
+    outputs:
+      integration: ${{ steps.filter.outputs.integration }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
-      # and https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          for image in $(docker image ls --all --quiet); do
-            docker rmi $image
-          done
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
       - uses: ./actions/paths-filter
         id: filter
         with:
@@ -77,8 +53,40 @@ jobs:
               - '!NOTICE'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/PULL_REQUEST_TEMPLATE'
+
+  build:
+    needs: changes
+    strategy:
+      matrix:
+        case:
+          - shenyu-integrated-test-apache-dubbo
+          - shenyu-integrated-test-grpc
+          - shenyu-integrated-test-http
+          - shenyu-integrated-test-https
+          - shenyu-integrated-test-spring-cloud
+          - shenyu-integrated-test-websocket
+          - shenyu-integrated-test-rewrite
+          - shenyu-integrated-test-combination
+          - shenyu-integrated-test-sdk-apache-dubbo
+          - shenyu-integrated-test-sdk-http
+    runs-on: ubuntu-latest
+    if: github.repository == 'apache/shenyu' && needs.changes.outputs.integration == 'true'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      # Copied from https://github.com/jens-maus/RaspberryMatic/blob/ea6b8ce0dd2d53ea88b2766ba8d7f8e1d667281f/.github/workflows/ci.yml#L34-L40
+      # and https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+      - name: Free disk space
+        run: |
+          df --human-readable
+          sudo apt clean
+          for image in $(docker image ls --all --quiet); do
+            docker rmi $image
+          done
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
       - uses: ./actions/setup-java-with-retry
-        if: steps.filter.outputs.integration == 'true'
         with:
           java-version: 17
           distribution: "temurin"
@@ -86,7 +94,6 @@ jobs:
           cache-dependency-path: |
             **/pom.xml
       - name: Install mvnd
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           MVND_VERSION=1.0.2
@@ -97,7 +104,6 @@ jobs:
           echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
           echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
       - name: Pre-pull docker base images
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           pull_with_retry() {
@@ -117,7 +123,6 @@ jobs:
           pull_with_retry centos:7
           pull_with_retry eclipse-temurin:17-centos7
       - name: Build with Maven
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -128,7 +133,6 @@ jobs:
             ./mvnw -B -T 1C clean install -Prelease,docker -Dmaven.javadoc.skip=true -Dmaven.test.skip=true
           fi
       - name: Build examples
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -139,7 +143,6 @@ jobs:
             ./mvnw -B -T 1C clean install -Pexample -Dmaven.javadoc.skip=true -Dmaven.test.skip=true -am -f ./shenyu-examples/pom.xml
           fi
       - name: Build integrated tests
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -150,17 +153,14 @@ jobs:
             ./mvnw -B -T 1C clean install -Pit -DskipTests -f ./shenyu-integrated-test/pom.xml
           fi
       - name: Start docker compose
-        if: steps.filter.outputs.integration == 'true'
         run: docker compose -f ./shenyu-integrated-test/${{ matrix.case }}/docker-compose.yml up -d
       - name: Wait for docker compose start up completely
-        if: steps.filter.outputs.integration == 'true'
         run: bash ./shenyu-integrated-test/${{ matrix.case }}/script/healthcheck.sh
       - name: Disk space info
         run: |
           df --human-readable
       - name: Run test
         id: test
-        if: steps.filter.outputs.integration == 'true'
         shell: bash
         run: |
           if mvnd --version > /dev/null 2>&1; then
@@ -172,7 +172,6 @@ jobs:
           fi
         continue-on-error: true
       - name: Check test result
-        if: steps.filter.outputs.integration == 'true'
         run: |
           docker compose -f ./shenyu-integrated-test/${{ matrix.case }}/docker-compose.yml logs --tail="all"
           if [[ ${{steps.test.outcome}} == "failure" ]]; then


### PR DESCRIPTION
### What changes are proposed?

Extract `paths-filter` from the matrix `build` job into a standalone `changes` job in `ci.yml`, `integrated-test.yml` and `integrated-test-k8s-ingress.yml`. The filter result is exposed as a job output and used to gate the whole `build` job, replacing the per-step `if: steps.filter.outputs.* == 'true'` guards.

### Why?

Previously every matrix leg checked out the repo and re-ran the same filter just to decide it had nothing to do — 5 legs in `ci`, 10 in `it`, 4 in `it-k8s`. Filtering once and skipping the job outright removes that redundant work, and drops ~20 duplicated `if:` guards that had to be kept in sync by hand.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
