### PR TITLE
infra(ci): use maven wrapper instead of mvnd on Windows to avoid daemon crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,42 +106,34 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: "temurin"
       - name: Install mvnd
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           MVND_VERSION=1.0.2
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
-            unzip -q mvnd.zip
-            mkdir -p $HOME/.local
-            mv maven-mvnd-${MVND_VERSION}-windows-amd64 $HOME/.local/mvnd
-            echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
-            echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
-          else
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
-            unzip -q mvnd.zip
-            mkdir -p $HOME/.local
-            mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd
-            echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
-            echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
-          fi
+          curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+          unzip -q mvnd.zip
+          mkdir -p $HOME/.local
+          mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd
+          echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
+          echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
 
       - name: Verify mvnd installation
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: mvnd --version || echo "mvnd version check failed, will use maven wrapper as fallback"
 
       - name: Build with Maven
         shell: bash
         run: |
-          if mvnd --version > /dev/null 2>&1; then
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            echo "Building with maven wrapper on Windows"
+            ./mvnw.cmd -B clean test -Prelease
+          elif mvnd --version > /dev/null 2>&1; then
             echo "Using mvnd for build"
             mvnd -B clean test -Prelease
           else
             echo "Falling back to maven wrapper"
-            if [[ "${{ runner.os }}" == "Windows" ]]; then
-              ./mvnw.cmd -B clean test -Prelease
-            else
-              ./mvnw -B clean test -Prelease
-            fi
+            ./mvnw -B clean test -Prelease
           fi
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
### What

On the Windows leg of the `ci` workflow, build with `./mvnw.cmd` instead of `mvnd`. mvnd is no longer installed or run on Windows; Linux legs are unchanged.

### Why

After #6435 merged, `build (17, windows-latest)` failed in "Build with Maven":
```java
 java.nio.charset.MalformedInputException: Input length = 1
        at org.mvndaemon.mvnd.client.DaemonDiagnostics.tail(...)

```

The mvnd daemon (mvnd 1.0.2 / bundled JDK 22) dies mid-build; the client then reads a non-UTF-8 daemon log with the platform charset and throws, masking the real error. It reproduces reliably on Windows (non-UTF-8 default charset) while Linux passes, and the `mvnd --version` guard can't catch it since the daemon dies during the build, not at startup. Skipping mvnd on Windows removes the path.

Not caused by #6435 — that PR only refactored paths-filter and touched no build command. Pre-existing Windows/mvnd flake.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
