### PR TITLE
infra(ci): skip redundant disk cleanup in path-filter-only jobs

### DIFF
--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -34,15 +34,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          for image in $(docker image ls --all --quiet); do
-            docker rmi $image
-          done
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
       - uses: ./actions/paths-filter
         id: filter
         with:

--- a/.github/workflows/k8s-examples-http.yml
+++ b/.github/workflows/k8s-examples-http.yml
@@ -33,15 +33,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Free disk space
-        run: |
-          df --human-readable
-          sudo apt clean
-          for image in $(docker image ls --all --quiet); do
-            docker rmi $image
-          done
-          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-          df --human-readable
       - uses: ./actions/paths-filter
         id: filter
         with:
@@ -61,6 +52,16 @@ jobs:
               - '!NOTICE'
               - '!.github/ISSUE_TEMPLATE/**'
               - '!.github/PULL_REQUEST_TEMPLATE'
+      - name: Free disk space
+        if: steps.filter.outputs.k8s-examples == 'true'
+        run: |
+          df --human-readable
+          sudo apt clean
+          for image in $(docker image ls --all --quiet); do
+            docker rmi $image
+          done
+          rm --recursive --force "$AGENT_TOOLSDIRECTORY"
+          df --human-readable
       - name: Install k8s
         if: steps.filter.outputs.k8s-examples == 'true'
         run: |


### PR DESCRIPTION
The "Free disk space" step takes several minutes but ran even when the paths-filter would skip the actual work.

- **e2e-k8s.yml**: remove it from the filter-only `changes` job; all build jobs keep their own cleanup steps.
- **k8s-examples-http.yml**: single-job workflow, so move the step after the paths-filter and gate it with `if: steps.filter.outputs.k8s-examples == 'true'`, same as other steps.

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
