### PR TITLE
fix: use OpenGauss profile and dialect in docker-compose E2E storage

### DIFF
--- a/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml
+++ b/shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml
@@ -53,8 +53,8 @@ services:
       - "31095:9095"
     environment:
       - TZ=Asia/Beijing
-      - SPRING_PROFILES_ACTIVE=mysql
-      - shenyu.database.dialect=mysql
+      - SPRING_PROFILES_ACTIVE=og
+      - shenyu.database.dialect=opengauss
       - shenyu.database.init_enable=true
       - spring.datasource.username=gaussdb
       - spring.datasource.password=ShenYuE2E@123


### PR DESCRIPTION
  shenyu-storage-opengauss.yml incorrectly used SPRING_PROFILES_ACTIVE=mysql
  and shenyu.database.dialect=mysql while connecting to an OpenGauss database
  (jdbc:opengauss://). This caused the OpenGauss-specific MyBatis SQL
  interceptors (backtick-to-double-quote rewriting, dateUpdated auto-fill,
  boolean type handler) to not be registered, making MySQL-style SQL with
  backticks get sent to OpenGauss unmodified.

  Changed to SPRING_PROFILES_ACTIVE=og and shenyu.database.dialect=opengauss,
  consistent with application-og.yml and the Kubernetes OpenGauss E2E
  deployment manifests.

  fix : https://github.com/apache/shenyu/issues/6443
  Make sure that:

  - [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
  - [ ] You submit test cases (unit or integration tests) that back your changes.
  - [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
