### PR TITLE
fix: JWT plugin throws ArrayIndexOutOfBoundsException on malformed Authorization header

### DIFF
--- a/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/JwtPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/JwtPlugin.java
@@ -98,19 +98,21 @@ public class JwtPlugin extends AbstractShenyuPlugin {
      * @return the authorization after processing
      */
     private String compatible(final String token, final String authorization) {
-        String finalAuthorization;
         if (StringUtils.isNotEmpty(token)) {
-            finalAuthorization = token;
-        } else if (StringUtils.isNotEmpty(authorization)) {
-            finalAuthorization = authorization;
-        } else {
+            return token;
+        }
+        if (StringUtils.isEmpty(authorization)) {
             return null;
         }
-        return isAuth2(finalAuthorization) ? finalAuthorization.split(" ")[1] : finalAuthorization;
+        if (isAuth2(authorization)) {
+            String jwtToken = authorization.substring(AUTH2_TOKEN.length()).trim();
+            return StringUtils.isEmpty(jwtToken) ? null : jwtToken;
+        }
+        return authorization;
     }
 
     private boolean isAuth2(final String authorization) {
-        return authorization.contains(AUTH2_TOKEN);
+        return authorization.startsWith(AUTH2_TOKEN + " ");
     }
 
     /**

--- a/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/test/java/org/apache/shenyu/plugin/jwt/JwtPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/test/java/org/apache/shenyu/plugin/jwt/JwtPluginTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -131,6 +132,67 @@ public final class JwtPluginTest {
     public void testGetOrder() {
         final int result = jwtPluginUnderTest.getOrder();
         Assertions.assertEquals(PluginEnum.JWT.getCode(), result);
+    }
+
+    @Test
+    public void testBearerWithoutToken() {
+        ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest
+                .get("localhost")
+                .header("Authorization", "Bearer")
+                .build());
+
+        Mono<Void> mono = jwtPluginUnderTest.doExecute(exchange, chain, selectorData, ruleData);
+        StepVerifier.create(mono).expectSubscription().verifyComplete();
+        verify(chain, never()).execute(any());
+    }
+
+    @Test
+    public void testAuthorizationNotBearerPrefix() {
+        ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest
+                .get("localhost")
+                .header("Authorization", "fooBearerbar")
+                .build());
+
+        Mono<Void> mono = jwtPluginUnderTest.doExecute(exchange, chain, selectorData, ruleData);
+        StepVerifier.create(mono).expectSubscription().verifyComplete();
+        verify(chain, never()).execute(any());
+    }
+
+    @Test
+    public void testBearerWithWhitespaceOnlyToken() {
+        ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest
+                .get("localhost")
+                .header("Authorization", "Bearer  ")
+                .build());
+
+        Mono<Void> mono = jwtPluginUnderTest.doExecute(exchange, chain, selectorData, ruleData);
+        StepVerifier.create(mono).expectSubscription().verifyComplete();
+        verify(chain, never()).execute(any());
+    }
+
+    @Test
+    public void testValidBearerAuthorization() {
+        ruleData.setHandle("{\"converter\":[{\"jwtVal\":\"userId\",\"headerVal\":\"id\"}]}");
+        jwtPluginDataHandlerUnderTest.handlerRule(ruleData);
+        when(chain.execute(any())).thenReturn(Mono.empty());
+
+        final String secreteKey = "shenyu-test-shenyu-test-shenyu-test";
+        Map<String, Object> map = ImmutableMap.<String, Object>builder().put("userId", 1).build();
+        String jwtToken = Jwts.builder()
+                .claims(map)
+                .issuedAt(new Date(1636371125000L))
+                .expiration(new Date(new Date().getTime() + 10000L))
+                .signWith(Keys.hmacShaKeyFor(secreteKey.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+
+        ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest
+                .get("localhost")
+                .header("Authorization", "Bearer " + jwtToken)
+                .build());
+
+        Mono<Void> mono = jwtPluginUnderTest.doExecute(exchange, chain, selectorData, ruleData);
+        StepVerifier.create(mono).expectSubscription().verifyComplete();
+        verify(chain).execute(any());
     }
 
     private void initContext() {


### PR DESCRIPTION
Use strict startsWith("Bearer ") check instead of contains("Bearer") and
handle empty tokens gracefully instead of accessing split[1] directly.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

Related Changes:
- Update JwtPlugin class

Test Cases:
- Add testBearerWithoutToken
- Add testAuthorizationNotBearerPrefix
- Add testBearerWithWhitespaceOnlyToken
- Add testValidBearerAuthorization

close [#6439](https://github.com/apache/shenyu/issues/6439)
