### PR TITLE
fix(admin): guard against null servers and parameters in Swagger MCP import

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java
@@ -216,6 +216,10 @@ public class SwaggerImportServiceImpl implements SwaggerImportService {
     private MetaDataRegisterDTO buildMetaDataRegisterDTO(final OpenAPI openapi, final String selectorName,
                                                          final ShenyuMcpTool shenyuMcpTool, final String contentPath,
                                                          final String namespaceId) {
+        if (Objects.isNull(openapi.getServers()) || openapi.getServers().isEmpty()) {
+            throw new IllegalArgumentException("OpenAPI document is missing the top-level 'servers' field, which is required for MCP import. "
+                + "Please add a servers section, e.g.: servers: [{ url: 'http://localhost:8080' }]");
+        }
         String urlString = openapi.getServers().get(0).getUrl();
         URL url;
         try {
@@ -227,10 +231,12 @@ public class SwaggerImportServiceImpl implements SwaggerImportService {
         String host = url.getHost();
         int port = url.getPort();
         Operation operation = shenyuMcpTool.getOperation();
-        String parameterTypes = operation.getParameters()
-                .stream()
-                .map(Parameter::getIn)
-                .collect(Collectors.joining(","));
+        String parameterTypes = Objects.isNull(operation.getParameters())
+                ? ""
+                : operation.getParameters()
+                        .stream()
+                        .map(Parameter::getIn)
+                        .collect(Collectors.joining(","));
 
         return MetaDataRegisterDTO.builder()
                 .appName(openapi.getInfo().getTitle())

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java
@@ -17,6 +17,10 @@
 
 package org.apache.shenyu.admin.service.impl;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -29,6 +33,8 @@ import org.apache.shenyu.admin.model.bean.UpstreamInstance;
 import org.apache.shenyu.admin.model.dto.SwaggerImportRequest;
 import org.apache.shenyu.admin.service.manager.DocManager;
 import org.apache.shenyu.admin.utils.HttpUtils;
+import org.apache.shenyu.client.mcp.common.dto.ShenyuMcpTool;
+import org.apache.shenyu.register.common.dto.MetaDataRegisterDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -38,10 +44,12 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -124,6 +132,49 @@ public class SwaggerImportServiceImplTest {
                 "readLimitedResponseBody", responseBody, 10L);
 
         assertEquals(body, result);
+    }
+
+    @Test
+    public void buildMetaDataRegisterDTOShouldThrowWhenServersIsNull() {
+        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
+        OpenAPI openapi = new OpenAPI()
+                .info(new Info().title("test"));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                ReflectionTestUtils.invokeMethod(service, "buildMetaDataRegisterDTO",
+                        openapi, "test", new ShenyuMcpTool(), "/ping", "ns1"));
+    }
+
+    @Test
+    public void buildMetaDataRegisterDTOShouldThrowWhenServersIsEmpty() {
+        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
+        OpenAPI openapi = new OpenAPI()
+                .info(new Info().title("test"))
+                .servers(Collections.emptyList());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                ReflectionTestUtils.invokeMethod(service, "buildMetaDataRegisterDTO",
+                        openapi, "test", new ShenyuMcpTool(), "/ping", "ns1"));
+    }
+
+    @Test
+    public void buildMetaDataRegisterDTOShouldHandleNullParameters() {
+        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
+        OpenAPI openapi = new OpenAPI()
+                .info(new Info().title("test"))
+                .servers(List.of(new Server().url("http://localhost:8080")));
+        Operation operation = new Operation()
+                .operationId("ping")
+                .parameters(null);
+        ShenyuMcpTool tool = new ShenyuMcpTool();
+        tool.setOperation(operation);
+        tool.setToolName("ping");
+
+        MetaDataRegisterDTO result = ReflectionTestUtils.invokeMethod(service, "buildMetaDataRegisterDTO",
+                openapi, "test", tool, "/ping", "ns1");
+
+        assertNotNull(result);
+        assertEquals("", result.getParameterTypes());
     }
 
     private SwaggerImportRequest request() {


### PR DESCRIPTION
Null-guard openapi.getServers() and operation.getParameters() to avoid
NPE/IndexOutOfBoundsException when importing valid OpenAPI 3 documents
that omit top-level servers or operation parameters.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary of the changes: 
### SwaggerImportServiceImpl.java:                                               
  - Line 219: Added null/empty guard for openapi.getServers(), throwing a clear                  
  IllegalArgumentException instead of NPE/IOOBE when the OpenAPI document lacks a top-level      
  servers field. The importMcpConfig caller already catches IllegalArgumentException and surfaces
   it as HTTP 400.                                                                               
  - Line 234: Added null guard for operation.getParameters(), defaulting to an empty string ""
  for parameterTypes when an operation declares no parameters.                                
                                                                                                 
 ### Unit tests (SwaggerImportServiceImplTest.java — 3 new tests):
  - buildMetaDataRegisterDTOShouldThrowWhenServersIsNull — verifies IllegalArgumentException when
   servers is null                                                                               
  - buildMetaDataRegisterDTOShouldThrowWhenServersIsEmpty — verifies IllegalArgumentException    
  when servers list is empty                                                                     
  - buildMetaDataRegisterDTOShouldHandleNullParameters — verifies parameterTypes is "" and       
  MetaDataRegisterDTO is built successfully when operation.parameters is null

close [#6440](https://github.com/apache/shenyu/issues/6440)
