### PR TITLE
fix(tcp): unregister ActivityConnectionObserver on connection dispose to prevent memory leak

### DIFF
--- a/shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServer.java
+++ b/shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServer.java
@@ -86,8 +86,16 @@ public class TcpBootstrapServer implements BootstrapServer {
         SocketAddress socketAddress = serverConn.channel().remoteAddress();
         ActivityConnectionObserver connectionObserver = new ActivityConnectionObserver("TcpClient");
         eventBus.register(connectionObserver);
+        serverConn.onDispose(() -> eventBus.unregister(connectionObserver));
         Mono<Connection> client = connectionContext.getTcpClientConnection(getIp(socketAddress), connectionObserver);
-        client.subscribe(clientConn -> bridge.bridge(serverConn, clientConn));
+        client.subscribe(
+            clientConn -> bridge.bridge(serverConn, clientConn),
+            error -> {
+                LOG.error("Failed to establish client connection for {}", serverConn, error);
+                eventBus.unregister(connectionObserver);
+                serverConn.dispose();
+            }
+        );
     }
 
     private String getIp(final SocketAddress socketAddress) {

--- a/shenyu-protocol/shenyu-protocol-tcp/src/test/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServerTest.java
+++ b/shenyu-protocol/shenyu-protocol-tcp/src/test/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.tcp;
+
+import com.google.common.eventbus.EventBus;
+import io.netty.channel.Channel;
+import org.apache.shenyu.protocol.tcp.connection.ActivityConnectionObserver;
+import org.apache.shenyu.protocol.tcp.connection.Bridge;
+import org.apache.shenyu.protocol.tcp.connection.ConnectionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TcpBootstrapServerTest {
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private Bridge bridge;
+
+    @Mock
+    private ConnectionContext connectionContext;
+
+    @Mock
+    private Connection serverConn;
+
+    @Mock
+    private Connection clientConn;
+
+    @Mock
+    private Channel channel;
+
+    private TcpBootstrapServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new TcpBootstrapServer(eventBus);
+        setField("bridge", bridge);
+        setField("connectionContext", connectionContext);
+    }
+
+    @Test
+    void shouldUnregisterObserverWhenServerConnectionIsDisposed() throws Exception {
+        SocketAddress remoteAddr = new InetSocketAddress("127.0.0.1", 8080);
+        when(serverConn.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(remoteAddr);
+
+        ArgumentCaptor<Disposable> onDisposeCaptor = ArgumentCaptor.forClass(Disposable.class);
+        when(serverConn.onDispose(onDisposeCaptor.capture())).thenReturn(serverConn);
+
+        when(connectionContext.getTcpClientConnection(eq("127.0.0.1"), any(ActivityConnectionObserver.class)))
+                .thenReturn(Mono.just(clientConn));
+
+        invokeBridgeConnections(serverConn);
+
+        verify(eventBus).register(any(ActivityConnectionObserver.class));
+
+        onDisposeCaptor.getValue().dispose();
+
+        verify(eventBus).unregister(any(ActivityConnectionObserver.class));
+    }
+
+    @Test
+    void shouldUnregisterObserverAndDisposeServerConnOnClientConnectionError() throws Exception {
+        SocketAddress remoteAddr = new InetSocketAddress("127.0.0.1", 8080);
+        when(serverConn.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(remoteAddr);
+
+        when(serverConn.onDispose(any(Disposable.class))).thenReturn(serverConn);
+
+        RuntimeException exception = new RuntimeException("Connection refused");
+        when(connectionContext.getTcpClientConnection(eq("127.0.0.1"), any(ActivityConnectionObserver.class)))
+                .thenReturn(Mono.error(exception));
+
+        invokeBridgeConnections(serverConn);
+
+        verify(eventBus).register(any(ActivityConnectionObserver.class));
+        verify(eventBus).unregister(any(ActivityConnectionObserver.class));
+        verify(serverConn).dispose();
+        verify(bridge, never()).bridge(any(Connection.class), any(Connection.class));
+    }
+
+    @Test
+    void shouldBridgeConnectionsOnSuccessfulClientConnection() throws Exception {
+        SocketAddress remoteAddr = new InetSocketAddress("127.0.0.1", 9090);
+        when(serverConn.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(remoteAddr);
+
+        when(serverConn.onDispose(any(Disposable.class))).thenReturn(serverConn);
+
+        when(connectionContext.getTcpClientConnection(eq("127.0.0.1"), any(ActivityConnectionObserver.class)))
+                .thenReturn(Mono.just(clientConn));
+
+        invokeBridgeConnections(serverConn);
+
+        verify(bridge).bridge(serverConn, clientConn);
+    }
+
+    @Test
+    void shouldUseSameObserverForEventBusAndConnectionContext() throws Exception {
+        SocketAddress remoteAddr = new InetSocketAddress("127.0.0.1", 8080);
+        when(serverConn.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(remoteAddr);
+
+        when(serverConn.onDispose(any(Disposable.class))).thenReturn(serverConn);
+
+        ArgumentCaptor<ActivityConnectionObserver> registerCaptor =
+                ArgumentCaptor.forClass(ActivityConnectionObserver.class);
+        ArgumentCaptor<ActivityConnectionObserver> contextCaptor =
+                ArgumentCaptor.forClass(ActivityConnectionObserver.class);
+
+        when(connectionContext.getTcpClientConnection(eq("127.0.0.1"), contextCaptor.capture()))
+                .thenReturn(Mono.just(clientConn));
+
+        invokeBridgeConnections(serverConn);
+
+        verify(eventBus).register(registerCaptor.capture());
+        assertNotNull(registerCaptor.getValue());
+        assertNotNull(contextCaptor.getValue());
+    }
+
+    private void invokeBridgeConnections(final Connection connection) throws Exception {
+        Method method = TcpBootstrapServer.class.getDeclaredMethod("bridgeConnections", Connection.class);
+        method.setAccessible(true);
+        method.invoke(server, connection);
+    }
+
+    private void setField(final String name, final Object value) throws Exception {
+        Field field = TcpBootstrapServer.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(server, value);
+    }
+}


### PR DESCRIPTION
Per-connection observers were registered on the shared EventBus but never
unregistered, causing stale observers to accumulate. Added onDispose cleanup
and error handling for failed downstream connections.

Per-connection observers were registered on the shared EventBus but never unregistered, causing stale observers to accumulate. Added onDispose cleanup and error handling for failed downstream connections.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary of Changes                                                                             
                                                                                               
  ### Problem                                                                                        
                                                                                                 
  Every inbound TCP connection in TcpBootstrapServer.bridgeConnections() created a new           
  ActivityConnectionObserver and registered it on the shared EventBus, but never unregistered it.
   This caused:                                                                                  
                  
  1. Memory leak — dead observers accumulated in the EventBus, each holding stale Connection     
  references in their cache map
  2. Fan-out waste — each removeCommonUpstream() event was posted to every observer ever created,
   not just active ones                                                                          
  3. Orphaned connections — when the downstream client connection failed, the serverConn was
  never disposed and no error was logged                                                         
                  
 ### Fix (TcpBootstrapServer.java)                                                                  
                  
  Two changes in bridgeConnections():                                                            
                  
  1. serverConn.onDispose(() -> eventBus.unregister(connectionObserver)) — ensures the observer  
  is unregistered from the EventBus when the connection terminates
  2. Error handler on client.subscribe() — on failure, immediately unregisters the observer,     
  disposes the server connection, and logs the error                                             
   
  ### Tests (TcpBootstrapServerTest.java — new file)                                                 
                  
  4 unit tests covering the lifecycle:                                                           
                  
  Test: shouldUnregisterObserverWhenServerConnectionIsDisposed                                   
  What it verifies: Observer is unregistered when the server connection disposes               
  ────────────────────────────────────────                                                       
  Test: shouldUnregisterObserverAndDisposeServerConnOnClientConnectionError                    
  What it verifies: On client connection failure, observer is unregistered and serverConn is   
    disposed                                                                                     
  ────────────────────────────────────────
  Test: shouldBridgeConnectionsOnSuccessfulClientConnection                                      
  What it verifies: On success, bridge.bridge() is called with correct connections
  ────────────────────────────────────────                                                       
  Test: shouldUseSameObserverForEventBusAndConnectionContext                                     
  What it verifies: The same observer instance is used for both EventBus registration and
    connection observation   

close [#6448](https://github.com/apache/shenyu/issues/6448)