### PR TITLE
fix(admin): enforce response body size limit on automatic swagger doc pull

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
+
 import org.apache.shenyu.admin.model.bean.UpstreamInstance;
 import org.apache.shenyu.admin.model.dto.SwaggerImportRequest;
 import org.apache.shenyu.admin.service.SwaggerImportService;
@@ -47,13 +47,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,17 +67,12 @@ public class SwaggerImportServiceImpl implements SwaggerImportService {
     
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerImportServiceImpl.class);
 
-    private static final int READ_BUFFER_SIZE = 8192;
-
-    private static final long DEFAULT_MAX_SWAGGER_BODY_SIZE = 10L * 1024 * 1024;
-
     private final DocManager docManager;
-    
+
     private final HttpUtils httpUtils;
 
-    // Default is 10 MB and can be overridden by shenyu.swagger.max-body-size.
     @Value("${shenyu.swagger.max-body-size:10485760}")
-    private long maxSwaggerBodySize = DEFAULT_MAX_SWAGGER_BODY_SIZE;
+    private long maxSwaggerBodySize;
 
     @Resource
     private ShenyuClientRegisterMcpServiceImpl shenyuClientRegisterMcpService;
@@ -275,49 +266,12 @@ public class SwaggerImportServiceImpl implements SwaggerImportService {
                 throw new RuntimeException("Failed to get Swagger document, HTTP status code: " + response.code());
             }
 
-            return readLimitedResponseBody(response.body(), maxSwaggerBodySize);
+            return HttpUtils.readLimitedResponseBody(response.body(), maxSwaggerBodySize);
         }
     }
 
 
-    private String readLimitedResponseBody(final ResponseBody responseBody, final long maxBodySize) throws IOException {
-        if (Objects.isNull(responseBody)) {
-            throw new IllegalArgumentException("Swagger document response body is empty");
-        }
-        if (maxBodySize < 0) {
-            throw new IllegalArgumentException("Max Swagger response body size must not be negative");
-        }
 
-        long contentLength = responseBody.contentLength();
-        // Reject early when the server declares a body larger than the configured limit.
-        if (contentLength > maxBodySize) {
-            throw new IllegalArgumentException(String.format(
-                    "Swagger document response body exceeds maximum size of %d bytes", maxBodySize));
-        }
-
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        byte[] buffer = new byte[READ_BUFFER_SIZE];
-        long totalBytes = 0;
-        try (InputStream inputStream = responseBody.byteStream()) {
-            int bytesRead;
-            while ((bytesRead = inputStream.read(buffer)) != -1) {
-                totalBytes += bytesRead;
-                // Content-Length can be missing or wrong, so enforce the limit while streaming.
-                if (totalBytes > maxBodySize) {
-                    throw new IllegalArgumentException(String.format(
-                            "Swagger document response body exceeds maximum size of %d bytes", maxBodySize));
-                }
-                outputStream.write(buffer, 0, bytesRead);
-            }
-        }
-
-        // Preserve the server-declared charset; default to UTF-8 when it is absent.
-        Charset charset = Objects.isNull(responseBody.contentType())
-                ? StandardCharsets.UTF_8
-                : responseBody.contentType().charset(StandardCharsets.UTF_8);
-        return outputStream.toString(charset.name());
-    }
-    
     private void validateSwaggerContent(final String swaggerJson) {
         try {
             JsonObject docRoot = GsonUtils.getInstance().fromJson(swaggerJson, JsonObject.class);

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/PullSwaggerDocServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/PullSwaggerDocServiceImpl.java
@@ -36,6 +36,7 @@ import org.apache.shenyu.common.constant.AdminConstants;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -61,6 +62,9 @@ public class PullSwaggerDocServiceImpl implements PullSwaggerDocService {
     private static final long PULL_MIN_INTERVAL_TIME = 30 * 1000;
 
     private static final long DOC_LOCK_EXPIRED_TIME = 60 * 1000;
+
+    @Value("${shenyu.swagger.max-body-size:10485760}")
+    private long maxSwaggerBodySize;
 
     private final Interner<Object> interner = Interners.newWeakInterner();
 
@@ -102,7 +106,7 @@ public class PullSwaggerDocServiceImpl implements PullSwaggerDocService {
             if (response.code() != HttpStatus.SC_OK) {
                 throw new IOException(response.toString());
             }
-            final String body = response.body().string();
+            final String body = HttpUtils.readLimitedResponseBody(response.body(), maxSwaggerBodySize);
             docManager.addDocInfo(
                 instance,
                 body,

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/HttpUtils.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/HttpUtils.java
@@ -43,6 +43,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -62,6 +63,8 @@ public class HttpUtils {
     private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
 
     private static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private static final int READ_BUFFER_SIZE = 8192;
 
     private Map<String, List<Cookie>> cookieStore = new HashMap<>();
 
@@ -458,6 +461,52 @@ public class HttpUtils {
         public String value() {
             return this.name();
         }
+    }
+
+    /**
+     * Read response body with a size limit to prevent excessive memory usage.
+     *
+     * @param responseBody the response body to read
+     * @param maxBodySize  maximum allowed body size in bytes
+     * @return the response body as a string
+     * @throws IOException              if an I/O error occurs
+     * @throws IllegalArgumentException if the body exceeds maxBodySize
+     */
+    public static String readLimitedResponseBody(final ResponseBody responseBody, final long maxBodySize) throws IOException {
+        if (Objects.isNull(responseBody)) {
+            throw new IllegalArgumentException("Response body is empty");
+        }
+        if (maxBodySize < 0) {
+            throw new IllegalArgumentException("Max response body size must not be negative");
+        }
+
+        long contentLength = responseBody.contentLength();
+        if (contentLength > maxBodySize) {
+            throw new IllegalArgumentException(String.format(
+                    "Response body exceeds maximum size of %d bytes", maxBodySize));
+        }
+
+        ByteArrayOutputStream outputStream = contentLength > 0
+                ? new ByteArrayOutputStream((int) Math.min(contentLength, Integer.MAX_VALUE))
+                : new ByteArrayOutputStream();
+        byte[] buffer = new byte[READ_BUFFER_SIZE];
+        long totalBytes = 0;
+        try (InputStream inputStream = responseBody.byteStream()) {
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                totalBytes += bytesRead;
+                if (totalBytes > maxBodySize) {
+                    throw new IllegalArgumentException(String.format(
+                            "Response body exceeds maximum size of %d bytes", maxBodySize));
+                }
+                outputStream.write(buffer, 0, bytesRead);
+            }
+        }
+
+        Charset charset = Objects.isNull(responseBody.contentType())
+                ? StandardCharsets.UTF_8
+                : responseBody.contentType().charset(StandardCharsets.UTF_8);
+        return outputStream.toString(charset.name());
     }
 
     public static class HttpToolConfig {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java
@@ -55,19 +55,24 @@ public class SwaggerImportServiceImplTest {
 
     private static final MediaType JSON_UTF_8 = MediaType.parse("application/json; charset=utf-8");
 
+    private static final long DEFAULT_MAX_SWAGGER_BODY_SIZE = 10L * 1024 * 1024;
+
     private RecordingDocManager docManager;
 
     private StubHttpUtils httpUtils;
+
+    private SwaggerImportServiceImpl service;
 
     @BeforeEach
     public void setUp() {
         docManager = new RecordingDocManager();
         httpUtils = new StubHttpUtils();
+        service = new SwaggerImportServiceImpl(docManager, httpUtils);
+        ReflectionTestUtils.setField(service, "maxSwaggerBodySize", DEFAULT_MAX_SWAGGER_BODY_SIZE);
     }
 
     @Test
     public void importSwaggerShouldReadSmallSwaggerBody() throws IOException {
-        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
         httpUtils.setResponse(response(responseBody(
                 SWAGGER_JSON, SWAGGER_JSON.getBytes(StandardCharsets.UTF_8).length, JSON_UTF_8)));
 
@@ -79,7 +84,6 @@ public class SwaggerImportServiceImplTest {
 
     @Test
     public void importSwaggerShouldRejectKnownContentLengthGreaterThanLimit() throws IOException {
-        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
         ReflectionTestUtils.setField(service, "maxSwaggerBodySize", 10L);
         httpUtils.setResponse(response(responseBody("small", 11L, JSON_UTF_8)));
 
@@ -88,42 +92,10 @@ public class SwaggerImportServiceImplTest {
 
     @Test
     public void importSwaggerShouldRejectUnknownContentLengthWhenActualBodyExceedsLimit() throws IOException {
-        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
         ReflectionTestUtils.setField(service, "maxSwaggerBodySize", 10L);
         httpUtils.setResponse(response(responseBody("01234567890", -1L, JSON_UTF_8)));
 
         assertThrows(IllegalArgumentException.class, () -> service.importSwagger(request()));
-    }
-
-    @Test
-    public void readLimitedResponseBodyShouldAllowBodyExactlyEqualToLimit() throws IOException {
-        String body = "0123456789";
-
-        String result = ReflectionTestUtils.invokeMethod(new SwaggerImportServiceImpl(docManager, httpUtils),
-                "readLimitedResponseBody", responseBody(body, -1L, JSON_UTF_8), 10L);
-
-        assertEquals(body, result);
-    }
-
-    @Test
-    public void readLimitedResponseBodyShouldHandleNullBodySafely() {
-        SwaggerImportServiceImpl service = new SwaggerImportServiceImpl(docManager, httpUtils);
-
-        assertThrows(IllegalArgumentException.class, () ->
-                ReflectionTestUtils.invokeMethod(service, "readLimitedResponseBody", null, 10L));
-    }
-
-    @Test
-    public void readLimitedResponseBodyShouldUseResponseCharset() throws IOException {
-        Charset charset = StandardCharsets.ISO_8859_1;
-        byte[] bytes = new byte[] {'c', 'a', 'f', (byte) 0xE9};
-        String body = new String(bytes, charset);
-        ResponseBody responseBody = responseBody(bytes, -1L, MediaType.parse("text/plain; charset=iso-8859-1"));
-
-        String result = ReflectionTestUtils.invokeMethod(new SwaggerImportServiceImpl(docManager, httpUtils),
-                "readLimitedResponseBody", responseBody, 10L);
-
-        assertEquals(body, result);
     }
 
     private SwaggerImportRequest request() {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,8 +31,12 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -418,6 +423,107 @@ public class HttpUtilsTest {
         } finally {
             server.stop(0);
         }
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldReadWithinLimit() throws IOException {
+        String body = "hello";
+        ResponseBody responseBody = responseBody(body.getBytes(StandardCharsets.UTF_8),
+                body.getBytes(StandardCharsets.UTF_8).length,
+                MediaType.parse("application/json; charset=utf-8"));
+
+        String result = HttpUtils.readLimitedResponseBody(responseBody, 1024);
+
+        Assert.assertEquals(body, result);
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldAllowBodyExactlyEqualToLimit() throws IOException {
+        String body = "0123456789";
+
+        String result = HttpUtils.readLimitedResponseBody(
+                responseBody(body.getBytes(StandardCharsets.UTF_8), -1L,
+                        MediaType.parse("text/plain")), 10L);
+
+        Assert.assertEquals(body, result);
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldRejectContentLengthGreaterThanLimit() {
+        ResponseBody responseBody = responseBody("small".getBytes(StandardCharsets.UTF_8), 11L,
+                MediaType.parse("application/json"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HttpUtils.readLimitedResponseBody(responseBody, 10L));
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldRejectActualBodyExceedingLimit() {
+        ResponseBody responseBody = responseBody("01234567890".getBytes(StandardCharsets.UTF_8), -1L,
+                MediaType.parse("application/json"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HttpUtils.readLimitedResponseBody(responseBody, 10L));
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldThrowOnNullBody() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HttpUtils.readLimitedResponseBody(null, 1024));
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldThrowOnNegativeMaxSize() {
+        ResponseBody responseBody = responseBody("test".getBytes(StandardCharsets.UTF_8), 4L,
+                MediaType.parse("text/plain"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HttpUtils.readLimitedResponseBody(responseBody, -1));
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldUseResponseCharset() throws IOException {
+        Charset charset = StandardCharsets.ISO_8859_1;
+        byte[] bytes = new byte[] {'c', 'a', 'f', (byte) 0xE9};
+        String expected = new String(bytes, charset);
+        ResponseBody responseBody = responseBody(bytes, -1L,
+                MediaType.parse("text/plain; charset=iso-8859-1"));
+
+        String result = HttpUtils.readLimitedResponseBody(responseBody, 100);
+
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void readLimitedResponseBodyShouldDefaultToUtf8WhenCharsetMissing() throws IOException {
+        String body = "hello";
+        ResponseBody responseBody = responseBody(body.getBytes(StandardCharsets.UTF_8),
+                body.getBytes(StandardCharsets.UTF_8).length,
+                MediaType.parse("application/json"));
+
+        String result = HttpUtils.readLimitedResponseBody(responseBody, 1024);
+
+        Assert.assertEquals(body, result);
+    }
+
+    private static ResponseBody responseBody(final byte[] bytes, final long contentLength,
+                                             final MediaType mediaType) {
+        return new ResponseBody() {
+            @Override
+            public MediaType contentType() {
+                return mediaType;
+            }
+
+            @Override
+            public long contentLength() {
+                return contentLength;
+            }
+
+            @Override
+            public BufferedSource source() {
+                return new Buffer().write(bytes);
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
PullSwaggerDocServiceImpl previously called response.body().string() with no size limit, allowing a malicious upstream to exhaust admin memory. Extract readLimitedResponseBody to a public static method in HttpUtils with Content-Length pre-check and streaming byte-count enforcement, reuse it in both SwaggerImportServiceImpl and PullSwaggerDocServiceImpl, and gate it with the existing shenyu.swagger.max-body-size property (default 10 MB).

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary of all changes:                                                      
                                         
  Problem                                                                               
                           
  PullSwaggerDocServiceImpl called response.body().string() directly, loading the entire
   upstream API document response into memory with no size limit. A malicious or        
  misconfigured upstream could cause excessive memory usage in shenyu-admin.            
                                                                                        
 Solution                                                                              
   
  3 production files changed, 2 test files changed:                                     
                                                            
  1. HttpUtils.java — Extracted readLimitedResponseBody() as a public static method     
  (moved from SwaggerImportServiceImpl where it was private). Implements two-layer
  defense: early rejection via Content-Length header check, and streaming byte-count    
  enforcement. Pre-allocates ByteArrayOutputStream when contentLength is known to avoid
  repeated buffer resizing.
  2. SwaggerImportServiceImpl.java — Delegates to HttpUtils.readLimitedResponseBody()
  instead of the removed private method. Removed unused imports, the READ_BUFFER_SIZE   
  constant, and the dead DEFAULT_MAX_SWAGGER_BODY_SIZE constant.
  3. PullSwaggerDocServiceImpl.java — The core fix. Added                               
  @Value("${shenyu.swagger.max-body-size:10485760}") injection and replaced             
  response.body().string() with HttpUtils.readLimitedResponseBody(response.body(), 
  maxSwaggerBodySize). Oversized responses are caught by the existing catch (Exception  
  e) block and logged gracefully.                           
  4. HttpUtilsTest.java — 8 new tests for readLimitedResponseBody: within-limit,
  exact-limit boundary, Content-Length rejection, streaming rejection, null body,       
  negative max size, charset handling (ISO-8859-1), and default UTF-8 fallback.
  5. SwaggerImportServiceImplTest.java — Removed 3 reflection-based tests that called   
  the now-deleted private method (covered by HttpUtilsTest). Moved service creation to  
  @BeforeEach with ReflectionTestUtils.setField to simulate Spring injection of the
  default 10 MB limit.

close [#6444](https://github.com/apache/shenyu/issues/6444)