### PR TITLE
fix: handle null discoveryUpstreams in proxy selector update

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java
@@ -368,28 +368,30 @@ public class ProxySelectorServiceImpl implements ProxySelectorService {
         discoveryDO.setProps(discovery.getProps());
         discoveryMapper.updateSelective(discoveryDO);
         // update discovery upstream list
-        int result = discoveryUpstreamMapper.deleteByDiscoveryHandlerId(discoveryHandlerId);
-        LOG.info("delete discovery upstreams, count is: {}", result);
-        proxySelectorAddDTO.getDiscoveryUpstreams().forEach(discoveryUpstream -> {
-            DiscoveryUpstreamDO discoveryUpstreamDO = DiscoveryUpstreamDO.builder()
-                    .id(UUIDUtils.getInstance().generateShortUuid())
-                    .discoveryHandlerId(discoveryHandlerId)
-                    .namespaceId(discoveryDO.getNamespaceId())
-                    .protocol(discoveryUpstream.getProtocol())
-                    .url(discoveryUpstream.getUrl())
-                    .status(discoveryUpstream.getStatus())
-                    .weight(discoveryUpstream.getWeight())
-                    .props(discoveryUpstream.getProps())
-                    .dateCreated(Optional.ofNullable(discoveryUpstream.getStartupTime()).map(t -> new Timestamp(Long.parseLong(t))).orElse(currentTime))
-                    .dateUpdated(Optional.ofNullable(discoveryUpstream.getStartupTime()).map(t -> new Timestamp(Long.parseLong(t))).orElse(currentTime))
-                    .build();
-            discoveryUpstreamMapper.insert(discoveryUpstreamDO);
-        });
+        if (!CollectionUtils.isEmpty(proxySelectorAddDTO.getDiscoveryUpstreams())) {
+            int result = discoveryUpstreamMapper.deleteByDiscoveryHandlerId(discoveryHandlerId);
+            LOG.info("delete discovery upstreams, count is: {}", result);
+            proxySelectorAddDTO.getDiscoveryUpstreams().forEach(discoveryUpstream -> {
+                DiscoveryUpstreamDO discoveryUpstreamDO = DiscoveryUpstreamDO.builder()
+                        .id(UUIDUtils.getInstance().generateShortUuid())
+                        .discoveryHandlerId(discoveryHandlerId)
+                        .namespaceId(discoveryDO.getNamespaceId())
+                        .protocol(discoveryUpstream.getProtocol())
+                        .url(discoveryUpstream.getUrl())
+                        .status(discoveryUpstream.getStatus())
+                        .weight(discoveryUpstream.getWeight())
+                        .props(discoveryUpstream.getProps())
+                        .dateCreated(Optional.ofNullable(discoveryUpstream.getStartupTime()).map(t -> new Timestamp(Long.parseLong(t))).orElse(currentTime))
+                        .dateUpdated(Optional.ofNullable(discoveryUpstream.getStartupTime()).map(t -> new Timestamp(Long.parseLong(t))).orElse(currentTime))
+                        .build();
+                discoveryUpstreamMapper.insert(discoveryUpstreamDO);
+            });
+            LOG.info("insert discovery upstreams, count is: {}", proxySelectorAddDTO.getDiscoveryUpstreams().size());
+        }
         List<DiscoveryUpstreamDTO> fetchAll = discoveryUpstreamMapper.selectByDiscoveryHandlerId(discoveryHandlerDO.getId()).stream()
                 .map(DiscoveryTransfer.INSTANCE::mapToDTO).collect(Collectors.toList());
         DiscoveryProcessor discoveryProcessor = discoveryProcessorHolder.chooseProcessor(discoveryDO.getDiscoveryType());
         discoveryProcessor.changeUpstream(DiscoveryTransfer.INSTANCE.mapToDTO(proxySelectorDO), fetchAll);
-        LOG.info("insert discovery upstreams, count is: {}", proxySelectorAddDTO.getDiscoveryUpstreams().size());
         return ShenyuResultMessage.UPDATE_SUCCESS;
     }
 

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ProxySelectorServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ProxySelectorServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.admin.service;
 
+import org.apache.shenyu.admin.discovery.DiscoveryProcessor;
 import org.apache.shenyu.admin.discovery.DiscoveryProcessorHolder;
 import org.apache.shenyu.admin.mapper.DiscoveryHandlerMapper;
 import org.apache.shenyu.admin.mapper.DiscoveryMapper;
@@ -25,6 +26,8 @@ import org.apache.shenyu.admin.mapper.DiscoveryUpstreamMapper;
 import org.apache.shenyu.admin.mapper.ProxySelectorMapper;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
 import org.apache.shenyu.admin.model.dto.ProxySelectorAddDTO;
+import org.apache.shenyu.admin.model.entity.DiscoveryDO;
+import org.apache.shenyu.admin.model.entity.DiscoveryHandlerDO;
 import org.apache.shenyu.admin.model.entity.DiscoveryRelDO;
 import org.apache.shenyu.admin.model.entity.ProxySelectorDO;
 import org.apache.shenyu.admin.model.page.PageParameter;
@@ -53,6 +56,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -117,6 +123,37 @@ class ProxySelectorServiceTest {
         given(proxySelectorMapper.nameExisted("test")).willReturn(null);
         given(proxySelectorMapper.insert(ProxySelectorDO.buildProxySelectorDO(proxySelectorDTO))).willReturn(1);
         assertEquals(proxySelectorService.createOrUpdate(proxySelectorDTO), ShenyuResultMessage.CREATE_SUCCESS);
+    }
+
+    @Test
+    void testUpdateWithNullDiscoveryUpstreams() {
+
+        ProxySelectorAddDTO proxySelectorDTO = new ProxySelectorAddDTO();
+        proxySelectorDTO.setId("proxy-1");
+        proxySelectorDTO.setName("test");
+        proxySelectorDTO.setPluginName("test");
+        proxySelectorDTO.setForwardPort(8080);
+        proxySelectorDTO.setDiscovery(new ProxySelectorAddDTO.Discovery());
+
+        DiscoveryRelDO discoveryRelDO = new DiscoveryRelDO();
+        discoveryRelDO.setDiscoveryHandlerId("handler-1");
+        given(discoveryRelMapper.selectByProxySelectorId("proxy-1")).willReturn(discoveryRelDO);
+
+        DiscoveryHandlerDO discoveryHandlerDO = new DiscoveryHandlerDO();
+        discoveryHandlerDO.setId("handler-1");
+        discoveryHandlerDO.setDiscoveryId("discovery-1");
+        given(discoveryHandlerMapper.selectById("handler-1")).willReturn(discoveryHandlerDO);
+
+        DiscoveryDO discoveryDO = new DiscoveryDO();
+        discoveryDO.setDiscoveryType("local");
+        given(discoveryMapper.selectById("discovery-1")).willReturn(discoveryDO);
+
+        DiscoveryProcessor discoveryProcessor = mock(DiscoveryProcessor.class);
+        given(discoveryProcessorHolder.chooseProcessor("local")).willReturn(discoveryProcessor);
+        given(discoveryUpstreamMapper.selectByDiscoveryHandlerId("handler-1")).willReturn(Collections.emptyList());
+
+        assertEquals(proxySelectorService.update(proxySelectorDTO), ShenyuResultMessage.UPDATE_SUCCESS);
+        verify(discoveryUpstreamMapper, never()).deleteByDiscoveryHandlerId(any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #6517

## What's changed
  - ProxySelectorServiceImpl.update no longer calls
    `discoveryUpstreams.forEach(...)` when the list is null/omitted.
  - The delete-and-reinsert of discovery upstreams (and its log statement) is
    now guarded by a non-empty check, consistent with the create path
    (`addUpstreamList`). A null/empty list means upstreams are left untouched.

  ## Why
  `discoveryUpstreams` is optional in ProxySelectorAddDTO, but the update path
  deleted existing upstream rows and then iterated the request list without a
  null check, throwing NullPointerException and returning a server error
  instead of a consistent result.

  ## Tests
  - Added ProxySelectorServiceTest.testUpdateWithNullDiscoveryUpstreams:
    update with null discoveryUpstreams must succeed and must not call
    deleteByDiscoveryHandlerId. It failed with
    `NullPointerException: ... getDiscoveryUpstreams() is null` before the fix.
  - `mvn -pl shenyu-admin test -Dtest=ProxySelectorServiceTest` → 6 tests passed.

  ## Manual verification
  - Create a proxy selector with one upstream, then PUT /proxy-selector/{id}
    with the JSON body omitting discoveryUpstreams.
  - Before fix: HTTP 500 + NPE in admin log.
  - After fix: HTTP 200 "update success", existing upstreams are preserved.


Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
