### PR TITLE
fix: validate parent tag existence when creating child tag

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/TagServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/TagServiceImpl.java
@@ -72,6 +72,7 @@ public class TagServiceImpl implements TagService {
         String ext = "";
         if (!tagDTO.getParentTagId().equals(AdminConstants.TAG_ROOT_PARENT_ID)) {
             TagDO tagDO = tagMapper.selectByPrimaryKey(tagDTO.getParentTagId());
+            Assert.notNull(tagDO, "parent tag is not found");
             ext = buildExtParamByParentTag(tagDO);
         } else {
             ext = GsonUtils.getInstance().toJson(Optional.ofNullable(tagExt).orElse(new TagDO.TagExt()));

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/TagServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/TagServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.admin.service;
 
 import com.google.common.collect.Lists;
+import org.apache.shenyu.admin.exception.ValidFailException;
 import org.apache.shenyu.admin.mapper.TagMapper;
 import org.apache.shenyu.admin.model.dto.TagDTO;
 import org.apache.shenyu.admin.model.entity.TagDO;
@@ -38,6 +39,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -72,6 +74,12 @@ public class TagServiceTest {
         tagService.create(buildTagDTO());
         int cnt = tagService.create(buildTagDTO1());
         assertEquals(cnt, 1);
+    }
+
+    @Test
+    public void testCreateWithNonExistentParentTag() {
+        given(this.tagMapper.selectByPrimaryKey("456")).willReturn(null);
+        assertThrows(ValidFailException.class, () -> tagService.create(buildTagDTO()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #6520

  ## What's changed
  - TagServiceImpl.createInner now validates the parent tag exists when
    parentTagId is not the root id. A missing parent tag throws
    ValidFailException("parent tag is not found") instead of passing null to
    buildExtParamByParentTag.

  ## Why
  Creating a child tag with a non-existent parentTagId made
  tagMapper.selectByPrimaryKey return null, then
  buildExtParamByParentTag(null) called parentTagDO.getId() and threw
  NullPointerException (internal 500) instead of a clear validation error.

  ## Tests
  - Added TagServiceTest.testCreateWithNonExistentParentTag: create with a
    missing parentTagId must throw ValidFailException. It failed with
    `NullPointerException: ... "parentTagDO" is null` before the fix.
  - `mvn -pl shenyu-admin test -Dtest=TagServiceTest` → 7 tests passed.

  ## Manual verification
  - POST /tag with a parentTagId that does not exist.
  - Before fix: NPE in admin log, generic error response.
  - After fix: response message "parent tag is not found", no NPE.

Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
