### PR TITLE
fix: enforce request body size limit during buffering in AiProxyPlugin

### DIFF
--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java
@@ -41,6 +41,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferLimitException;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -63,7 +64,7 @@ public class AiProxyPlugin extends AbstractShenyuPlugin {
     /**
      * Maximum request body size: 5MB.
      */
-    private static final long MAX_REQUEST_BODY_SIZE_BYTES = 5 * 1024 * 1024L;
+    private static final int MAX_REQUEST_BODY_SIZE_BYTES = 5 * 1024 * 1024;
 
     private final AiModelFactoryRegistry aiModelFactoryRegistry;
 
@@ -100,18 +101,8 @@ public class AiProxyPlugin extends AbstractShenyuPlugin {
                         CacheKeyUtils.INST.getKey(
                                 selector.getId(), Constants.DEFAULT_RULE));
 
-        return DataBufferUtils.join(exchange.getRequest().getBody())
+        return DataBufferUtils.join(exchange.getRequest().getBody(), MAX_REQUEST_BODY_SIZE_BYTES)
                 .flatMap(dataBuffer -> {
-                    // Validate actual body size after reading, not just Content-Length header
-                    final int actualSize = dataBuffer.readableByteCount();
-                    if (actualSize > MAX_REQUEST_BODY_SIZE_BYTES) {
-                        DataBufferUtils.release(dataBuffer);
-                        LOG.warn("[AiProxy] Request body size {} exceeds maximum allowed size {}", 
-                                actualSize, MAX_REQUEST_BODY_SIZE_BYTES);
-                        exchange.getResponse().setStatusCode(HttpStatus.PAYLOAD_TOO_LARGE);
-                        return exchange.getResponse().setComplete();
-                    }
-                    
                     final String requestBody = dataBuffer.toString(StandardCharsets.UTF_8);
                     DataBufferUtils.release(dataBuffer);
 
@@ -152,6 +143,12 @@ public class AiProxyPlugin extends AbstractShenyuPlugin {
                         return handleStreamRequest(exchange, selector, requestBody, primaryConfig, selectorHandle);
                     }
                     return handleNonStreamRequest(exchange, selector, requestBody, primaryConfig, selectorHandle);
+                })
+                .onErrorResume(DataBufferLimitException.class, e -> {
+                    LOG.warn("[AiProxy] Request body exceeds maximum allowed size {} bytes",
+                            MAX_REQUEST_BODY_SIZE_BYTES);
+                    exchange.getResponse().setStatusCode(HttpStatus.PAYLOAD_TOO_LARGE);
+                    return exchange.getResponse().setComplete();
                 });
     }
 

--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java
@@ -47,6 +47,8 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.buffer.DataBufferLimitException;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -57,6 +59,7 @@ import reactor.test.StepVerifier;
 
 import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -338,5 +341,22 @@ public class AiProxyPluginTest {
         verify(configService).resolveDynamicFallbackConfig(primaryConfig, REQUEST_BODY);
         verify(configService).resolveAdminFallbackConfig(primaryConfig, handle);
         verify(executorService).execute(any(), any(), any());
+    }
+
+    @Test
+    public void testRequestBodyExceedsMaxSize() {
+        final AiProxyHandle handle = new AiProxyHandle();
+        aiProxyPluginHandler.getSelectorCachedHandle()
+                .cachedHandle(CacheKeyUtils.INST.getKey(SELECTOR_ID, Constants.DEFAULT_RULE), handle);
+
+        try (MockedStatic<DataBufferUtils> dataBufferUtilsMock = mockStatic(DataBufferUtils.class)) {
+            dataBufferUtilsMock.when(() -> DataBufferUtils.join(any(), anyInt()))
+                    .thenReturn(Mono.error(new DataBufferLimitException("Request body exceeds limit")));
+
+            StepVerifier.create(plugin.doExecute(exchange, mock(ShenyuPluginChain.class), selector, rule))
+                    .verifyComplete();
+
+            assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, exchange.getResponse().getStatusCode());
+        }
     }
 }


### PR DESCRIPTION
Use DataBufferUtils.join with maxSize to prevent OOM from large request bodies. Previously the full body was buffered into memory before the size check ran, allowing a multi-GB payload to exhaust heap. Now DataBufferLimitException is raised during buffering and returned as 413.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary
- Replaced DataBufferUtils.join(exchange.getRequest().getBody()) (no max size) with DataBufferUtils.join(exchange.getRequest().getBody(), MAX_REQUEST_BODY_SIZE_BYTES). This makes   
  Spring's DataBufferUtils enforce the 5 MB limit during buffering — a DataBufferLimitException is thrown immediately when the limit is exceeded, rather than buffering the entire   
  multi-GB body into heap first. Added .onErrorResume(DataBufferLimitException.class, ...) to catch that exception and return HTTP 413. Removed the now-redundant post-buffer size   
  check.
- Added testRequestBodyExceedsMaxSize which mocks DataBufferUtils.join to return Mono.error(new DataBufferLimitException(...)) and asserts the response status is 413                
  PAYLOAD_TOO_LARGE.


close [#6837](https://github.com/apache/shenyu/issues/6837)