### PR TITLE
fix: NPE in AbstractLogCollector.desensitizeShenyuRequestLog on null boxed Integer/Long

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/collector/AbstractLogCollector.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/collector/AbstractLogCollector.java
@@ -186,13 +186,19 @@ public abstract class AbstractLogCollector<T extends AbstractLogConsumeClient<?,
         logInfo.setTimeLocal(desensitizeForSingleWord(GenericLoggingConstant.TIME_LOCAL, logInfo.getTimeLocal(), keyWordMatch, desensitizedAlg));
         logInfo.setMethod(desensitizeForSingleWord(GenericLoggingConstant.METHOD, logInfo.getMethod(), keyWordMatch, desensitizedAlg));
         logInfo.setRequestUri(desensitizeForSingleWord(GenericLoggingConstant.REQUEST_URI, logInfo.getRequestUri(), keyWordMatch, desensitizedAlg));
-        logInfo.setResponseContentLength(Integer.valueOf(desensitizeForSingleWord(GenericLoggingConstant.RESPONSE_CONTENT_LENGTH,
-                logInfo.getResponseContentLength().toString(), keyWordMatch, desensitizedAlg)));
+        if (Objects.nonNull(logInfo.getResponseContentLength())) {
+            logInfo.setResponseContentLength(Integer.valueOf(desensitizeForSingleWord(GenericLoggingConstant.RESPONSE_CONTENT_LENGTH,
+                    logInfo.getResponseContentLength().toString(), keyWordMatch, desensitizedAlg)));
+        }
         logInfo.setRpcType(desensitizeForSingleWord(GenericLoggingConstant.RPC_TYPE, logInfo.getRpcType(), keyWordMatch, desensitizedAlg));
-        logInfo.setStatus(Integer.valueOf(desensitizeForSingleWord(GenericLoggingConstant.STATUS, logInfo.getStatus().toString(), keyWordMatch, desensitizedAlg)));
+        if (Objects.nonNull(logInfo.getStatus())) {
+            logInfo.setStatus(Integer.valueOf(desensitizeForSingleWord(GenericLoggingConstant.STATUS, logInfo.getStatus().toString(), keyWordMatch, desensitizedAlg)));
+        }
         logInfo.setUpstreamIp(desensitizeForSingleWord(GenericLoggingConstant.UP_STREAM_IP, logInfo.getUpstreamIp(), keyWordMatch, desensitizedAlg));
-        logInfo.setUpstreamResponseTime(Long.valueOf(desensitizeForSingleWord(GenericLoggingConstant.UP_STREAM_RESPONSE_TIME,
-                logInfo.getUpstreamResponseTime().toString(), keyWordMatch, desensitizedAlg)));
+        if (Objects.nonNull(logInfo.getUpstreamResponseTime())) {
+            logInfo.setUpstreamResponseTime(Long.valueOf(desensitizeForSingleWord(GenericLoggingConstant.UP_STREAM_RESPONSE_TIME,
+                    logInfo.getUpstreamResponseTime().toString(), keyWordMatch, desensitizedAlg)));
+        }
         logInfo.setUserAgent(desensitizeForSingleWord(GenericLoggingConstant.USERAGENT, logInfo.getUserAgent(), keyWordMatch, desensitizedAlg));
         logInfo.setHost(desensitizeForSingleWord(GenericLoggingConstant.HOST, logInfo.getHost(), keyWordMatch, desensitizedAlg));
         logInfo.setModule(desensitizeForSingleWord(GenericLoggingConstant.MODULE, logInfo.getModule(), keyWordMatch, desensitizedAlg));

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/test/java/org/apache/shenyu/plugin/logging/common/collector/AbstractLogCollectorTest.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/test/java/org/apache/shenyu/plugin/logging/common/collector/AbstractLogCollectorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.logging.common.collector;
+
+import org.apache.shenyu.plugin.logging.common.client.AbstractLogConsumeClient;
+import org.apache.shenyu.plugin.logging.common.config.GenericGlobalConfig;
+import org.apache.shenyu.plugin.logging.common.constant.GenericLoggingConstant;
+import org.apache.shenyu.plugin.logging.common.entity.ShenyuRequestLog;
+import org.apache.shenyu.plugin.logging.desensitize.api.enums.DataDesensitizeEnum;
+import org.apache.shenyu.plugin.logging.desensitize.api.matcher.KeyWordMatch;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The Test Case For AbstractLogCollector.
+ */
+public class AbstractLogCollectorTest {
+
+    private final AbstractLogCollector<AbstractLogConsumeClient<?, ShenyuRequestLog>, ShenyuRequestLog, GenericGlobalConfig> collector =
+            new AbstractLogCollector<>() {
+                @Override
+                protected AbstractLogConsumeClient<?, ShenyuRequestLog> getLogConsumeClient() {
+                    return null;
+                }
+
+                @Override
+                protected GenericGlobalConfig getLogCollectConfig() {
+                    return null;
+                }
+
+                @Override
+                protected void desensitizeLog(final ShenyuRequestLog log, final KeyWordMatch keyWordMatch, final String desensitizeAlg) {
+                }
+            };
+
+    @Test
+    public void testDesensitizeToleratesNullBoxedNumericFields() {
+        // a chunked byte-type response reaches desensitize with responseContentLength,
+        // status and upstreamResponseTime unset (LoggingServerHttpResponse passes a null
+        // writer for byte media and only sets status once the status code is committed)
+        ShenyuRequestLog log = new ShenyuRequestLog();
+        log.setClientIp("192.168.1.1");
+        KeyWordMatch keyWordMatch = new KeyWordMatch(new HashSet<>(Collections.singletonList(GenericLoggingConstant.CLIENT_IP)));
+        assertDoesNotThrow(() -> collector.desensitize(log, keyWordMatch, DataDesensitizeEnum.CHARACTER_REPLACE.getDataDesensitizeAlg()));
+        assertNull(log.getResponseContentLength());
+        assertNull(log.getStatus());
+        assertNull(log.getUpstreamResponseTime());
+        assertNotEquals("192.168.1.1", log.getClientIp());
+    }
+
+    @Test
+    public void testDesensitizePreservesPopulatedNumericFields() {
+        ShenyuRequestLog log = new ShenyuRequestLog();
+        log.setClientIp("192.168.1.1");
+        log.setResponseContentLength(1024);
+        log.setStatus(200);
+        log.setUpstreamResponseTime(15L);
+        Set<String> keyWords = new HashSet<>(Collections.singletonList(GenericLoggingConstant.CLIENT_IP));
+        collector.desensitize(log, new KeyWordMatch(keyWords), DataDesensitizeEnum.CHARACTER_REPLACE.getDataDesensitizeAlg());
+        assertEquals(1024, log.getResponseContentLength());
+        assertEquals(200, log.getStatus());
+        assertEquals(15L, log.getUpstreamResponseTime());
+    }
+}


### PR DESCRIPTION
Fixes #6884

desensitizeShenyuRequestLog unconditionally calls toString on three boxed numeric fields of ShenyuRequestLog. For byte type media appendResponse invokes logResponse with a null writer, so a chunked response with no Content-Length header reaches desensitize with responseContentLength still null and the collector throws an NPE inside the response doFinally, losing the access log for that request. status and upstreamResponseTime are nullable on the same class of paths.

This change guards each of the three fields with Objects.nonNull before desensitizing, matching the null tolerance the String fields already get from StringUtils.hasLength inside desensitizeForSingleWord. Added AbstractLogCollectorTest covering the null case (chunked byte response shape) and the populated case (values preserved when keywords do not match them).

Note for reviewers, the issue body on #6884 describes a different bug due to an off by one paste in the Aug 4 batch, the analysis matching this title is in the body of #6883, details in my comment on the issue.

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true` (module scoped build of shenyu-plugin-logging-common with tests).