### PR TITLE
fix: evict stale upstream countMap entries in LeastActiveLoadBalance 

### DIFF
--- a/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
+++ b/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
@@ -68,6 +68,7 @@ public class LeastActiveLoadBalance extends AbstractLoadBalancer {
             activeCount.increase();
         }
 
+        // A removed domain's entry lingers for up to recyclePeriod, safely excluded from selection meanwhile.
         if (!updateLock.get() && now - lastRecycle > recyclePeriod && updateLock.compareAndSet(false, true)) {
             try {
                 countMap.entrySet().removeIf(item -> now - item.getValue().getLastUpdate() > recyclePeriod);

--- a/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
+++ b/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
@@ -24,8 +24,11 @@ import org.apache.shenyu.spi.Join;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 /**
@@ -34,28 +37,93 @@ import java.util.stream.Collectors;
 @Join
 public class LeastActiveLoadBalance extends AbstractLoadBalancer {
 
-    private final Map<String, Long> countMap = new ConcurrentHashMap<>();
+    private final int recyclePeriod = 60000;
+
+    private final ConcurrentMap<String, ActiveCount> countMap = new ConcurrentHashMap<>(16);
+
+    private final AtomicBoolean updateLock = new AtomicBoolean();
+
+    private volatile long lastRecycle;
 
     @Override
     protected Upstream doSelect(final List<Upstream> upstreamList, final LoadBalanceData data) {
+        long now = System.currentTimeMillis();
         Map<String, Upstream> domainMap = upstreamList.stream()
                 .collect(Collectors.toConcurrentMap(Upstream::buildDomain, upstream -> upstream));
 
-        domainMap.keySet().stream()
-                .filter(key -> !countMap.containsKey(key))
-                .forEach(domain -> countMap.put(domain, Long.MIN_VALUE));
-
-        countMap.keySet().retainAll(domainMap.keySet());
+        domainMap.keySet().forEach(domain -> {
+            ActiveCount activeCount = countMap.computeIfAbsent(domain, key -> new ActiveCount(now));
+            activeCount.setLastUpdate(now);
+        });
 
         final String domain = countMap.entrySet().stream()
                 // Ensure that the filtered domain is included in the domainMap.
                 .filter(entry -> domainMap.containsKey(entry.getKey()))
-                .min(Comparator.comparingLong(Map.Entry::getValue))
+                .min(Comparator.comparingLong(entry -> entry.getValue().getCount()))
                 .map(Map.Entry::getKey)
                 .orElse(upstreamList.get(0).buildDomain());
 
-        countMap.computeIfPresent(domain, (key, activated) -> Optional.of(activated).orElse(Long.MIN_VALUE) + 1);
+        ActiveCount activeCount = countMap.get(domain);
+        if (Objects.nonNull(activeCount)) {
+            activeCount.increase();
+        }
+
+        if (!updateLock.get() && now - lastRecycle > recyclePeriod && updateLock.compareAndSet(false, true)) {
+            try {
+                countMap.entrySet().removeIf(item -> now - item.getValue().getLastUpdate() > recyclePeriod);
+                lastRecycle = now;
+            } finally {
+                updateLock.set(false);
+            }
+        }
         return domainMap.get(domain);
     }
-    
+
+    /**
+     * The type Active count.
+     */
+    protected static class ActiveCount {
+
+        private final AtomicLong count = new AtomicLong(Long.MIN_VALUE);
+
+        private volatile long lastUpdate;
+
+        ActiveCount(final long lastUpdate) {
+            this.lastUpdate = lastUpdate;
+        }
+
+        /**
+         * Increase count.
+         */
+        void increase() {
+            count.addAndGet(1);
+        }
+
+        /**
+         * Get count.
+         *
+         * @return the count
+         */
+        long getCount() {
+            return count.get();
+        }
+
+        /**
+         * Gets last update.
+         *
+         * @return the last update
+         */
+        long getLastUpdate() {
+            return lastUpdate;
+        }
+
+        /**
+         * Sets last update.
+         *
+         * @param lastUpdate the last update
+         */
+        void setLastUpdate(final long lastUpdate) {
+            this.lastUpdate = lastUpdate;
+        }
+    }
 }

--- a/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
+++ b/shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java
@@ -45,6 +45,8 @@ public class LeastActiveLoadBalance extends AbstractLoadBalancer {
                 .filter(key -> !countMap.containsKey(key))
                 .forEach(domain -> countMap.put(domain, Long.MIN_VALUE));
 
+        countMap.keySet().retainAll(domainMap.keySet());
+
         final String domain = countMap.entrySet().stream()
                 // Ensure that the filtered domain is included in the domainMap.
                 .filter(entry -> domainMap.containsKey(entry.getKey()))

--- a/shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java
+++ b/shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java
@@ -22,8 +22,10 @@ import org.apache.shenyu.loadbalancer.entity.Upstream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The type least activity load balance test.
@@ -55,5 +57,26 @@ public class LeastActiveLoadBalanceTest {
         Upstream upstream1 = leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
         Assertions.assertTrue(upstream.getUrl().equals("baidu.com") && upstream1.getUrl().equals("pro.jd.com")
                 || upstream1.getUrl().equals("baidu.com") && upstream.getUrl().equals("pro.jd.com"));
+    }
+
+    @Test
+    public void testRemoveStaleCountMapEntries() throws Exception {
+        buildUpstreamList();
+        final LeastActiveLoadBalance leastActiveLoadBalance = new LeastActiveLoadBalance();
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        Assertions.assertEquals(2, getCountMap(leastActiveLoadBalance).size());
+        onlyOneList.remove(1);
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        Map<String, Long> countMap = getCountMap(leastActiveLoadBalance);
+        Assertions.assertEquals(1, countMap.size());
+        Assertions.assertTrue(countMap.containsKey("https://baidu.com"));
+        Assertions.assertFalse(countMap.containsKey("https://pro.jd.com"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> getCountMap(final LeastActiveLoadBalance loadBalance) throws Exception {
+        Field field = LeastActiveLoadBalance.class.getDeclaredField("countMap");
+        field.setAccessible(true);
+        return (Map<String, Long>) field.get(loadBalance);
     }
 }

--- a/shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java
+++ b/shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java
@@ -66,17 +66,82 @@ public class LeastActiveLoadBalanceTest {
         leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
         Assertions.assertEquals(2, getCountMap(leastActiveLoadBalance).size());
         onlyOneList.remove(1);
+        // The periodic cleanup is time-driven, simulate the elapsed time so that the entry of the
+        // removed upstream becomes stale and is evicted by the next cleanup.
+        long old = System.currentTimeMillis() - 60_001;
+        setLastUpdate(leastActiveLoadBalance, "https://pro.jd.com", old);
+        setLastRecycle(leastActiveLoadBalance, old);
         leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
-        Map<String, Long> countMap = getCountMap(leastActiveLoadBalance);
+        Map<String, LeastActiveLoadBalance.ActiveCount> countMap = getCountMap(leastActiveLoadBalance);
         Assertions.assertEquals(1, countMap.size());
         Assertions.assertTrue(countMap.containsKey("https://baidu.com"));
         Assertions.assertFalse(countMap.containsKey("https://pro.jd.com"));
     }
 
+    @Test
+    public void testCountMapNotAffectOtherSelector() throws Exception {
+        buildUpstreamList();
+        final List<Upstream> anotherList = new ArrayList<>();
+        anotherList.add(Upstream.builder().url("jd.com").protocol("https://").build());
+        final LeastActiveLoadBalance leastActiveLoadBalance = new LeastActiveLoadBalance();
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        leastActiveLoadBalance.doSelect(anotherList, new LoadBalanceData());
+        Assertions.assertEquals(3, getCountMap(leastActiveLoadBalance).size());
+        // Selector 1 removes pro.jd.com, and the cleanup must not evict the live entry jd.com
+        // which only belongs to selector 2.
+        onlyOneList.remove(1);
+        long old = System.currentTimeMillis() - 60_001;
+        setLastUpdate(leastActiveLoadBalance, "https://pro.jd.com", old);
+        setLastRecycle(leastActiveLoadBalance, old);
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        Map<String, LeastActiveLoadBalance.ActiveCount> countMap = getCountMap(leastActiveLoadBalance);
+        Assertions.assertEquals(2, countMap.size());
+        Assertions.assertTrue(countMap.containsKey("https://baidu.com"));
+        Assertions.assertTrue(countMap.containsKey("https://jd.com"));
+        Assertions.assertFalse(countMap.containsKey("https://pro.jd.com"));
+    }
+
+    @Test
+    public void testCountMapNotAffectOtherSelectorWhenFirstRemoved() throws Exception {
+        buildUpstreamList();
+        final List<Upstream> anotherList = new ArrayList<>();
+        anotherList.add(Upstream.builder().url("jd.com").protocol("https://").build());
+        final LeastActiveLoadBalance leastActiveLoadBalance = new LeastActiveLoadBalance();
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        leastActiveLoadBalance.doSelect(anotherList, new LoadBalanceData());
+        Assertions.assertEquals(3, getCountMap(leastActiveLoadBalance).size());
+        // Symmetric case: selector 1 removes the first upstream baidu.com. The cleanup must evict
+        // baidu.com but keep pro.jd.com (still served by selector 1) and jd.com (served by selector 2).
+        onlyOneList.remove(0);
+        long old = System.currentTimeMillis() - 60_001;
+        setLastUpdate(leastActiveLoadBalance, "https://baidu.com", old);
+        setLastRecycle(leastActiveLoadBalance, old);
+        leastActiveLoadBalance.doSelect(onlyOneList, new LoadBalanceData());
+        Map<String, LeastActiveLoadBalance.ActiveCount> countMap = getCountMap(leastActiveLoadBalance);
+        Assertions.assertEquals(2, countMap.size());
+        Assertions.assertTrue(countMap.containsKey("https://pro.jd.com"));
+        Assertions.assertTrue(countMap.containsKey("https://jd.com"));
+        Assertions.assertFalse(countMap.containsKey("https://baidu.com"));
+    }
+
     @SuppressWarnings("unchecked")
-    private Map<String, Long> getCountMap(final LeastActiveLoadBalance loadBalance) throws Exception {
+    private Map<String, LeastActiveLoadBalance.ActiveCount> getCountMap(final LeastActiveLoadBalance loadBalance) throws Exception {
         Field field = LeastActiveLoadBalance.class.getDeclaredField("countMap");
         field.setAccessible(true);
-        return (Map<String, Long>) field.get(loadBalance);
+        return (Map<String, LeastActiveLoadBalance.ActiveCount>) field.get(loadBalance);
+    }
+
+    private void setLastUpdate(final LeastActiveLoadBalance loadBalance, final String domain, final long lastUpdate) throws Exception {
+        LeastActiveLoadBalance.ActiveCount activeCount = getCountMap(loadBalance).get(domain);
+        Assertions.assertNotNull(activeCount);
+        Field field = LeastActiveLoadBalance.ActiveCount.class.getDeclaredField("lastUpdate");
+        field.setAccessible(true);
+        field.set(activeCount, lastUpdate);
+    }
+
+    private void setLastRecycle(final LeastActiveLoadBalance loadBalance, final long lastRecycle) throws Exception {
+        Field field = LeastActiveLoadBalance.class.getDeclaredField("lastRecycle");
+        field.setAccessible(true);
+        field.set(loadBalance, lastRecycle);
     }
 }


### PR DESCRIPTION
Fixes #6891
- Fix the memory leak in LeastActiveLoadBalance.countMap. Previously entries were only added and never removed, so an upstream's entry lingered forever after it was taken out of the list, causing unbounded memory growth proportional to historical upstream churn and O(n) scan overhead on every selection. Now stale entries are evicted via a time-based periodic sweep (gated by CAS + 60s recyclePeriod) using entrySet().removeIf() on lastUpdate age, rather than an immediate retainAll against the current domain set. This tolerates temporary domain absence and avoids O(n) overhead per selection call. Evicted domains may linger in countMap for up to 60s but are safely excluded from selection by the domainMap.containsKey() filter.



<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
