### PR TITLE
[ISSUE-6523] Add break after successful long polling to avoid unnecessary retries

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/HttpSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/HttpSyncDataService.java
@@ -281,6 +281,7 @@ public class HttpSyncDataService implements SyncDataService {
                     try {
                         //do long polling.
                         doLongPolling(server);
+                        break;
                     } catch (Exception e) {
                         // print warnning LOG.
                         if (time < retryTimes) {


### PR DESCRIPTION
### Bug Description

`HttpLongPollingTask.run()` retries failed long-poll requests with a `for (time = 1; time <= retryTimes; time++)` loop, but it does not leave that retry loop after a successful `doLongPolling(server)` call. A single outer loop can therefore perform 10 successful long-poll requests back-to-back instead of one.

### Fix

Added `break` after `doLongPolling(server)` succeeds so the retry loop exits on success and only continues on failure.

Closes #6523