### PR TITLE
feat: implement MQTT Last Will and Testament (LWT)

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
+++ b/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
@@ -46,6 +46,39 @@
             <artifactId>reflections</artifactId>
             <version>0.9.11</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.net=ALL-UNNAMED
+                        -Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Connect.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Connect.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.mqtt.MqttVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +68,17 @@ public class Connect extends MessageType {
 
         // record connect
         Singleton.INST.get(ChannelRepository.class).add(ctx.channel(), clientId);
+
+        // store will if present
+        if (msg.variableHeader().isWillFlag()) {
+            WillRepository.WillEntry will = new WillRepository.WillEntry(
+                    msg.payload().willTopic(),
+                    msg.payload().willMessageInBytes(),
+                    msg.variableHeader().willQos(),
+                    msg.variableHeader().isWillRetain());
+            Singleton.INST.get(WillRepository.class).add(ctx.channel(), will);
+        }
+
         MqttConnAckMessage ackMessage = MqttMessageBuilders.connAck()
                 .returnCode(MqttConnectReturnCode.CONNECTION_ACCEPTED)
                 .sessionPresent(true)

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Disconnect.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Disconnect.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
 
 /**
  * The DISCONNECT message is sent from the client to the server to indicate
@@ -36,8 +37,7 @@ public class Disconnect extends MessageType {
 
     @Override
     public void disconnect(final ChannelHandlerContext ctx) {
-        //// todo Last words
-        //// todo Clean session
+        Singleton.INST.get(WillRepository.class).remove(ctx.channel());
         cleanChannel(ctx.channel());
         ctx.close();
     }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttFactory.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttFactory.java
@@ -65,8 +65,10 @@ public class MqttFactory {
             case PINGREQ:
                 messageType.pingReq(ctx);
                 break;
-            case PUBACK:
             case DISCONNECT:
+                messageType.disconnect(ctx);
+                break;
+            case PUBACK:
             default:
                 break;
         }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandler.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandler.java
@@ -22,6 +22,10 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+
+import java.util.Objects;
 
 /**
  * mqtt transport handler.
@@ -36,6 +40,16 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         } else {
             ctx.close();
         }
+    }
+
+    @Override
+    public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
+        WillRepository.WillEntry will = Singleton.INST.get(WillRepository.class).get(ctx.channel());
+        if (Objects.nonNull(will)) {
+            Publish.publishWill(will);
+            Singleton.INST.get(WillRepository.class).remove(ctx.channel());
+        }
+        super.channelInactive(ctx);
     }
 
     @Override

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -35,6 +35,7 @@ import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
 import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static io.netty.handler.codec.mqtt.MqttMessageType.PUBACK;
@@ -133,10 +134,10 @@ public class Publish extends MessageType {
      * @param will the will entry containing topic, message, qos, and retain flag
      */
     static void publishWill(final WillRepository.WillEntry will) {
-        if (will == null || will.getTopic() == null || will.getMessage() == null) {
+        if (Objects.isNull(will) || Objects.isNull(will.getTopic()) || Objects.isNull(will.getMessage())) {
             return;
         }
-        final List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(will.getTopic());
+        final List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).getChannelsByTopic(will.getTopic());
         final MqttQoS willQos = MqttQoS.valueOf(will.getQos());
         final int packetId = willQos == MqttQoS.AT_MOST_ONCE
                 ? 0

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -133,12 +133,18 @@ public class Publish extends MessageType {
      * @param will the will entry containing topic, message, qos, and retain flag
      */
     static void publishWill(final WillRepository.WillEntry will) {
-        List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(will.getTopic());
-        MqttQoS willQos = MqttQoS.valueOf(will.getQos());
+        if (will == null || will.getTopic() == null || will.getMessage() == null) {
+            return;
+        }
+        final List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(will.getTopic());
+        final MqttQoS willQos = MqttQoS.valueOf(will.getQos());
+        final int packetId = willQos == MqttQoS.AT_MOST_ONCE
+                ? 0
+                : java.util.concurrent.ThreadLocalRandom.current().nextInt(1, 65536);
         channels.parallelStream().forEach(channel -> {
             if (channel.isActive()) {
                 MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, willQos, will.isRetain(), 0);
-                MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(will.getTopic(), 0);
+                MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(will.getTopic(), packetId);
                 MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader,
                         Unpooled.wrappedBuffer(will.getMessage()));
                 channel.writeAndFlush(mqttPublishMessage);

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -32,6 +32,8 @@ import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
 import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
 
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -120,6 +122,25 @@ public class Publish extends MessageType {
                 MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_MOST_ONCE, false, 0);
                 MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(topic, packetId);
                 MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, Unpooled.wrappedBuffer(payload));
+                channel.writeAndFlush(mqttPublishMessage);
+            }
+        });
+    }
+
+    /**
+     * Publish a Last Will message to all subscribers of the will topic.
+     *
+     * @param will the will entry containing topic, message, qos, and retain flag
+     */
+    static void publishWill(final WillRepository.WillEntry will) {
+        List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(will.getTopic());
+        MqttQoS willQos = MqttQoS.valueOf(will.getQos());
+        channels.parallelStream().forEach(channel -> {
+            if (channel.isActive()) {
+                MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, willQos, will.isRetain(), 0);
+                MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(will.getTopic(), 0);
+                MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader,
+                        Unpooled.wrappedBuffer(will.getMessage()));
                 channel.writeAndFlush(mqttPublishMessage);
             }
         });

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import java.util.Objects;
+
+/**
+ * MQTT topic filter matching per MQTT-4.7.
+ *
+ * <p>+ matches exactly one topic level.</p>
+ *
+ * <p># matches any number of subsequent levels (must appear at the end of the filter).</p>
+ */
+public final class TopicMatcher {
+
+    private TopicMatcher() {
+    }
+
+    /**
+     * Check whether a topic filter matches a topic name.
+     *
+     * @param filter the subscription topic filter (may contain + and # wildcards)
+     * @param topic  the published topic name (no wildcards)
+     * @return true if the filter matches the topic
+     */
+    public static boolean matches(final String filter, final String topic) {
+        if (Objects.isNull(filter) || Objects.isNull(topic)) {
+            return false;
+        }
+
+        // $ topics must not be matched by wildcards at the first level
+        if (topic.startsWith("$") && filter.length() > 0 && (filter.charAt(0) == '+' || filter.charAt(0) == '#')) {
+            return false;
+        }
+
+        String[] filterLevels = filter.split("/", -1);
+        String[] topicLevels = topic.split("/", -1);
+
+        int filterLen = filterLevels.length;
+        int topicLen = topicLevels.length;
+
+        for (int i = 0; i < filterLen; i++) {
+            String f = filterLevels[i];
+
+            if ("#".equals(f)) {
+                // MQTT-4.7.1-2: # matches any number of levels including the parent level
+                return i == filterLen - 1;
+            }
+
+            if (i >= topicLen) {
+                return false;
+            }
+
+            if (!"+".equals(f) && !f.equals(topicLevels[i])) {
+                return false;
+            }
+        }
+
+        return filterLen == topicLen;
+    }
+
+    /**
+     * Validate a topic filter per MQTT-4.7.1: wildcards must occupy an entire
+     * level, and # must be the last level. Filters must not be empty or
+     * contain the null character.
+     *
+     * @param filter the subscription topic filter
+     * @return true if the filter is valid
+     */
+    public static boolean isValidFilter(final String filter) {
+        if (Objects.isNull(filter) || filter.isEmpty() || filter.indexOf((char) 0) >= 0) {
+            return false;
+        }
+        String[] levels = filter.split("/", -1);
+        for (int i = 0; i < levels.length; i++) {
+            String level = levels[i];
+            if (level.indexOf('+') >= 0 || level.indexOf('#') >= 0) {
+                if (level.length() > 1) {
+                    return false;
+                }
+                if ("#".equals(level) && i != levels.length - 1) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -19,11 +19,15 @@ package org.apache.shenyu.protocol.mqtt.repositories;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.shenyu.protocol.mqtt.TopicMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -89,6 +93,36 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      */
     public List<Channel> get(final String topic) {
         return TOPIC_CHANNEL_FACTORY.getOrDefault(topic, new CopyOnWriteArrayList<>());
+    }
+
+    /**
+     * Get channels whose subscription filter matches the published topic.
+     * Supports MQTT wildcards: + (single-level) and # (multi-level).
+     *
+     * @param topic the published topic name
+     * @return channels subscribed to matching topic filters
+     */
+    public List<Channel> getChannelsByTopic(final String topic) {
+        // MQTT requires at most one delivery per publish per client, so dedupe
+        // channels when overlapping filters (e.g. sport/# and #) both match.
+        Set<Channel> result = new LinkedHashSet<>();
+
+        // fast path: exact subscription, no wildcard scan needed
+        List<Channel> exactMatch = TOPIC_CHANNEL_FACTORY.get(topic);
+        if (Objects.nonNull(exactMatch)) {
+            result.addAll(exactMatch);
+        }
+
+        for (Map.Entry<String, List<Channel>> entry : TOPIC_CHANNEL_FACTORY.entrySet()) {
+            String filter = entry.getKey();
+            if (filter.equals(topic) || filter.indexOf('+') < 0 && filter.indexOf('#') < 0) {
+                continue;
+            }
+            if (TopicMatcher.matches(filter, topic)) {
+                result.addAll(entry.getValue());
+            }
+        }
+        return new ArrayList<>(result);
     }
 
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/WillRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/WillRepository.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.Channel;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Stores Last Will and Testament for connected clients.
+ * Will is set on CONNECT and cleared on graceful DISCONNECT.
+ * On ungraceful disconnect (channelInactive with will present), the will is published.
+ */
+public class WillRepository implements BaseRepository<Channel, WillRepository.WillEntry> {
+
+    private static final Map<Channel, WillEntry> WILL_FACTORY = new ConcurrentHashMap<>();
+
+    @Override
+    public void add(final Channel channel, final WillEntry willEntry) {
+        WILL_FACTORY.put(channel, willEntry);
+    }
+
+    @Override
+    public void remove(final Channel channel) {
+        WILL_FACTORY.remove(channel);
+    }
+
+    @Override
+    public WillEntry get(final Channel channel) {
+        return WILL_FACTORY.get(channel);
+    }
+
+    /**
+     * Holds the will message fields from a CONNECT payload.
+     */
+    public static class WillEntry {
+
+        private final String topic;
+
+        private final byte[] message;
+
+        private final int qos;
+
+        private final boolean retain;
+
+        public WillEntry(final String topic, final byte[] message, final int qos, final boolean retain) {
+            this.topic = topic;
+            this.message = message;
+            this.qos = qos;
+            this.retain = retain;
+        }
+
+        public String getTopic() {
+            return topic;
+        }
+
+        public byte[] getMessage() {
+            return message;
+        }
+
+        public int getQos() {
+            return qos;
+        }
+
+        public boolean isRetain() {
+            return retain;
+        }
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/ConnectTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/ConnectTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttConnectPayload;
+import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectTest {
+
+    private static final String VALID_USER = "admin";
+
+    private static final String VALID_PASS = "pass123";
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private MqttConnectMessage msg;
+
+    @Mock
+    private MqttConnectVariableHeader variableHeader;
+
+    @Mock
+    private MqttConnectPayload payload;
+
+    private Connect connect;
+
+    private WillRepository willRepository;
+
+    private ChannelRepository channelRepository;
+
+    @BeforeEach
+    public void setUp() {
+        connect = new Connect();
+        willRepository = new WillRepository();
+        channelRepository = new ChannelRepository();
+        Singleton.INST.single(WillRepository.class, willRepository);
+        Singleton.INST.single(ChannelRepository.class, channelRepository);
+
+        when(ctx.channel()).thenReturn(channel);
+        when(msg.variableHeader()).thenReturn(variableHeader);
+        when(msg.payload()).thenReturn(payload);
+        when(variableHeader.version()).thenReturn((int) MqttVersion.MQTT_3_1.protocolLevel());
+        when(payload.clientIdentifier()).thenReturn("test-client-001");
+        when(payload.userName()).thenReturn(VALID_USER);
+        when(payload.passwordInBytes()).thenReturn(VALID_PASS.getBytes());
+
+        MqttContext mqttContext = new MqttContext();
+        mqttContext.setUserName(VALID_USER);
+        mqttContext.setPassword(VALID_PASS);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Singleton.INST.single(WillRepository.class, new WillRepository());
+        Singleton.INST.single(ChannelRepository.class, new ChannelRepository());
+    }
+
+    @Test
+    public void testStoresWillOnConnect() {
+        byte[] willMessage = "client disconnected unexpectedly".getBytes();
+        when(variableHeader.isWillFlag()).thenReturn(true);
+        when(variableHeader.willQos()).thenReturn(1);
+        when(variableHeader.isWillRetain()).thenReturn(true);
+        when(payload.willTopic()).thenReturn("status/client-001");
+        when(payload.willMessageInBytes()).thenReturn(willMessage);
+
+        connect.connect(ctx, msg);
+
+        WillRepository.WillEntry will = willRepository.get(channel);
+        assertThat(will, notNullValue());
+        assertEquals("status/client-001", will.getTopic());
+        assertArrayEquals(willMessage, will.getMessage());
+        assertEquals(1, will.getQos());
+        assertTrue(will.isRetain());
+    }
+
+    @Test
+    public void testDoesNotStoreWillWhenWillFlagIsFalse() {
+        when(variableHeader.isWillFlag()).thenReturn(false);
+
+        connect.connect(ctx, msg);
+
+        WillRepository.WillEntry will = willRepository.get(channel);
+        assertThat(will, nullValue());
+    }
+
+    @Test
+    public void testWillQosZero() {
+        byte[] willMessage = "qos0 will".getBytes();
+        when(variableHeader.isWillFlag()).thenReturn(true);
+        when(variableHeader.willQos()).thenReturn(0);
+        when(variableHeader.isWillRetain()).thenReturn(false);
+        when(payload.willTopic()).thenReturn("topic/qos0");
+        when(payload.willMessageInBytes()).thenReturn(willMessage);
+
+        connect.connect(ctx, msg);
+
+        WillRepository.WillEntry will = willRepository.get(channel);
+        assertThat(will, notNullValue());
+        assertEquals(0, will.getQos());
+        assertFalse(will.isRetain());
+    }
+
+    @Test
+    public void testWillRetainTrue() {
+        byte[] willMessage = "retained will".getBytes();
+        when(variableHeader.isWillFlag()).thenReturn(true);
+        when(variableHeader.willQos()).thenReturn(2);
+        when(variableHeader.isWillRetain()).thenReturn(true);
+        when(payload.willTopic()).thenReturn("topic/retained");
+        when(payload.willMessageInBytes()).thenReturn(willMessage);
+
+        connect.connect(ctx, msg);
+
+        WillRepository.WillEntry will = willRepository.get(channel);
+        assertThat(will, notNullValue());
+        assertTrue(will.isRetain());
+        assertEquals(2, will.getQos());
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/DisconnectTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/DisconnectTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DisconnectTest {
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    private Disconnect disconnect;
+
+    private WillRepository willRepository;
+
+    private ChannelRepository channelRepository;
+
+    @BeforeEach
+    public void setUp() {
+        disconnect = new Disconnect();
+        willRepository = new WillRepository();
+        channelRepository = new ChannelRepository();
+        Singleton.INST.single(WillRepository.class, willRepository);
+        Singleton.INST.single(ChannelRepository.class, channelRepository);
+        when(ctx.channel()).thenReturn(channel);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Singleton.INST.single(WillRepository.class, new WillRepository());
+        Singleton.INST.single(ChannelRepository.class, new ChannelRepository());
+    }
+
+    @Test
+    public void testDisconnectClearsWill() {
+        WillRepository.WillEntry will = new WillRepository.WillEntry("topic/will", "goodbye".getBytes(), 0, false);
+        willRepository.add(channel, will);
+
+        disconnect.disconnect(ctx);
+
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testDisconnectWithoutWill() {
+        disconnect.disconnect(ctx);
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testDisconnectRemovesChannel() {
+        channelRepository.add(channel, "client-1");
+        disconnect.disconnect(ctx);
+        assertThat(channelRepository.get(channel), nullValue());
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
@@ -71,7 +71,7 @@ public class MqttTransportHandlerTest {
         willRepository.add(channel, will);
 
         // publishWill uses subscribeRepository to get target channels
-        when(subscribeRepository.get("status/offline")).thenReturn(java.util.Collections.emptyList());
+        when(subscribeRepository.getChannelsByTopic("status/offline")).thenReturn(java.util.Collections.emptyList());
 
         handler.channelInactive(ctx);
 

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MqttTransportHandlerTest {
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private SubscribeRepository subscribeRepository;
+
+    private MqttTransportHandler handler;
+
+    private WillRepository willRepository;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new MqttTransportHandler();
+        willRepository = new WillRepository();
+        Singleton.INST.single(WillRepository.class, willRepository);
+        Singleton.INST.single(SubscribeRepository.class, subscribeRepository);
+        when(ctx.channel()).thenReturn(channel);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Singleton.INST.single(WillRepository.class, new WillRepository());
+        Singleton.INST.single(SubscribeRepository.class, new SubscribeRepository());
+    }
+
+    @Test
+    public void testChannelInactiveFiresWillAndRemovesIt() throws Exception {
+        byte[] willMessage = "sudden disconnect".getBytes();
+        WillRepository.WillEntry will = new WillRepository.WillEntry("status/offline", willMessage, 1, true);
+        willRepository.add(channel, will);
+
+        // publishWill uses subscribeRepository to get target channels
+        when(subscribeRepository.get("status/offline")).thenReturn(java.util.Collections.emptyList());
+
+        handler.channelInactive(ctx);
+
+        // will should be removed after firing
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testChannelInactiveDoesNothingWhenNoWill() throws Exception {
+        handler.channelInactive(ctx);
+
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testChannelInactiveAfterDisconnectClearsWill() throws Exception {
+        byte[] willMessage = "graceful close".getBytes();
+        WillRepository.WillEntry will = new WillRepository.WillEntry("status/clean", willMessage, 0, false);
+        willRepository.add(channel, will);
+
+        // simulate graceful disconnect: remove will first, then channelInactive
+        willRepository.remove(channel);
+        handler.channelInactive(ctx);
+
+        assertThat(willRepository.get(channel), nullValue());
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishWillTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishWillTest.java
@@ -62,7 +62,7 @@ public class PublishWillTest {
     @Test
     public void testPublishWillToActiveSubscriber() {
         when(subscriberChannel.isActive()).thenReturn(true);
-        when(subscribeRepository.get("status/offline"))
+        when(subscribeRepository.getChannelsByTopic("status/offline"))
                 .thenReturn(Collections.singletonList(subscriberChannel));
 
         byte[] message = "client lost".getBytes();
@@ -80,7 +80,7 @@ public class PublishWillTest {
     @Test
     public void testPublishWillSkipsInactiveChannel() {
         when(subscriberChannel.isActive()).thenReturn(false);
-        when(subscribeRepository.get("status/inactive"))
+        when(subscribeRepository.getChannelsByTopic("status/inactive"))
                 .thenReturn(Collections.singletonList(subscriberChannel));
 
         WillRepository.WillEntry will = new WillRepository.WillEntry("status/inactive", "msg".getBytes(), 0, false);
@@ -91,7 +91,7 @@ public class PublishWillTest {
 
     @Test
     public void testPublishWillToEmptySubscribers() {
-        when(subscribeRepository.get("topic/none")).thenReturn(Collections.emptyList());
+        when(subscribeRepository.getChannelsByTopic("topic/none")).thenReturn(Collections.emptyList());
 
         WillRepository.WillEntry will = new WillRepository.WillEntry("topic/none", "msg".getBytes(), 2, false);
         Publish.publishWill(will);
@@ -100,7 +100,7 @@ public class PublishWillTest {
     @Test
     public void testPublishWillQosAndRetain() {
         when(subscriberChannel.isActive()).thenReturn(true);
-        when(subscribeRepository.get("qos/retain"))
+        when(subscribeRepository.getChannelsByTopic("qos/retain"))
                 .thenReturn(Collections.singletonList(subscriberChannel));
 
         WillRepository.WillEntry will = new WillRepository.WillEntry("qos/retain", "data".getBytes(), 0, false);
@@ -111,5 +111,20 @@ public class PublishWillTest {
         MqttPublishMessage published = (MqttPublishMessage) captor.getValue();
         assertEquals(0, published.fixedHeader().qosLevel().value());
         assertFalse(published.fixedHeader().isRetain());
+    }
+
+    @Test
+    public void testPublishWillToWildcardSubscriber() {
+        when(subscriberChannel.isActive()).thenReturn(true);
+        when(subscribeRepository.getChannelsByTopic("status/client-001"))
+                .thenReturn(Collections.singletonList(subscriberChannel));
+
+        WillRepository.WillEntry will = new WillRepository.WillEntry("status/client-001", "gone".getBytes(), 0, false);
+        Publish.publishWill(will);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(subscriberChannel).writeAndFlush(captor.capture());
+        MqttPublishMessage published = (MqttPublishMessage) captor.getValue();
+        assertEquals("status/client-001", published.variableHeader().topicName());
     }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishWillTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishWillTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.WillRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PublishWillTest {
+
+    @Mock
+    private SubscribeRepository subscribeRepository;
+
+    @Mock
+    private Channel subscriberChannel;
+
+    @BeforeEach
+    public void setUp() {
+        Singleton.INST.single(SubscribeRepository.class, subscribeRepository);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Singleton.INST.single(SubscribeRepository.class, new SubscribeRepository());
+    }
+
+    @Test
+    public void testPublishWillToActiveSubscriber() {
+        when(subscriberChannel.isActive()).thenReturn(true);
+        when(subscribeRepository.get("status/offline"))
+                .thenReturn(Collections.singletonList(subscriberChannel));
+
+        byte[] message = "client lost".getBytes();
+        WillRepository.WillEntry will = new WillRepository.WillEntry("status/offline", message, 1, true);
+        Publish.publishWill(will);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(subscriberChannel).writeAndFlush(captor.capture());
+        MqttPublishMessage published = (MqttPublishMessage) captor.getValue();
+        assertEquals("status/offline", published.variableHeader().topicName());
+        assertEquals(1, published.fixedHeader().qosLevel().value());
+        assertTrue(published.fixedHeader().isRetain());
+    }
+
+    @Test
+    public void testPublishWillSkipsInactiveChannel() {
+        when(subscriberChannel.isActive()).thenReturn(false);
+        when(subscribeRepository.get("status/inactive"))
+                .thenReturn(Collections.singletonList(subscriberChannel));
+
+        WillRepository.WillEntry will = new WillRepository.WillEntry("status/inactive", "msg".getBytes(), 0, false);
+        Publish.publishWill(will);
+
+        verify(subscriberChannel, never()).writeAndFlush(any());
+    }
+
+    @Test
+    public void testPublishWillToEmptySubscribers() {
+        when(subscribeRepository.get("topic/none")).thenReturn(Collections.emptyList());
+
+        WillRepository.WillEntry will = new WillRepository.WillEntry("topic/none", "msg".getBytes(), 2, false);
+        Publish.publishWill(will);
+    }
+
+    @Test
+    public void testPublishWillQosAndRetain() {
+        when(subscriberChannel.isActive()).thenReturn(true);
+        when(subscribeRepository.get("qos/retain"))
+                .thenReturn(Collections.singletonList(subscriberChannel));
+
+        WillRepository.WillEntry will = new WillRepository.WillEntry("qos/retain", "data".getBytes(), 0, false);
+        Publish.publishWill(will);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(subscriberChannel).writeAndFlush(captor.capture());
+        MqttPublishMessage published = (MqttPublishMessage) captor.getValue();
+        assertEquals(0, published.fixedHeader().qosLevel().value());
+        assertFalse(published.fixedHeader().isRetain());
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TopicMatcherTest {
+
+    @Test
+    void testExactMatch() {
+        assertTrue(TopicMatcher.matches("sport/tennis/player1", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("sport/tennis/player1", "sport/tennis/player2"));
+    }
+
+    @Test
+    void testSingleLevelWildcard() {
+        assertTrue(TopicMatcher.matches("sport/+/player1", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("sport/+/player1", "sport/football/player1"));
+        assertTrue(TopicMatcher.matches("+/tennis/+", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("sport/+/player1", "sport/tennis/stadium/player1"));
+        assertFalse(TopicMatcher.matches("sport/+", "sport"));
+    }
+
+    @Test
+    void testMultiLevelWildcard() {
+        assertTrue(TopicMatcher.matches("#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("#", "sport"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis/player1/ranking"));
+        assertFalse(TopicMatcher.matches("sport#", "sport/tennis"));
+        assertFalse(TopicMatcher.matches("sport/tennis#", "sport/tennis/player1"));
+    }
+
+    @Test
+    void testMixedWildcards() {
+        assertTrue(TopicMatcher.matches("+/tennis/#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("+/tennis/#", "sport/tennis/player1/ranking"));
+        assertTrue(TopicMatcher.matches("sport/+/#", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("+/tennis/#", "sport/football/player1"));
+    }
+
+    @Test
+    void testDollarTopicNotMatchedByLeadingWildcard() {
+        assertFalse(TopicMatcher.matches("#", "$SYS/broker/version"));
+        assertFalse(TopicMatcher.matches("+", "$SYS"));
+        assertFalse(TopicMatcher.matches("+/b", "$SYS/b"));
+        assertTrue(TopicMatcher.matches("$SYS/#", "$SYS/broker/version"));
+        assertTrue(TopicMatcher.matches("$SYS/+", "$SYS/broker"));
+    }
+
+    @Test
+    void testNullInput() {
+        assertFalse(TopicMatcher.matches(null, "topic"));
+        assertFalse(TopicMatcher.matches("topic", null));
+    }
+
+    @Test
+    void testValidFilter() {
+        assertTrue(TopicMatcher.isValidFilter("sport/tennis/player1"));
+        assertTrue(TopicMatcher.isValidFilter("sport/+/player1"));
+        assertTrue(TopicMatcher.isValidFilter("+"));
+        assertTrue(TopicMatcher.isValidFilter("#"));
+        assertTrue(TopicMatcher.isValidFilter("sport/#"));
+        assertTrue(TopicMatcher.isValidFilter("+/tennis/#"));
+    }
+
+    @Test
+    void testInvalidFilter() {
+        assertFalse(TopicMatcher.isValidFilter("sport#"));
+        assertFalse(TopicMatcher.isValidFilter("sport/tennis#"));
+        assertFalse(TopicMatcher.isValidFilter("#/sport"));
+        assertFalse(TopicMatcher.isValidFilter("sport/#/ranking"));
+        assertFalse(TopicMatcher.isValidFilter("sport+"));
+        assertFalse(TopicMatcher.isValidFilter("+tennis"));
+        assertFalse(TopicMatcher.isValidFilter("sport/+tennis"));
+        assertFalse(TopicMatcher.isValidFilter(""));
+        assertFalse(TopicMatcher.isValidFilter(null));
+        assertFalse(TopicMatcher.isValidFilter("sport/" + (char) 0));
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class SubscribeRepositoryTest {
+
+    private final SubscribeRepository repository = new SubscribeRepository();
+
+    private final List<Channel> channels = new ArrayList<>();
+
+    private final List<String> topicFilters = new ArrayList<>();
+
+    @AfterEach
+    void cleanup() throws InterruptedException {
+        if (!topicFilters.isEmpty()) {
+            for (Channel subscribed : channels) {
+                repository.remove(topicFilters, subscribed);
+            }
+            awaitUntil(() -> topicFilters.stream().allMatch(topic -> repository.get(topic).isEmpty()));
+        }
+        channels.forEach(channel -> ((EmbeddedChannel) channel).finishAndReleaseAll());
+    }
+
+    @Test
+    void testGetChannelsByTopicExactMatch() throws InterruptedException {
+        Channel subscriber = newSubscriber("sport/tennis");
+
+        assertTrue(repository.getChannelsByTopic("sport/tennis").contains(subscriber));
+        assertTrue(repository.getChannelsByTopic("sport/tennis/player1").isEmpty());
+    }
+
+    @Test
+    void testGetChannelsByTopicWildcardMatch() throws InterruptedException {
+        Channel subscriber = newSubscriber("sport/+/player1");
+
+        assertTrue(repository.getChannelsByTopic("sport/tennis/player1").contains(subscriber));
+        assertTrue(repository.getChannelsByTopic("sport/tennis").isEmpty());
+    }
+
+    @Test
+    void testGetChannelsByTopicDeduplicatesOverlappingSubscriptions() throws InterruptedException {
+        Channel subscriber = newSubscriber("#", "sport/#");
+
+        // MQTT requires at most one delivery per publish per client
+        assertEquals(1, repository.getChannelsByTopic("sport/tennis").size());
+        assertTrue(repository.getChannelsByTopic("sport/tennis").contains(subscriber));
+    }
+
+    @Test
+    void testGetChannelsByTopicMultipleSubscribers() throws InterruptedException {
+        final Channel first = newSubscriber("sport/tennis");
+        final Channel second = new EmbeddedChannel();
+        channels.add(second);
+        topicFilters.add("sport/tennis");
+        repository.add(second, subscriptions("sport/tennis"));
+        awaitUntil(() -> repository.get("sport/tennis").containsAll(Arrays.asList(first, second)));
+
+        assertEquals(2, repository.getChannelsByTopic("sport/tennis").size());
+    }
+
+    private Channel newSubscriber(final String... topics) throws InterruptedException {
+        Channel subscriber = new EmbeddedChannel();
+        channels.add(subscriber);
+        topicFilters.addAll(Arrays.asList(topics));
+        repository.add(subscriber, subscriptions(topics));
+        awaitUntil(() -> Arrays.stream(topics).allMatch(topic -> repository.get(topic).contains(subscriber)));
+        return subscriber;
+    }
+
+    private List<MqttTopicSubscription> subscriptions(final String... topics) {
+        return Arrays.stream(topics)
+                .map(topic -> new MqttTopicSubscription(topic, MqttQoS.AT_MOST_ONCE))
+                .collect(Collectors.toList());
+    }
+
+    private void awaitUntil(final BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() >= deadline) {
+                fail("condition not met within timeout");
+            }
+            Thread.sleep(10);
+        }
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/WillRepositoryTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/WillRepositoryTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WillRepositoryTest {
+
+    private WillRepository willRepository;
+
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    public void setUp() {
+        willRepository = new WillRepository();
+        channel = new EmbeddedChannel();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        channel.close();
+    }
+
+    @Test
+    public void testAddAndGetWillEntry() {
+        byte[] message = "offline".getBytes();
+        WillRepository.WillEntry entry = new WillRepository.WillEntry("topic/test", message, 1, true);
+        willRepository.add(channel, entry);
+
+        WillRepository.WillEntry result = willRepository.get(channel);
+        assertThat(result, notNullValue());
+        assertEquals("topic/test", result.getTopic());
+        assertArrayEquals(message, result.getMessage());
+        assertEquals(1, result.getQos());
+        assertTrue(result.isRetain());
+    }
+
+    @Test
+    public void testRemoveWillEntry() {
+        WillRepository.WillEntry entry = new WillRepository.WillEntry("topic/test", "bye".getBytes(), 0, false);
+        willRepository.add(channel, entry);
+        assertThat(willRepository.get(channel), notNullValue());
+
+        willRepository.remove(channel);
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testGetReturnsNullForUnknownChannel() {
+        assertThat(willRepository.get(channel), nullValue());
+    }
+
+    @Test
+    public void testWillEntryFields() {
+        byte[] message = "disconnected".getBytes();
+        WillRepository.WillEntry entry = new WillRepository.WillEntry("alerts/disconnect", message, 2, false);
+
+        assertEquals("alerts/disconnect", entry.getTopic());
+        assertArrayEquals("disconnected".getBytes(), entry.getMessage());
+        assertEquals(2, entry.getQos());
+        assertFalse(entry.isRetain());
+    }
+
+    @Test
+    public void testReplaceWillEntryOnReconnect() {
+        WillRepository.WillEntry first = new WillRepository.WillEntry("topic/a", "msg1".getBytes(), 0, false);
+        WillRepository.WillEntry second = new WillRepository.WillEntry("topic/b", "msg2".getBytes(), 1, true);
+        willRepository.add(channel, first);
+        willRepository.add(channel, second);
+
+        WillRepository.WillEntry result = willRepository.get(channel);
+        assertEquals("topic/b", result.getTopic());
+        assertArrayEquals("msg2".getBytes(), result.getMessage());
+    }
+
+    @Test
+    public void testRemoveNonexistentChannel() {
+        EmbeddedChannel otherChannel = new EmbeddedChannel();
+        try {
+            willRepository.remove(otherChannel);
+            assertThat(willRepository.get(channel), nullValue());
+        } finally {
+            otherChannel.close();
+        }
+    }
+}


### PR DESCRIPTION
Parse and store will fields (topic, message, QoS, retain) in WillRepository on CONNECT. Publish will message to subscribers on ungraceful disconnect via channelInactive hook. Clear will on graceful DISCONNECT. Fix DISCONNECT message dispatch in MqttFactory that was previously dropped.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary

### Core changes:                                                                                                                                                                      

  - WillRepository.java (new) — A ConcurrentHashMap-backed repository that stores WillEntry (topic, message bytes, QoS, retain flag) keyed by Netty Channel. Implements the existing 
  BaseRepository interface.
  - Connect.java — On CONNECT, if isWillFlag() is true, extracts the will fields from the MQTT CONNECT payload and stores them via WillRepository.                                   
  - Disconnect.java — On graceful DISCONNECT, removes the will from WillRepository (so it won't fire). Replaces the old // todo Last words placeholder.                              
  - MqttTransportHandler.java — Overrides channelInactive() to detect ungraceful disconnects. If a will is still present for that channel when it goes inactive, it publishes the    
  will via Publish.publishWill() and then clears it.                                                                                                                                 
  - Publish.java — New publishWill() static method that looks up subscribers for the will topic and writes the will message as an MQTT PUBLISH packet to each active subscriber      
  channel.                                                                                                                                                                           
  - MqttFactory.java — Fixes a bug where DISCONNECT was falling through to PUBACK/default instead of calling messageType.disconnect(ctx).
  - pom.xml — Adds JUnit Jupiter, Mockito, and maven-surefire-plugin with --add-opens JVM args for testing.                                                                          
                                                                                                                                                                                     
### Tests (5 new test files): 

- ConnectTest, DisconnectTest, MqttTransportHandlerTest, PublishWillTest, and WillRepositoryTest — covering will storage on connect, will clearance on disconnect, will firing on channel inactivity, inactive channel skipping, empty subscriber handling, and QoS/retain flag propagation. 

close [#6852](https://github.com/apache/shenyu/issues/6852)