### PR TITLE
feat: implement MQTT wildcard subscription matching

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -113,7 +113,7 @@ public class Publish extends MessageType {
     }
 
     private void send(final String topic, final ByteBuf payload, final int packetId) {
-        List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(topic);
+        List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).getChannelsByTopic(topic);
         //// todo thread pool
         channels.parallelStream().forEach(channel -> {
             if (channel.isActive()) {

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Subscribe.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Subscribe.java
@@ -61,36 +61,40 @@ public class Subscribe extends MessageType {
         int packetId = msg.variableHeader().messageId();
 
         //// todo Regular match
-        List<String> ackTopics = mqttTopicSubscriptions
+        List<MqttTopicSubscription> validSubscriptions = mqttTopicSubscriptions
                 .stream()
                 .filter(topicSub -> topicSub.qualityOfService() != FAILURE)
-                .map(MqttTopicSubscription::topicName)
+                .filter(topicSub -> TopicMatcher.isValidFilter(topicSub.topicName()))
                 .collect(Collectors.toList());
 
-        Singleton.INST.get(SubscribeRepository.class).add(ctx.channel(), mqttTopicSubscriptions);
+        Singleton.INST.get(SubscribeRepository.class).add(ctx.channel(), validSubscriptions);
 
-        for (String ackTopic : ackTopics) {
-            String message = Singleton.INST.get(TopicRepository.class).get(ackTopic);
+        for (MqttTopicSubscription subscription : validSubscriptions) {
+            String message = Singleton.INST.get(TopicRepository.class).get(subscription.topicName());
             if (StringUtils.isNotEmpty(message)) {
-                sendSubMessage(ackTopic, message, packetId, channel);
+                sendSubMessage(subscription.topicName(), message, packetId, channel);
             }
         }
 
-        sendSubAckMessage(packetId, ackTopics, channel);
+        sendSubAckMessage(packetId, mqttTopicSubscriptions, channel);
     }
 
     /**
      * call back request of message.
      * @param packetId packetId
-     * @param ackTopics ackTopics
+     * @param subscriptions subscriptions
      * @param channel channel
      */
-    private void sendSubAckMessage(final int packetId, final List<String> ackTopics, final Channel channel) {
+    private void sendSubAckMessage(final int packetId, final List<MqttTopicSubscription> subscriptions, final Channel channel) {
 
         List<Integer> qos = new ArrayList<>();
-        for (int i = 0; i < ackTopics.size(); i++) {
-            // default qos 0
-            qos.add(MqttQoS.AT_MOST_ONCE.value());
+        for (MqttTopicSubscription subscription : subscriptions) {
+            // invalid topic filters are rejected with 0x80, otherwise default qos 0
+            if (TopicMatcher.isValidFilter(subscription.topicName())) {
+                qos.add(MqttQoS.AT_MOST_ONCE.value());
+            } else {
+                qos.add(MqttQoS.FAILURE.value());
+            }
         }
 
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.SUBACK, false, AT_MOST_ONCE,

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
@@ -73,4 +73,31 @@ public final class TopicMatcher {
 
         return filterLen == topicLen;
     }
+
+    /**
+     * Validate a topic filter per MQTT-4.7.1: wildcards must occupy an entire
+     * level, and # must be the last level. Filters must not be empty or
+     * contain the null character.
+     *
+     * @param filter the subscription topic filter
+     * @return true if the filter is valid
+     */
+    public static boolean isValidFilter(final String filter) {
+        if (Objects.isNull(filter) || filter.isEmpty() || filter.indexOf((char) 0) >= 0) {
+            return false;
+        }
+        String[] levels = filter.split("/", -1);
+        for (int i = 0; i < levels.length; i++) {
+            String level = levels[i];
+            if (level.indexOf('+') >= 0 || level.indexOf('#') >= 0) {
+                if (level.length() > 1) {
+                    return false;
+                }
+                if ("#".equals(level) && i != levels.length - 1) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/TopicMatcher.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import java.util.Objects;
+
+/**
+ * MQTT topic filter matching per MQTT-4.7.
+ *
+ * <p>+ matches exactly one topic level.</p>
+ *
+ * <p># matches any number of subsequent levels (must appear at the end of the filter).</p>
+ */
+public final class TopicMatcher {
+
+    private TopicMatcher() {
+    }
+
+    /**
+     * Check whether a topic filter matches a topic name.
+     *
+     * @param filter the subscription topic filter (may contain + and # wildcards)
+     * @param topic  the published topic name (no wildcards)
+     * @return true if the filter matches the topic
+     */
+    public static boolean matches(final String filter, final String topic) {
+        if (Objects.isNull(filter) || Objects.isNull(topic)) {
+            return false;
+        }
+
+        // $ topics must not be matched by wildcards at the first level
+        if (topic.startsWith("$") && filter.length() > 0 && (filter.charAt(0) == '+' || filter.charAt(0) == '#')) {
+            return false;
+        }
+
+        String[] filterLevels = filter.split("/", -1);
+        String[] topicLevels = topic.split("/", -1);
+
+        int filterLen = filterLevels.length;
+        int topicLen = topicLevels.length;
+
+        for (int i = 0; i < filterLen; i++) {
+            String f = filterLevels[i];
+
+            if ("#".equals(f)) {
+                // MQTT-4.7.1-2: # matches any number of levels including the parent level
+                return i == filterLen - 1;
+            }
+
+            if (i >= topicLen) {
+                return false;
+            }
+
+            if (!"+".equals(f) && !f.equals(topicLevels[i])) {
+                return false;
+            }
+        }
+
+        return filterLen == topicLen;
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -19,9 +19,11 @@ package org.apache.shenyu.protocol.mqtt.repositories;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.shenyu.protocol.mqtt.TopicMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,6 +91,23 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      */
     public List<Channel> get(final String topic) {
         return TOPIC_CHANNEL_FACTORY.getOrDefault(topic, new CopyOnWriteArrayList<>());
+    }
+
+    /**
+     * Get channels whose subscription filter matches the published topic.
+     * Supports MQTT wildcards: + (single-level) and # (multi-level).
+     *
+     * @param topic the published topic name
+     * @return channels subscribed to matching topic filters
+     */
+    public List<Channel> getChannelsByTopic(final String topic) {
+        List<Channel> result = new ArrayList<>();
+        for (Map.Entry<String, List<Channel>> entry : TOPIC_CHANNEL_FACTORY.entrySet()) {
+            if (TopicMatcher.matches(entry.getKey(), topic)) {
+                result.addAll(entry.getValue());
+            }
+        }
+        return result;
     }
 
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -24,8 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -101,13 +103,26 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      * @return channels subscribed to matching topic filters
      */
     public List<Channel> getChannelsByTopic(final String topic) {
-        List<Channel> result = new ArrayList<>();
+        // MQTT requires at most one delivery per publish per client, so dedupe
+        // channels when overlapping filters (e.g. sport/# and #) both match.
+        Set<Channel> result = new LinkedHashSet<>();
+
+        // fast path: exact subscription, no wildcard scan needed
+        List<Channel> exactMatch = TOPIC_CHANNEL_FACTORY.get(topic);
+        if (Objects.nonNull(exactMatch)) {
+            result.addAll(exactMatch);
+        }
+
         for (Map.Entry<String, List<Channel>> entry : TOPIC_CHANNEL_FACTORY.entrySet()) {
-            if (TopicMatcher.matches(entry.getKey(), topic)) {
+            String filter = entry.getKey();
+            if (filter.equals(topic) || filter.indexOf('+') < 0 && filter.indexOf('#') < 0) {
+                continue;
+            }
+            if (TopicMatcher.matches(filter, topic)) {
                 result.addAll(entry.getValue());
             }
         }
-        return result;
+        return new ArrayList<>(result);
     }
 
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/SubscribeTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/SubscribeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class SubscribeTest {
+
+    @Test
+    void testSubscribeRejectsInvalidTopicFilter() throws InterruptedException {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter());
+        ChannelHandlerContext ctx = channel.pipeline().firstContext();
+        MqttSubscribeMessage msg = MqttMessageBuilders.subscribe()
+                .messageId(1)
+                .addSubscription(MqttQoS.AT_MOST_ONCE, "sport/#")
+                .addSubscription(MqttQoS.AT_MOST_ONCE, "bad#filter")
+                .build();
+
+        SubscribeRepository repository = new SubscribeRepository();
+        Singleton.INST.single(SubscribeRepository.class, repository);
+        Singleton.INST.single(TopicRepository.class, new TopicRepository());
+
+        new Subscribe().subscribe(ctx, msg);
+        awaitUntil(() -> repository.get("sport/#").contains(channel));
+        assertTrue(repository.get("bad#filter").isEmpty());
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertNotNull(subAck);
+        List<Integer> granted = subAck.payload().grantedQoSLevels();
+        assertEquals(2, granted.size());
+        assertEquals(0, granted.get(0).intValue());
+        assertEquals(0x80, granted.get(1).intValue());
+
+        repository.remove(Collections.singletonList("sport/#"), channel);
+        awaitUntil(() -> repository.get("sport/#").isEmpty());
+        channel.finishAndReleaseAll();
+    }
+
+    private void awaitUntil(final BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() >= deadline) {
+                fail("condition not met within timeout");
+            }
+            Thread.sleep(10);
+        }
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
@@ -73,4 +73,28 @@ class TopicMatcherTest {
         assertFalse(TopicMatcher.matches(null, "topic"));
         assertFalse(TopicMatcher.matches("topic", null));
     }
+
+    @Test
+    void testValidFilter() {
+        assertTrue(TopicMatcher.isValidFilter("sport/tennis/player1"));
+        assertTrue(TopicMatcher.isValidFilter("sport/+/player1"));
+        assertTrue(TopicMatcher.isValidFilter("+"));
+        assertTrue(TopicMatcher.isValidFilter("#"));
+        assertTrue(TopicMatcher.isValidFilter("sport/#"));
+        assertTrue(TopicMatcher.isValidFilter("+/tennis/#"));
+    }
+
+    @Test
+    void testInvalidFilter() {
+        assertFalse(TopicMatcher.isValidFilter("sport#"));
+        assertFalse(TopicMatcher.isValidFilter("sport/tennis#"));
+        assertFalse(TopicMatcher.isValidFilter("#/sport"));
+        assertFalse(TopicMatcher.isValidFilter("sport/#/ranking"));
+        assertFalse(TopicMatcher.isValidFilter("sport+"));
+        assertFalse(TopicMatcher.isValidFilter("+tennis"));
+        assertFalse(TopicMatcher.isValidFilter("sport/+tennis"));
+        assertFalse(TopicMatcher.isValidFilter(""));
+        assertFalse(TopicMatcher.isValidFilter(null));
+        assertFalse(TopicMatcher.isValidFilter("sport/" + (char) 0));
+    }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/TopicMatcherTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TopicMatcherTest {
+
+    @Test
+    void testExactMatch() {
+        assertTrue(TopicMatcher.matches("sport/tennis/player1", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("sport/tennis/player1", "sport/tennis/player2"));
+    }
+
+    @Test
+    void testSingleLevelWildcard() {
+        assertTrue(TopicMatcher.matches("sport/+/player1", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("sport/+/player1", "sport/football/player1"));
+        assertTrue(TopicMatcher.matches("+/tennis/+", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("sport/+/player1", "sport/tennis/stadium/player1"));
+        assertFalse(TopicMatcher.matches("sport/+", "sport"));
+    }
+
+    @Test
+    void testMultiLevelWildcard() {
+        assertTrue(TopicMatcher.matches("#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("#", "sport"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("sport/#", "sport/tennis/player1/ranking"));
+        assertFalse(TopicMatcher.matches("sport#", "sport/tennis"));
+        assertFalse(TopicMatcher.matches("sport/tennis#", "sport/tennis/player1"));
+    }
+
+    @Test
+    void testMixedWildcards() {
+        assertTrue(TopicMatcher.matches("+/tennis/#", "sport/tennis/player1"));
+        assertTrue(TopicMatcher.matches("+/tennis/#", "sport/tennis/player1/ranking"));
+        assertTrue(TopicMatcher.matches("sport/+/#", "sport/tennis/player1"));
+        assertFalse(TopicMatcher.matches("+/tennis/#", "sport/football/player1"));
+    }
+
+    @Test
+    void testDollarTopicNotMatchedByLeadingWildcard() {
+        assertFalse(TopicMatcher.matches("#", "$SYS/broker/version"));
+        assertFalse(TopicMatcher.matches("+", "$SYS"));
+        assertFalse(TopicMatcher.matches("+/b", "$SYS/b"));
+        assertTrue(TopicMatcher.matches("$SYS/#", "$SYS/broker/version"));
+        assertTrue(TopicMatcher.matches("$SYS/+", "$SYS/broker"));
+    }
+
+    @Test
+    void testNullInput() {
+        assertFalse(TopicMatcher.matches(null, "topic"));
+        assertFalse(TopicMatcher.matches("topic", null));
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class SubscribeRepositoryTest {
+
+    private final SubscribeRepository repository = new SubscribeRepository();
+
+    private final List<Channel> channels = new ArrayList<>();
+
+    private final List<String> topicFilters = new ArrayList<>();
+
+    @AfterEach
+    void cleanup() throws InterruptedException {
+        if (!topicFilters.isEmpty()) {
+            for (Channel subscribed : channels) {
+                repository.remove(topicFilters, subscribed);
+            }
+            awaitUntil(() -> topicFilters.stream().allMatch(topic -> repository.get(topic).isEmpty()));
+        }
+        channels.forEach(channel -> ((EmbeddedChannel) channel).finishAndReleaseAll());
+    }
+
+    @Test
+    void testGetChannelsByTopicExactMatch() throws InterruptedException {
+        Channel subscriber = newSubscriber("sport/tennis");
+
+        assertTrue(repository.getChannelsByTopic("sport/tennis").contains(subscriber));
+        assertTrue(repository.getChannelsByTopic("sport/tennis/player1").isEmpty());
+    }
+
+    @Test
+    void testGetChannelsByTopicWildcardMatch() throws InterruptedException {
+        Channel subscriber = newSubscriber("sport/+/player1");
+
+        assertTrue(repository.getChannelsByTopic("sport/tennis/player1").contains(subscriber));
+        assertTrue(repository.getChannelsByTopic("sport/tennis").isEmpty());
+    }
+
+    @Test
+    void testGetChannelsByTopicDeduplicatesOverlappingSubscriptions() throws InterruptedException {
+        Channel subscriber = newSubscriber("#", "sport/#");
+
+        // MQTT requires at most one delivery per publish per client
+        assertEquals(1, repository.getChannelsByTopic("sport/tennis").size());
+        assertTrue(repository.getChannelsByTopic("sport/tennis").contains(subscriber));
+    }
+
+    @Test
+    void testGetChannelsByTopicMultipleSubscribers() throws InterruptedException {
+        final Channel first = newSubscriber("sport/tennis");
+        final Channel second = new EmbeddedChannel();
+        channels.add(second);
+        topicFilters.add("sport/tennis");
+        repository.add(second, subscriptions("sport/tennis"));
+        awaitUntil(() -> repository.get("sport/tennis").containsAll(Arrays.asList(first, second)));
+
+        assertEquals(2, repository.getChannelsByTopic("sport/tennis").size());
+    }
+
+    private Channel newSubscriber(final String... topics) throws InterruptedException {
+        Channel subscriber = new EmbeddedChannel();
+        channels.add(subscriber);
+        topicFilters.addAll(Arrays.asList(topics));
+        repository.add(subscriber, subscriptions(topics));
+        awaitUntil(() -> Arrays.stream(topics).allMatch(topic -> repository.get(topic).contains(subscriber)));
+        return subscriber;
+    }
+
+    private List<MqttTopicSubscription> subscriptions(final String... topics) {
+        return Arrays.stream(topics)
+                .map(topic -> new MqttTopicSubscription(topic, MqttQoS.AT_MOST_ONCE))
+                .collect(Collectors.toList());
+    }
+
+    private void awaitUntil(final BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() >= deadline) {
+                fail("condition not met within timeout");
+            }
+            Thread.sleep(10);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary:                                                                                                                     
                                            
Problem                                                                                                                                                                            
                                                                                                                                                                                     
Subscriptions using + (single-level wildcard) or # (multi-level wildcard) were silently broken. Publish.send() performed an exact-key lookup (ConcurrentHashMap.getOrDefault), so a publish to sensor/room1/temperature would never match a subscription filter like sensor/+/temperature.                                                                            
                  
Changes

  1. New: TopicMatcher.java — Utility class implementing MQTT topic filter matching per the MQTT-4.7 spec:
    - + matches exactly one topic level
    - # matches any number of levels (must appear at the end of the filter)
    - Wildcards at the first level do not match $-prefixed topics
  3. Modified: SubscribeRepository.java — Added getChannelsByTopic(String topic) method that iterates over all stored subscription filters and returns channels whose filter matches 
  the published topic using TopicMatcher.matches().                                                                                                                                  
  4. Modified: Publish.java:116 — Changed send() from get(topic) (exact-key lookup) to getChannelsByTopic(topic) (wildcard-aware matching).                                          
  5. New: TopicMatcherTest.java — 6 unit tests covering: exact match, + single-level, # multi-level, mixed wildcards, $ topic protection, and null inputs.

close [#6851](https://github.com/apache/shenyu/issues/6851)