### PR TITLE
fix(admin): tag_relation updateByPrimaryKeySelective sets non-existent name column

### DIFF
--- a/shenyu-admin/src/main/resources/mappers/tag-relation-sqlmap.xml
+++ b/shenyu-admin/src/main/resources/mappers/tag-relation-sqlmap.xml
@@ -122,7 +122,7 @@
                 date_updated = #{dateUpdated, jdbcType=TIMESTAMP},
             </if>
             <if test="apiId != null">
-                name = #{apiId, jdbcType=VARCHAR},
+                api_id = #{apiId, jdbcType=VARCHAR},
             </if>
             <if test="tagId != null">
                 tag_id = #{tagId, jdbcType=VARCHAR},

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/TagRelationMapperTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/TagRelationMapperTest.java
@@ -87,6 +87,23 @@ public class TagRelationMapperTest extends AbstractSpringIntegrationTest {
     }
 
     @Test
+    public void testUpdateByPrimaryKeySelective() {
+        TagRelationDO record = buildTagRelationDO();
+        int count = tagRelationMapper.insertSelective(record);
+        assertThat(count, greaterThan(0));
+
+        record.setApiId("456");
+        int updateCount = tagRelationMapper.updateByPrimaryKeySelective(record);
+        assertThat(updateCount, greaterThan(0));
+
+        TagRelationDO tagRelationDO = tagRelationMapper.selectByPrimaryKey(record.getId());
+        assertThat(tagRelationDO.getApiId(), equalTo("456"));
+
+        int delete = tagRelationMapper.deleteByPrimaryKey(record.getId());
+        assertThat(delete, equalTo(1));
+    }
+
+    @Test
     public void testSelectByQuery() {
         TagRelationDO record = buildTagRelationDO();
         int count = tagRelationMapper.insertSelective(record);


### PR DESCRIPTION
Fixes #6830

### Problem

`tag-relation-sqlmap.xml` line 125 emits `name = #{apiId, jdbcType=VARCHAR}` in the `apiId` branch of `updateByPrimaryKeySelective`, but `tag_relation` only has the columns `id`, `api_id`, `tag_id`, `date_created` and `date_updated`. There is no `name` column.

This is reachable from the REST layer: `PUT /tag-relation/id/{id}` → `TagRelationController.updateTagRelation` → `TagRelationServiceImpl.update` → `TagRelationDO.buildTagRelationDO`, which always populates `apiId` from the DTO. Whenever the request body carries an `apiId`, the `<if>` branch fires and the statement becomes `UPDATE tag_relation SET name = ? ...`, which fails with a SQL grammar error instead of performing the update.

The sibling `updateByPrimaryKey` in the same mapper (line 137) already uses `api_id`, which confirms this is a copy-paste defect rather than intent.

### Change

- `tag-relation-sqlmap.xml`: `name` → `api_id` in `updateByPrimaryKeySelective`.
- `TagRelationMapperTest`: add `testUpdateByPrimaryKeySelective`. This was the only `TagRelationMapper` method the test class did not cover, which is why the defect went unnoticed. The test inserts a row, updates `apiId`, asserts the new value is persisted, and deletes the row so it does not perturb the sibling tests that assert on row counts.

### Verification

Run against JDK 17 (matching the CI matrix):

With the fix applied:

```
[INFO] You have 0 Checkstyle violations.
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0 - in org.apache.shenyu.admin.mapper.TagRelationMapperTest
[INFO] BUILD SUCCESS
```

With the mapper change reverted and only the new test in place, to confirm the test actually pins the defect:

```
[ERROR] TagRelationMapperTest.testUpdateByPrimaryKeySelective:96 » BadSqlGrammar
### Cause: org.h2.jdbc.JdbcSQLSyntaxErrorException: Column "NAME" not found
```

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed. Scope note: I ran `./mvnw -pl shenyu-admin -am -DskipTests install` followed by `./mvnw -pl shenyu-admin test -Dtest=TagRelationMapperTest` with Checkstyle enabled, rather than a full-reactor `clean install`. The change touches a single MyBatis statement in `shenyu-admin`, so no other module is affected.
