### PR TITLE
fix(admin): InstanceInfoServiceImpl.findById always returns null

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java
@@ -90,7 +90,8 @@ public class InstanceInfoServiceImpl implements InstanceInfoService {
 
     @Override
     public InstanceInfoVO findById(final String id) {
-        return null;
+        InstanceInfoDO instanceInfoDO = instanceInfoMapper.selectById(id);
+        return Objects.isNull(instanceInfoDO) ? null : this.buildInstanceInfoVO(instanceInfoDO);
     }
 
     private List<InstanceInfoVO> buildInstanceInfoVO(final List<InstanceInfoDO> instanceInfoDOList) {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/InstanceInfoServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/InstanceInfoServiceTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -98,8 +99,20 @@ public final class InstanceInfoServiceTest {
 
     @Test
     void testFindById() {
-        // current implementation returns null
-        assertEquals(null, instanceInfoService.findById("any"));
+        InstanceInfoDO instanceInfoDO = buildDO();
+        when(instanceInfoMapper.selectById("id-1")).thenReturn(instanceInfoDO);
+        InstanceInfoVO instanceInfoVO = instanceInfoService.findById("id-1");
+        assertNotNull(instanceInfoVO);
+        assertEquals(instanceInfoDO.getInstanceIp(), instanceInfoVO.getInstanceIp());
+        assertEquals(instanceInfoDO.getInstancePort(), instanceInfoVO.getInstancePort());
+        assertEquals(instanceInfoDO.getInstanceType(), instanceInfoVO.getInstanceType());
+        assertEquals(instanceInfoDO.getNamespaceId(), instanceInfoVO.getNamespaceId());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(instanceInfoMapper.selectById("not-exist")).thenReturn(null);
+        assertNull(instanceInfoService.findById("not-exist"));
     }
 
     private InstanceInfoVO buildVO() {


### PR DESCRIPTION
Fixes #6618

### Problem

`InstanceInfoServiceImpl.findById` was a stub:

```java
@Override
public InstanceInfoVO findById(final String id) {
    return null;
}
```

It never read from `instanceInfoMapper`. `InstanceController.detailInstanceInfo` (`GET /instance/{id}`, gated by `system:instance:edit`) passes the result straight into the response payload, so the instance detail endpoint always answered with null data regardless of whether the row existed. The feature was non-functional.

Everything needed to implement it was already present in the class: `InstanceInfoMapper.selectById(String)` and the private `buildInstanceInfoVO(InstanceInfoDO)` helper already used by `list()` and `listByPage(...)`.

### Change

- Implement `findById` via `instanceInfoMapper.selectById(id)` and the existing `buildInstanceInfoVO` mapper. A missing row still yields `null`, so the controller contract is unchanged and this stays a pure bug fix rather than a behaviour change.
- `InstanceInfoServiceTest.testFindById` previously pinned the stub in place:

```java
@Test
void testFindById() {
    // current implementation returns null
    assertEquals(null, instanceInfoService.findById("any"));
}
```

  It is replaced by a case asserting the DO is mapped onto the VO, plus a `testFindByIdNotFound` case covering the missing-row path.

### Verification

Run against JDK 17, matching the CI matrix.

With the fix applied:

```
[INFO] You have 0 Checkstyle violations.
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 - in org.apache.shenyu.admin.service.InstanceInfoServiceTest
[INFO] BUILD SUCCESS
```

With the service change reverted to the stub and only the new tests in place, to confirm they actually pin the defect:

```
[ERROR] InstanceInfoServiceTest.testFindById:105 expected: not <null>
[ERROR] InstanceInfoServiceTest.testFindByIdNotFound » UnnecessaryStubbing
```

The second failure is Mockito strict stubbing reporting that the stub implementation never reaches the mapper at all.

Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed. Scope note: I ran `./mvnw -pl shenyu-admin -am -DskipTests install` followed by `./mvnw -pl shenyu-admin test -Dtest=InstanceInfoServiceTest` with Checkstyle enabled, rather than a full-reactor `clean install`. The change is confined to one method in `shenyu-admin`.
