### PR TITLE
fix: correct thread pool keep-alive time unit from microseconds to mi…

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/main/java/org/apache/shenyu/plugin/aliyun/sls/client/AliyunSlsLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/main/java/org/apache/shenyu/plugin/aliyun/sls/client/AliyunSlsLogCollectClient.java
@@ -181,7 +181,7 @@ public class AliyunSlsLogCollectClient extends AbstractLogConsumeClient<AliyunLo
             LOG.warn("send thread count number too large!");
             sendThreadCount = GenericLoggingConstant.MAX_ALLOW_THREADS;
         }
-        return new ThreadPoolExecutor(sendThreadCount, GenericLoggingConstant.MAX_ALLOW_THREADS, 60000L, TimeUnit.MICROSECONDS,
+        return new ThreadPoolExecutor(sendThreadCount, GenericLoggingConstant.MAX_ALLOW_THREADS, 60000000L, TimeUnit.MICROSECONDS,
                 new LinkedBlockingQueue<>(GenericLoggingConstant.MAX_QUEUE_NUMBER), ShenyuThreadFactory.create("shenyu-aliyun-sls", true),
                 new ThreadPoolExecutor.AbortPolicy());
     }

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/test/java/org/apache/shenyu/plugin/aliyun/sls/aliyunsls/AliyunSlsLogCollectClientTest.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/test/java/org/apache/shenyu/plugin/aliyun/sls/aliyunsls/AliyunSlsLogCollectClientTest.java
@@ -27,8 +27,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * test cases for AliyunSlsLogCollectClient.
@@ -68,6 +71,18 @@ public class AliyunSlsLogCollectClientTest {
         accessId.setAccessible(true);
         Assertions.assertEquals(accessId.get(aliyunSlsLogCollectClient), "shenyu-test");
         aliyunSlsLogCollectClient.close();
+    }
+
+    @Test
+    public void testCreateThreadPoolExecutorKeepAliveTime() throws ReflectiveOperationException {
+        Method method = AliyunSlsLogCollectClient.class.getDeclaredMethod("createThreadPoolExecutor", AliyunLogCollectConfig.AliyunSlsLogConfig.class);
+        method.setAccessible(true);
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) method.invoke(null, aliyunSlsLogConfig);
+        try {
+            Assertions.assertEquals(60000L, executor.getKeepAliveTime(TimeUnit.MILLISECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/main/java/org/apache/shenyu/plugin/tencent/cls/client/TencentClsLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/main/java/org/apache/shenyu/plugin/tencent/cls/client/TencentClsLogCollectClient.java
@@ -160,7 +160,7 @@ public class TencentClsLogCollectClient extends AbstractLogConsumeClient<Tencent
             LOG.warn("send thread count number too large!");
             threadCount = GenericLoggingConstant.MAX_ALLOW_THREADS;
         }
-        return new ThreadPoolExecutor(threadCount, GenericLoggingConstant.MAX_ALLOW_THREADS, 60000L, TimeUnit.MICROSECONDS,
+        return new ThreadPoolExecutor(threadCount, GenericLoggingConstant.MAX_ALLOW_THREADS, 60000000L, TimeUnit.MICROSECONDS,
                 new LinkedBlockingQueue<>(GenericLoggingConstant.MAX_QUEUE_NUMBER), ShenyuThreadFactory.create("shenyu-tencent-cls", true),
                 new ThreadPoolExecutor.AbortPolicy());
     }

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/test/java/org/apache/shenyu/plugin/tencent/cls/tencentcls/TencentClsLogCollectClientTest.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/test/java/org/apache/shenyu/plugin/tencent/cls/tencentcls/TencentClsLogCollectClientTest.java
@@ -27,9 +27,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * test cases for TencentClsLogCollectClient.
@@ -68,6 +71,18 @@ public class TencentClsLogCollectClientTest {
         field.setAccessible(true);
         Assertions.assertEquals(field.get(tencentClsLogCollectClient), "shenyu-topic-test");
         tencentClsLogCollectClient.close();
+    }
+
+    @Test
+    public void testCreateThreadPoolExecutorKeepAliveTime() throws ReflectiveOperationException {
+        Method method = TencentClsLogCollectClient.class.getDeclaredMethod("createThreadPoolExecutor", int.class);
+        method.setAccessible(true);
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) method.invoke(null, 1);
+        try {
+            Assertions.assertEquals(60000L, executor.getKeepAliveTime(TimeUnit.MILLISECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
…lliseconds in Aliyun and Tencent logging clients

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
