### PR TITLE
Fix #6820 Fix missing Dubbo rpcExt in ApiDoc registration

### DIFF
--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/AbstractApiDocRegistrar.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/AbstractApiDocRegistrar.java
@@ -137,7 +137,7 @@ public abstract class AbstractApiDocRegistrar extends AbstractApiRegistrar<ApiDo
         ext.setServiceName(apiDefinition.getApiBean().getBeanClass().getName());
         ext.setMethodName(apiDefinition.getApiMethodName());
         ext.setParameterTypes(apiDefinition.getParameterTypes());
-        ext.setRpcExt(apiDefinition.getPropertiesValue("RpcExt"));
+        ext.setRpcExt(apiDefinition.getPropertiesValue("rpcExt"));
         ext.setAddPrefixed(addPrefixed);
         
         if (rpcTypeEnum == RpcTypeEnum.HTTP) {

--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImpl.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImpl.java
@@ -110,7 +110,7 @@ public class ApiDocRegistrarImpl extends BaseApiRegistrarImpl {
         apiExt.setServiceName(api.getApiBean().getBeanClass().getName());
         apiExt.setMethodName(api.getApiMethodName());
         apiExt.setParameterTypes(api.getParameterTypes());
-        apiExt.setRpcExt(api.getPropertiesValue("RpcExt"));
+        apiExt.setRpcExt(api.getPropertiesValue("rpcExt"));
         apiExt.setAddPrefixed(clientRegisterConfig.getAddPrefixed());
         final String rpcType = getRpcType(api);
         

--- a/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImplTest.java
+++ b/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImplTest.java
@@ -123,11 +123,36 @@ public class ApiDocRegistrarImplTest {
         assertThat(docMap.get("operationId"), is("/custom"));
     }
 
+    @Test
+    void testGetExtWithRpcExt() throws Exception {
+        ApiBean apiBean = new ApiBean(RpcTypeEnum.DUBBO.getName(),
+                TestDubboService.class.getName(),
+                TestDubboService.class.getDeclaredConstructor().newInstance(),
+                "dubboTestService");
+
+        apiBean.addApiDefinition(TestDubboService.class.getMethod("findById", String.class), "/findById");
+        ApiBean.ApiDefinition apiDefinition = apiBean.getApiDefinitions().get(0);
+        String rpcExt = "{\"group\":\"test-group\",\"version\":\"1.0.0\"}";
+        apiDefinition.addProperties("rpcExt", rpcExt);
+
+        String ext = invokeGetExt(dubboRegistrar, apiDefinition);
+
+        Map<String, Object> extMap = GsonUtils.getInstance().toObjectMap(ext);
+        assertThat(extMap.get("rpcExt"), is(rpcExt));
+    }
+
     @SuppressWarnings("unchecked")
     private String invokeGetDocument(final ApiDocRegistrarImpl registrar, final ApiBean.ApiDefinition api) throws Exception {
         Method getDocumentMethod = ApiDocRegistrarImpl.class.getDeclaredMethod("getDocument", ApiBean.ApiDefinition.class);
         getDocumentMethod.setAccessible(true);
         return (String) getDocumentMethod.invoke(registrar, api);
+    }
+
+    @SuppressWarnings("unchecked")
+    private String invokeGetExt(final ApiDocRegistrarImpl registrar, final ApiBean.ApiDefinition api) throws Exception {
+        Method getExtMethod = ApiDocRegistrarImpl.class.getDeclaredMethod("getExt", ApiBean.ApiDefinition.class);
+        getExtMethod.setAccessible(true);
+        return (String) getExtMethod.invoke(registrar, api);
     }
 
     // --- Inner types (must be after all methods per checkstyle InnerTypeLast) ---

--- a/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/NoHttpApiDocRegistrarTest.java
+++ b/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/NoHttpApiDocRegistrarTest.java
@@ -25,11 +25,14 @@ import org.apache.shenyu.client.core.register.ApiBean;
 import org.apache.shenyu.client.core.register.ClientRegisterConfig;
 import org.apache.shenyu.common.enums.ApiHttpMethodEnum;
 import org.apache.shenyu.common.enums.RpcTypeEnum;
+import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.register.client.api.ShenyuClientRegisterRepository;
 import org.apache.shenyu.register.common.dto.ApiDocRegisterDTO;
 import org.apache.shenyu.register.common.type.DataTypeParent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -128,6 +131,24 @@ public class NoHttpApiDocRegistrarTest {
         assertThat(dto.getDocument(), notNullValue());
         assertThat("responseParameters should contain object type",
                 dto.getDocument().contains("\"responseParameters\""), is(true));
+    }
+
+    @Test
+    public void testRpcExtInExtJson() throws Exception {
+        ApiBean apiBean = new ApiBean(RpcTypeEnum.DUBBO.getName(),
+                DubboTestServiceImpl.class.getName(),
+                DubboTestServiceImpl.class.getDeclaredConstructor().newInstance(),
+                "dubboTestService");
+
+        apiBean.addApiDefinition(DubboTestServiceImpl.class.getMethod("findById", String.class), "/findById");
+        ApiBean.ApiDefinition apiDefinition = apiBean.getApiDefinitions().get(0);
+        String rpcExt = "{\"group\":\"test-group\",\"version\":\"1.0.0\"}";
+        apiDefinition.addProperties("rpcExt", rpcExt);
+
+        noHttpApiDocRegistrar.register(apiBean);
+
+        Map<String, Object> extMap = GsonUtils.getInstance().toObjectMap(testPublisher.metaData.getExt());
+        assertThat(extMap.get("rpcExt"), is(rpcExt));
     }
 
     @Test


### PR DESCRIPTION
Fixes #6820.

## Summary

`DubboServiceProcessor` stores the Dubbo RPC extension using the lowercase `rpcExt` property key, while both ApiDoc registrars read it using `RpcExt`.

Because `Properties` keys are case-sensitive, the generated ApiDoc extension JSON contained a null `rpcExt` value.

This PR:

- Standardizes both ApiDoc registrars to read the lowercase `rpcExt` key.
- Adds regression tests for both registration paths.
- Verifies that Dubbo RPC extension data is preserved in the generated ApiDoc extension JSON.
