### PR TITLE
fix: deliver mqtt messages at granted qos with per-subscriber packet id

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/AbstractMessageType.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/AbstractMessageType.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.protocol.mqtt;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
@@ -85,6 +86,15 @@ public interface AbstractMessageType {
      * @param ctx ctx
      */
     default void disconnect(final ChannelHandlerContext ctx) {
+
+    }
+
+    /**
+     * Publish Release, third message of the QoS 2 protocol flow.
+     * @param ctx ctx
+     * @param msg msg
+     */
+    default void pubRel(final ChannelHandlerContext ctx, final MqttMessage msg) {
 
     }
 

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Disconnect.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Disconnect.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.utils.MqttPacketIdGenerator;
 
 /**
  * The DISCONNECT message is sent from the client to the server to indicate
@@ -45,5 +46,6 @@ public class Disconnect extends MessageType {
     private void cleanChannel(final Channel channel) {
         //// todo ttl
         Singleton.INST.get(ChannelRepository.class).remove(channel);
+        MqttPacketIdGenerator.remove(channel);
     }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MessageType.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MessageType.java
@@ -19,6 +19,7 @@ package org.apache.shenyu.protocol.mqtt;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
@@ -86,5 +87,11 @@ public class MessageType implements AbstractMessageType {
     public void disconnect(final ChannelHandlerContext ctx) {
         //// todo polymorphism disconnect
         new Disconnect().disconnect(ctx);
+    }
+
+    @Override
+    public void pubRel(final ChannelHandlerContext ctx, final MqttMessage msg) {
+        //// todo polymorphism pubRel
+        new PubRel().pubRel(ctx, msg);
     }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttFactory.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttFactory.java
@@ -65,6 +65,9 @@ public class MqttFactory {
             case PINGREQ:
                 messageType.pingReq(ctx);
                 break;
+            case PUBREL:
+                messageType.pubRel(ctx, msg);
+                break;
             case PUBACK:
             case DISCONNECT:
             default:

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandler.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandler.java
@@ -17,11 +17,17 @@
 
 package org.apache.shenyu.protocol.mqtt;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.utils.MqttPacketIdGenerator;
 
 /**
  * mqtt transport handler.
@@ -40,7 +46,10 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
 
     @Override
     public void operationComplete(final Future<? super Void> future) throws Exception {
-
+        Channel channel = ((ChannelFuture) future).channel();
+        Singleton.INST.get(ChannelRepository.class).remove(channel);
+        Singleton.INST.get(SubscribeRepository.class).remove(channel);
+        MqttPacketIdGenerator.remove(channel);
     }
 
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/PubRel.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/PubRel.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+import static io.netty.handler.codec.mqtt.MqttMessageType.PUBCOMP;
+
+/**
+ * The PUBREL message is the third message of the QoS 2 protocol flow,
+ * the server responds with PUBCOMP to release the packet id.
+ */
+public class PubRel extends MessageType {
+
+    @Override
+    public void pubRel(final ChannelHandlerContext ctx, final MqttMessage msg) {
+        MqttMessageIdVariableHeader variableHeader = (MqttMessageIdVariableHeader) msg.variableHeader();
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(PUBCOMP, false, MqttQoS.AT_MOST_ONCE, false, 0);
+        MqttMessage mqttPubCompMessage = new MqttMessage(mqttFixedHeader, variableHeader);
+        ctx.writeAndFlush(mqttPubCompMessage);
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -31,8 +31,9 @@ import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
 import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
+import org.apache.shenyu.protocol.mqtt.utils.MqttPacketIdGenerator;
 
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static io.netty.handler.codec.mqtt.MqttMessageType.PUBACK;
@@ -50,11 +51,10 @@ public class Publish extends MessageType {
         String topic = msg.variableHeader().topicName();
         ByteBuf payload = msg.payload();
         String message = byteBufToString(payload);
-        //// todo qos
         MqttQoS mqttQoS = msg.fixedHeader().qosLevel();
         Singleton.INST.get(TopicRepository.class).add(topic, message);
         int packetId = msg.variableHeader().packetId();
-        CompletableFuture.runAsync(() -> send(topic, payload, packetId));
+        CompletableFuture.runAsync(() -> send(topic, payload, mqttQoS));
 
         switch (mqttQoS.value()) {
             case 0:
@@ -112,16 +112,23 @@ public class Publish extends MessageType {
         }
     }
 
-    private void send(final String topic, final ByteBuf payload, final int packetId) {
-        List<Channel> channels = Singleton.INST.get(SubscribeRepository.class).get(topic);
+    private void send(final String topic, final ByteBuf payload, final MqttQoS publishQoS) {
+        Map<Channel, MqttQoS> subscribers = Singleton.INST.get(SubscribeRepository.class).get(topic);
         //// todo thread pool
-        channels.parallelStream().forEach(channel -> {
+        subscribers.entrySet().parallelStream().forEach(entry -> {
+            Channel channel = entry.getKey();
             if (channel.isActive()) {
-                MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_MOST_ONCE, false, 0);
+                MqttQoS qos = minQoS(publishQoS, entry.getValue());
+                int packetId = MqttQoS.AT_MOST_ONCE == qos ? 0 : MqttPacketIdGenerator.next(channel);
+                MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
                 MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(topic, packetId);
                 MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, Unpooled.wrappedBuffer(payload));
                 channel.writeAndFlush(mqttPublishMessage);
             }
         });
+    }
+
+    private static MqttQoS minQoS(final MqttQoS publishQoS, final MqttQoS grantedQoS) {
+        return publishQoS.value() <= grantedQoS.value() ? publishQoS : grantedQoS;
     }
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static io.netty.handler.codec.mqtt.MqttMessageType.PUBACK;
+import static io.netty.handler.codec.mqtt.MqttMessageType.PUBREC;
 
 /**
  * Publish message.
@@ -74,17 +76,10 @@ public class Publish extends MessageType {
     }
 
     /**
-     * todo qos0.
-     */
-    private void qos0() {
-
-    }
-
-    /**
-     * todo qos1.
+     * send PUBACK to the publisher for a qos1 publish.
      */
     private void qos1(final ChannelHandlerContext ctx, final int packetId) {
-        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(PUBACK, false, MqttQoS.AT_LEAST_ONCE, false, 0);
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(PUBACK, false, MqttQoS.AT_MOST_ONCE, false, 0);
         MqttMessageIdVariableHeader mqttMsgIdVariableHeader = MqttMessageIdVariableHeader.from(packetId);
 
         MqttPubAckMessage mqttPubAckMessage = new MqttPubAckMessage(mqttFixedHeader, mqttMsgIdVariableHeader);
@@ -92,14 +87,14 @@ public class Publish extends MessageType {
     }
 
     /**
-     * todo qos2.
+     * send PUBREC to the publisher for a qos2 publish.
      */
     private void qos2(final ChannelHandlerContext ctx, final int packetId) {
-        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(PUBACK, false, MqttQoS.EXACTLY_ONCE, false, 0);
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(PUBREC, false, MqttQoS.AT_MOST_ONCE, false, 0);
         MqttMessageIdVariableHeader mqttMsgIdVariableHeader = MqttMessageIdVariableHeader.from(packetId);
 
-        MqttPubAckMessage mqttPubAckMessage = new MqttPubAckMessage(mqttFixedHeader, mqttMsgIdVariableHeader);
-        ctx.writeAndFlush(mqttPubAckMessage);
+        MqttMessage mqttPubRecMessage = new MqttMessage(mqttFixedHeader, mqttMsgIdVariableHeader);
+        ctx.writeAndFlush(mqttPubRecMessage);
     }
 
     private String byteBufToString(final ByteBuf byteBuf) {

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Publish.java
@@ -122,7 +122,7 @@ public class Publish extends MessageType {
                 int packetId = MqttQoS.AT_MOST_ONCE == qos ? 0 : MqttPacketIdGenerator.next(channel);
                 MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
                 MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader(topic, packetId);
-                MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, Unpooled.wrappedBuffer(payload));
+                MqttPublishMessage mqttPublishMessage = new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, Unpooled.wrappedBuffer(payload.retain()));
                 channel.writeAndFlush(mqttPublishMessage);
             }
         });

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -18,34 +18,33 @@
 package org.apache.shenyu.protocol.mqtt.repositories;
 
 import io.netty.channel.Channel;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * Topic and channel association.
  */
-public class SubscribeRepository implements BaseRepository<List<String>, List<Channel>> {
+public class SubscribeRepository implements BaseRepository<List<String>, Map<Channel, MqttQoS>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SubscribeRepository.class);
 
-    private static final Map<String, List<Channel>> TOPIC_CHANNEL_FACTORY = new ConcurrentHashMap<>();
+    private static final Map<String, Map<Channel, MqttQoS>> TOPIC_CHANNEL_FACTORY = new ConcurrentHashMap<>();
 
     @Override
-    public void add(final List<String> topics, final List<Channel> channels) {
-        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(s -> {
-            List<Channel> list = get(s);
-            list.addAll(channels);
-            TOPIC_CHANNEL_FACTORY.put(s, list);
-        }));
+    public void add(final List<String> topics, final Map<Channel, MqttQoS> channelQos) {
+        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(topic ->
+                channelQos.forEach((channel, qos) -> TOPIC_CHANNEL_FACTORY
+                        .computeIfAbsent(topic, key -> new ConcurrentHashMap<>())
+                        .merge(channel, qos, SubscribeRepository::maxQoS))));
     }
 
     /**
@@ -54,11 +53,11 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      * @param mqttTopicSubscription mqtt subscription info
      */
     public void add(final Channel channel, final List<MqttTopicSubscription> mqttTopicSubscription) {
-        CompletableFuture.runAsync(() -> mqttTopicSubscription.parallelStream().forEach(s -> {
-            List<Channel> channels = get(s.topicName());
-            channels.add(channel);
-            TOPIC_CHANNEL_FACTORY.put(s.topicName(), channels);
-        }));
+        CompletableFuture.runAsync(() -> mqttTopicSubscription.parallelStream()
+                .filter(s -> s.qualityOfService() != MqttQoS.FAILURE)
+                .forEach(s -> TOPIC_CHANNEL_FACTORY
+                        .computeIfAbsent(s.topicName(), key -> new ConcurrentHashMap<>())
+                        .merge(channel, s.qualityOfService(), SubscribeRepository::maxQoS)));
     }
 
     @Override
@@ -72,23 +71,33 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      * @param channel channel
      */
     public void remove(final List<String> topics, final Channel channel) {
-        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(topic -> TOPIC_CHANNEL_FACTORY.get(topic).remove(channel)));
+        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(topic -> {
+            Map<Channel, MqttQoS> subscribers = TOPIC_CHANNEL_FACTORY.get(topic);
+            if (Objects.nonNull(subscribers)) {
+                subscribers.remove(channel);
+            }
+        }));
     }
 
     @Override
-    public List<Channel> get(final List<String> topics) {
-        Set<Channel> channels = new CopyOnWriteArraySet<>();
-        topics.parallelStream().forEach(s -> channels.addAll(TOPIC_CHANNEL_FACTORY.get(s)));
-        return new CopyOnWriteArrayList<>(channels);
+    public Map<Channel, MqttQoS> get(final List<String> topics) {
+        Map<Channel, MqttQoS> subscribers = new ConcurrentHashMap<>();
+        topics.parallelStream().forEach(topic -> TOPIC_CHANNEL_FACTORY.getOrDefault(topic, Collections.emptyMap())
+                .forEach((channel, qos) -> subscribers.merge(channel, qos, SubscribeRepository::maxQoS)));
+        return subscribers;
     }
 
     /**
-     * get Channels.
+     * get subscriber channels with their granted qos.
      * @param topic topic
-     * @return Channels
+     * @return map of channel to granted qos
      */
-    public List<Channel> get(final String topic) {
-        return TOPIC_CHANNEL_FACTORY.getOrDefault(topic, new CopyOnWriteArrayList<>());
+    public Map<Channel, MqttQoS> get(final String topic) {
+        return TOPIC_CHANNEL_FACTORY.getOrDefault(topic, Collections.emptyMap());
+    }
+
+    private static MqttQoS maxQoS(final MqttQoS qos1, final MqttQoS qos2) {
+        return qos1.value() >= qos2.value() ? qos1 : qos2;
     }
 
 }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -79,6 +79,15 @@ public class SubscribeRepository implements BaseRepository<List<String>, Map<Cha
         }));
     }
 
+    /**
+     * remove the channel from all topics it subscribed.
+     * @param channel channel
+     */
+    public void remove(final Channel channel) {
+        CompletableFuture.runAsync(() -> TOPIC_CHANNEL_FACTORY.values().parallelStream()
+                .forEach(subscribers -> subscribers.remove(channel)));
+    }
+
     @Override
     public Map<Channel, MqttQoS> get(final List<String> topics) {
         Map<Channel, MqttQoS> subscribers = new ConcurrentHashMap<>();

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGenerator.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGenerator.java
@@ -19,8 +19,9 @@ package org.apache.shenyu.protocol.mqtt.utils;
 
 import io.netty.channel.Channel;
 
+import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -32,7 +33,8 @@ public final class MqttPacketIdGenerator {
 
     private static final int MAX_PACKET_ID = 0xFFFF;
 
-    private static final Map<Channel, AtomicInteger> CHANNEL_PACKET_ID_FACTORY = new ConcurrentHashMap<>();
+    // weak keys so channels closed without a DISCONNECT do not leak their id space
+    private static final Map<Channel, AtomicInteger> CHANNEL_PACKET_ID_FACTORY = Collections.synchronizedMap(new WeakHashMap<>());
 
     private MqttPacketIdGenerator() {
     }

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGenerator.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGenerator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.utils;
+
+import io.netty.channel.Channel;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Allocates packet identifiers for outbound messages from each channel's own id space.
+ */
+public final class MqttPacketIdGenerator {
+
+    private static final int MIN_PACKET_ID = 1;
+
+    private static final int MAX_PACKET_ID = 0xFFFF;
+
+    private static final Map<Channel, AtomicInteger> CHANNEL_PACKET_ID_FACTORY = new ConcurrentHashMap<>();
+
+    private MqttPacketIdGenerator() {
+    }
+
+    /**
+     * get next packet id of the channel.
+     * @param channel channel
+     * @return next packet id
+     */
+    public static int next(final Channel channel) {
+        AtomicInteger packetId = CHANNEL_PACKET_ID_FACTORY.computeIfAbsent(channel, key -> new AtomicInteger());
+        return packetId.updateAndGet(current -> current >= MAX_PACKET_ID ? MIN_PACKET_ID : current + 1);
+    }
+
+    /**
+     * remove the channel packet id.
+     * @param channel channel
+     */
+    public static void remove(final Channel channel) {
+        CHANNEL_PACKET_ID_FACTORY.remove(channel);
+    }
+
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttTransportHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.ChannelRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.utils.MqttPacketIdGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test cases for MqttTransportHandler.
+ */
+public class MqttTransportHandlerTest {
+
+    private static final String TOPIC = "test/topic";
+
+    private static final String CLIENT_ID = "test-client";
+
+    private final ChannelRepository channelRepository = new ChannelRepository();
+
+    private final SubscribeRepository subscribeRepository = new SubscribeRepository();
+
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    public void setUp() {
+        channel = new EmbeddedChannel();
+        Singleton.INST.single(ChannelRepository.class, channelRepository);
+        Singleton.INST.single(SubscribeRepository.class, subscribeRepository);
+        channelRepository.add(channel, CLIENT_ID);
+        subscribeRepository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, MqttQoS.AT_LEAST_ONCE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(CLIENT_ID, channelRepository.get(channel));
+            assertTrue(!subscribeRepository.get(TOPIC).isEmpty());
+        });
+    }
+
+    @AfterEach
+    public void tearDown() {
+        channel.finishAndReleaseAll();
+        channel.close();
+    }
+
+    @Test
+    public void testOperationCompleteCleansRepositoriesOnClose() throws Exception {
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+
+        new MqttTransportHandler().operationComplete(channel.closeFuture());
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertNull(channelRepository.get(channel));
+            assertTrue(subscribeRepository.get(TOPIC).isEmpty());
+        });
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PubRelTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PubRelTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test cases for PubRel.
+ */
+public class PubRelTest {
+
+    private static final int PACKET_ID = 12345;
+
+    private final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+    @Test
+    public void testPubRelRespondsWithPubComp() {
+        MqttFixedHeader pubRelFixedHeader = new MqttFixedHeader(MqttMessageType.PUBREL, false, MqttQoS.AT_LEAST_ONCE, false, 0);
+        MqttMessage pubRel = new MqttMessage(pubRelFixedHeader, MqttMessageIdVariableHeader.from(PACKET_ID));
+        new PubRel().pubRel(ctx, pubRel);
+
+        ArgumentCaptor<MqttMessage> captor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(ctx).writeAndFlush(captor.capture());
+        MqttMessage pubComp = captor.getValue();
+        assertEquals(MqttMessageType.PUBCOMP, pubComp.fixedHeader().messageType());
+        assertEquals(MqttQoS.AT_MOST_ONCE, pubComp.fixedHeader().qosLevel());
+        assertEquals(PACKET_ID, ((MqttMessageIdVariableHeader) pubComp.variableHeader()).messageId());
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
@@ -22,7 +22,10 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
 import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -158,6 +161,28 @@ public class PublishTest {
             ReferenceCountUtil.release(payload);
             MqttPacketIdGenerator.remove(otherSubscriberChannel);
         }
+    }
+
+    @Test
+    public void testPublishQos1SendsPubAckToPublisher() {
+        publish(MqttQoS.AT_LEAST_ONCE);
+
+        ArgumentCaptor<MqttPubAckMessage> captor = ArgumentCaptor.forClass(MqttPubAckMessage.class);
+        verify(ctx, timeout(5000)).writeAndFlush(captor.capture());
+        assertEquals(PUBLISHER_PACKET_ID, captor.getValue().variableHeader().messageId());
+        assertEquals(MqttQoS.AT_MOST_ONCE, captor.getValue().fixedHeader().qosLevel());
+    }
+
+    @Test
+    public void testPublishQos2SendsPubRecToPublisher() {
+        publish(MqttQoS.EXACTLY_ONCE);
+
+        ArgumentCaptor<MqttMessage> captor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(ctx, timeout(5000)).writeAndFlush(captor.capture());
+        MqttMessage pubRec = captor.getValue();
+        assertEquals(MqttMessageType.PUBREC, pubRec.fixedHeader().messageType());
+        assertEquals(MqttQoS.AT_MOST_ONCE, pubRec.fixedHeader().qosLevel());
+        assertEquals(PUBLISHER_PACKET_ID, ((MqttMessageIdVariableHeader) pubRec.variableHeader()).messageId());
     }
 
     private void addSubscriber(final Channel channel, final MqttQoS qos) {

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.protocol.mqtt;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -27,6 +28,7 @@ import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
 import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
@@ -135,15 +137,42 @@ public class PublishTest {
         }
     }
 
+    @Test
+    public void testPublishFanOutRetainsPayloadPerSubscriber() {
+        Channel otherSubscriberChannel = mock(Channel.class);
+        when(otherSubscriberChannel.isActive()).thenReturn(true);
+        addSubscriber(subscriberChannel, MqttQoS.AT_LEAST_ONCE);
+        addSubscriber(otherSubscriberChannel, MqttQoS.AT_LEAST_ONCE);
+        ByteBuf payload = Unpooled.copiedBuffer(PAYLOAD, CharsetUtil.UTF_8);
+        try {
+            publish(MqttQoS.AT_LEAST_ONCE, payload);
+            await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(3, payload.refCnt()));
+
+            ArgumentCaptor<MqttPublishMessage> captor = ArgumentCaptor.forClass(MqttPublishMessage.class);
+            verify(subscriberChannel, timeout(5000)).writeAndFlush(captor.capture());
+            verify(otherSubscriberChannel, timeout(5000)).writeAndFlush(captor.capture());
+            assertEquals(PAYLOAD, captor.getAllValues().get(0).payload().toString(CharsetUtil.UTF_8));
+            captor.getAllValues().forEach(ReferenceCountUtil::release);
+            assertEquals(1, payload.refCnt());
+        } finally {
+            ReferenceCountUtil.release(payload);
+            MqttPacketIdGenerator.remove(otherSubscriberChannel);
+        }
+    }
+
     private void addSubscriber(final Channel channel, final MqttQoS qos) {
         subscribeRepository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, qos)));
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(qos, subscribeRepository.get(TOPIC).get(channel)));
     }
 
     private void publish(final MqttQoS qos) {
+        publish(qos, Unpooled.copiedBuffer(PAYLOAD, CharsetUtil.UTF_8));
+    }
+
+    private void publish(final MqttQoS qos, final ByteBuf payload) {
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
         MqttPublishVariableHeader variableHeader = new MqttPublishVariableHeader(TOPIC, PUBLISHER_PACKET_ID);
-        MqttPublishMessage message = new MqttPublishMessage(fixedHeader, variableHeader, Unpooled.copiedBuffer(PAYLOAD, CharsetUtil.UTF_8));
+        MqttPublishMessage message = new MqttPublishMessage(fixedHeader, variableHeader, payload);
         new Publish().publish(ctx, message);
     }
 

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/PublishTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import io.netty.util.CharsetUtil;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
+import org.apache.shenyu.protocol.mqtt.utils.MqttPacketIdGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for Publish.
+ */
+public class PublishTest {
+
+    private static final String TOPIC = "test/topic";
+
+    private static final String PAYLOAD = "hello";
+
+    private static final int PUBLISHER_PACKET_ID = 12345;
+
+    private final SubscribeRepository subscribeRepository = new SubscribeRepository();
+
+    private final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+    private final Channel subscriberChannel = mock(Channel.class);
+
+    @BeforeEach
+    public void setUp() {
+        Singleton.INST.single(SubscribeRepository.class, subscribeRepository);
+        Singleton.INST.single(TopicRepository.class, new TopicRepository());
+        when(subscriberChannel.isActive()).thenReturn(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MqttPacketIdGenerator.remove(subscriberChannel);
+        subscribeRepository.remove(Collections.singletonList(TOPIC));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(subscribeRepository.get(TOPIC).isEmpty()));
+    }
+
+    @Test
+    public void testPublishDeliversAtGrantedQosWithOwnPacketId() {
+        addSubscriber(subscriberChannel, MqttQoS.AT_LEAST_ONCE);
+        publish(MqttQoS.EXACTLY_ONCE);
+
+        MqttPublishMessage message = captureMessage(subscriberChannel);
+        assertEquals(MqttQoS.AT_LEAST_ONCE, message.fixedHeader().qosLevel());
+        assertEquals(1, message.variableHeader().packetId());
+        assertEquals(TOPIC, message.variableHeader().topicName());
+        assertEquals(PAYLOAD, message.payload().toString(CharsetUtil.UTF_8));
+    }
+
+    @Test
+    public void testPublishDeliversQos0SubscriberWithZeroPacketId() {
+        addSubscriber(subscriberChannel, MqttQoS.AT_MOST_ONCE);
+        publish(MqttQoS.EXACTLY_ONCE);
+
+        MqttPublishMessage message = captureMessage(subscriberChannel);
+        assertEquals(MqttQoS.AT_MOST_ONCE, message.fixedHeader().qosLevel());
+        assertEquals(0, message.variableHeader().packetId());
+    }
+
+    @Test
+    public void testPublishQos0FanOutDeliversAtMostOnce() {
+        addSubscriber(subscriberChannel, MqttQoS.EXACTLY_ONCE);
+        publish(MqttQoS.AT_MOST_ONCE);
+
+        MqttPublishMessage message = captureMessage(subscriberChannel);
+        assertEquals(MqttQoS.AT_MOST_ONCE, message.fixedHeader().qosLevel());
+        assertEquals(0, message.variableHeader().packetId());
+    }
+
+    @Test
+    public void testPublishAllocatesPacketIdFromSubscriberIdSpace() {
+        Channel otherSubscriberChannel = mock(Channel.class);
+        when(otherSubscriberChannel.isActive()).thenReturn(true);
+        addSubscriber(subscriberChannel, MqttQoS.EXACTLY_ONCE);
+        addSubscriber(otherSubscriberChannel, MqttQoS.EXACTLY_ONCE);
+        try {
+            publish(MqttQoS.EXACTLY_ONCE);
+
+            ArgumentCaptor<MqttPublishMessage> captor = ArgumentCaptor.forClass(MqttPublishMessage.class);
+            verify(subscriberChannel, timeout(5000)).writeAndFlush(captor.capture());
+            verify(otherSubscriberChannel, timeout(5000)).writeAndFlush(captor.capture());
+            assertEquals(1, captor.getAllValues().get(0).variableHeader().packetId());
+            assertEquals(1, captor.getAllValues().get(1).variableHeader().packetId());
+
+            publish(MqttQoS.EXACTLY_ONCE);
+            ArgumentCaptor<MqttPublishMessage> secondCaptor = ArgumentCaptor.forClass(MqttPublishMessage.class);
+            verify(subscriberChannel, timeout(5000).times(2)).writeAndFlush(secondCaptor.capture());
+            assertEquals(1, secondCaptor.getAllValues().get(0).variableHeader().packetId());
+            assertEquals(2, secondCaptor.getAllValues().get(1).variableHeader().packetId());
+        } finally {
+            MqttPacketIdGenerator.remove(otherSubscriberChannel);
+        }
+    }
+
+    private void addSubscriber(final Channel channel, final MqttQoS qos) {
+        subscribeRepository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, qos)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(qos, subscribeRepository.get(TOPIC).get(channel)));
+    }
+
+    private void publish(final MqttQoS qos) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
+        MqttPublishVariableHeader variableHeader = new MqttPublishVariableHeader(TOPIC, PUBLISHER_PACKET_ID);
+        MqttPublishMessage message = new MqttPublishMessage(fixedHeader, variableHeader, Unpooled.copiedBuffer(PAYLOAD, CharsetUtil.UTF_8));
+        new Publish().publish(ctx, message);
+    }
+
+    private MqttPublishMessage captureMessage(final Channel channel) {
+        ArgumentCaptor<MqttPublishMessage> captor = ArgumentCaptor.forClass(MqttPublishMessage.class);
+        verify(channel, timeout(5000)).writeAndFlush(captor.capture());
+        return captor.getValue();
+    }
+
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.shenyu.common.utils.Singleton;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test cases for SubscribeRepository.
+ */
+public class SubscribeRepositoryTest {
+
+    private static final String TOPIC = "test/topic";
+
+    private static final String OTHER_TOPIC = "test/other-topic";
+
+    private final SubscribeRepository repository = new SubscribeRepository();
+
+    private final Channel channel = mock(Channel.class);
+
+    @BeforeEach
+    public void setUp() {
+        Singleton.INST.single(SubscribeRepository.class, repository);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        repository.remove(Arrays.asList(TOPIC, OTHER_TOPIC));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(repository.get(TOPIC).isEmpty()));
+    }
+
+    @Test
+    public void testAddStoresGrantedQosPerTopic() {
+        repository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, MqttQoS.AT_LEAST_ONCE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                assertEquals(MqttQoS.AT_LEAST_ONCE, repository.get(TOPIC).get(channel)));
+    }
+
+    @Test
+    public void testAddKeepsMaxQosForOverlappingSubscription() {
+        repository.add(channel, Arrays.asList(
+                new MqttTopicSubscription(TOPIC, MqttQoS.AT_LEAST_ONCE),
+                new MqttTopicSubscription(TOPIC, MqttQoS.EXACTLY_ONCE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                assertEquals(MqttQoS.EXACTLY_ONCE, repository.get(TOPIC).get(channel)));
+    }
+
+    @Test
+    public void testAddIgnoresFailureSubscription() {
+        repository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, MqttQoS.FAILURE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(repository.get(TOPIC).isEmpty()));
+    }
+
+    @Test
+    public void testRemoveChannelFromTopic() {
+        repository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, MqttQoS.AT_MOST_ONCE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                assertEquals(MqttQoS.AT_MOST_ONCE, repository.get(TOPIC).get(channel)));
+        repository.remove(Collections.singletonList(TOPIC), channel);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertTrue(repository.get(TOPIC).isEmpty()));
+    }
+
+    @Test
+    public void testGetTopicsMergesSubscribers() {
+        repository.add(channel, Arrays.asList(
+                new MqttTopicSubscription(TOPIC, MqttQoS.AT_MOST_ONCE),
+                new MqttTopicSubscription(OTHER_TOPIC, MqttQoS.AT_LEAST_ONCE)));
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            Map<Channel, MqttQoS> subscribers = repository.get(Arrays.asList(TOPIC, OTHER_TOPIC));
+            assertEquals(MqttQoS.AT_LEAST_ONCE, subscribers.get(channel));
+        });
+    }
+
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGeneratorTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/utils/MqttPacketIdGeneratorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.utils;
+
+import io.netty.channel.Channel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test cases for MqttPacketIdGenerator.
+ */
+public class MqttPacketIdGeneratorTest {
+
+    private static final int MAX_PACKET_ID = 0xFFFF;
+
+    private final Channel channel = mock(Channel.class);
+
+    @AfterEach
+    public void tearDown() {
+        MqttPacketIdGenerator.remove(channel);
+    }
+
+    @Test
+    public void testNextAllocatesSequentialPacketIds() {
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+        assertEquals(2, MqttPacketIdGenerator.next(channel));
+        assertEquals(3, MqttPacketIdGenerator.next(channel));
+    }
+
+    @Test
+    public void testNextKeepsIndependentIdSpacesPerChannel() {
+        Channel otherChannel = mock(Channel.class);
+        try {
+            assertEquals(1, MqttPacketIdGenerator.next(channel));
+            assertEquals(1, MqttPacketIdGenerator.next(otherChannel));
+            assertEquals(2, MqttPacketIdGenerator.next(channel));
+        } finally {
+            MqttPacketIdGenerator.remove(otherChannel);
+        }
+    }
+
+    @Test
+    public void testNextWrapsAroundAfterMaxPacketId() {
+        for (int i = 0; i < MAX_PACKET_ID - 1; i++) {
+            MqttPacketIdGenerator.next(channel);
+        }
+        assertEquals(MAX_PACKET_ID, MqttPacketIdGenerator.next(channel));
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+    }
+
+    @Test
+    public void testRemoveResetsChannelIdSpace() {
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+        assertEquals(2, MqttPacketIdGenerator.next(channel));
+        MqttPacketIdGenerator.remove(channel);
+        assertEquals(1, MqttPacketIdGenerator.next(channel));
+    }
+
+}


### PR DESCRIPTION
Store the granted qos per subscriber channel in SubscribeRepository and allocate a packet id from each subscriber's own id space when fanning out publishes, instead of hard-coding AT_MOST_ONCE and reusing the publisher's packet id for every subscriber.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary                                                                                                                                                                            
                                                                                                                                                                                     
  Fixed MQTT broker→subscriber fan-out to respect granted QoS and per-subscriber packet IDs.                                                                                         
                       
  Changes                                                                                                                                                                            
  - SubscribeRepository — now stores topic → Map<Channel, MqttQoS> instead of topic → List<Channel>; keeps the max QoS for overlapping subscriptions and ignores FAILURE             
  subscriptions.                                                                                                                                                                     
  - MqttPacketIdGenerator (new) — allocates packet IDs 1–65535 (wrapping) from each channel's own ID space; state cleaned up on Disconnect.                                          
  - Publish.send — delivers at min(publishQoS, grantedQoS), assigns a per-subscriber packet ID for QoS > 0, and uses 0 for QoS 0, instead of hard-coding AT_MOST_ONCE and reusing the
   publisher's packet ID.                                                                                                                                                            
                                                                                                                                                                                     
  Tests — 13 new unit tests covering the generator, repository, and publish fan-out behavior; all pass with checkstyle. 

close [#6850](https://github.com/apache/shenyu/issues/6850)

New Changs

#6743 — QoS 2 PUBLISH answered with PUBACK instead of PUBREC

  Publish.java
  - qos2() now responds with PUBREC instead of PUBACK — the first ack of the QoS 2 four-step handshake
  - Fixed reserved fixed-header bits on both acks: PUBACK/PUBREC must encode QoS bits as 00 (AT_MOST_ONCE); previously qos1 sent AT_LEAST_ONCE and qos2 sent EXACTLY_ONCE, which
  spec-compliant clients treat as a protocol error
  - Removed the unused empty qos0() stub

  PUBREL → PUBCOMP half-handshake (new)
  - New PubRel class: on receiving PUBREL, responds with PUBCOMP echoing the same packet id (flags 0000)
  - Wired the dispatch chain: AbstractMessageType.pubRel() default method → MessageType.pubRel() delegate → MqttFactory PUBREL case

  Tests: testPublishQos2SendsPubRecToPublisher verifies PUBREC type/flags/message-id; new PubRelTest verifies PUBCOMP echo.

  #6744 — No cleanup on channel close → repository leak

  MqttTransportHandler.java
  - Implemented the previously empty operationComplete(): removes the closing channel from ChannelRepository, SubscribeRepository, and MqttPacketIdGenerator
  - The handler is already registered as a listener on ch.closeFuture(), so both graceful and ungraceful (TCP drop) disconnects now trigger cleanup

  SubscribeRepository.java
  - Added remove(Channel) overload that removes the channel from every topic it subscribed to (existing APIs only removed by topic)

  Test: new MqttTransportHandlerTest uses an EmbeddedChannel to verify all three repositories no longer hold the channel after close, and the packet-id space resets.

close [#6743](https://github.com/apache/shenyu/issues/6743) 
close [#6744](https://github.com/apache/shenyu/issues/6744)