### PR TITLE
fix: invalidate rule match cache when deleting a selector (#6797)

### DIFF
--- a/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java
@@ -289,10 +289,14 @@ public class CommonPluginDataSubscriber implements PluginDataSubscriber {
             BaseDataCache.getInstance().removeSelectData(selectorData);
             Optional.ofNullable(handlerMap.get(selectorData.getPluginName()))
                     .ifPresent(handler -> handler.removeSelector(selectorData));
-            // remove selector match cache
+            // remove match cache
             if (selectorMatchConfig.getCache().getEnabled()) {
                 MatchDataCache.getInstance().removeSelectorData(selectorData.getPluginName(), selectorData.getId());
                 MatchDataCache.getInstance().removeEmptySelectorData(selectorData.getPluginName());
+            }
+            if (ruleMatchCacheConfig.getCache().getEnabled()) {
+                MatchDataCache.getInstance().removeRuleDataBySelector(selectorData.getPluginName(), selectorData.getId());
+                MatchDataCache.getInstance().removeEmptyRuleData(selectorData.getPluginName());
             }
         } else if (data instanceof RuleData) {
             RuleData ruleData = (RuleData) data;

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriberTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriberTest.java
@@ -140,13 +140,40 @@ public final class CommonPluginDataSubscriberTest {
 
     @Test
     public void testUnSelectorSubscribe() {
+        final String path = "/selector";
+        final String emptyRulePath = "/empty-rule";
+        final String unrelatedRulePath = "/unrelated-rule";
+        final MatchDataCache matchDataCache = MatchDataCache.getInstance();
         baseDataCache.cleanSelectorData();
-        SelectorData selectorData = SelectorData.builder().id("1").enabled(true).pluginName(mockPluginName1).build();
-        baseDataCache.cacheSelectData(selectorData);
-        assertNotNull(baseDataCache.obtainSelectorData(selectorData.getPluginName()));
+        matchDataCache.cleanSelectorData();
+        matchDataCache.cleanRuleDataData();
 
-        commonPluginDataSubscriber.unSelectorSubscribe(selectorData);
-        assertEquals(Lists.newArrayList(), baseDataCache.obtainSelectorData(selectorData.getPluginName()));
+        final SelectorData selectorData = SelectorData.builder().id(mockSelectorId1).enabled(true).pluginName(mockPluginName1).build();
+        final RuleData ruleData = RuleData.builder().id("1").selectorId(mockSelectorId1).pluginName(mockPluginName1).build();
+        final RuleData emptyRuleData = RuleData.builder().selectorId(mockSelectorId1).pluginName(mockPluginName1).build();
+        final RuleData unrelatedRuleData = RuleData.builder().id("2").selectorId(mockSelectorId2).pluginName(mockPluginName1).build();
+        baseDataCache.cacheSelectData(selectorData);
+        matchDataCache.cacheSelectorData(path, selectorData, 100, 100);
+        matchDataCache.cacheRuleData(path, ruleData, 100, 100);
+        matchDataCache.cacheRuleData(emptyRulePath, emptyRuleData, 100, 100);
+        matchDataCache.cacheRuleData(unrelatedRulePath, unrelatedRuleData, 100, 100);
+
+        try {
+            assertNotNull(baseDataCache.obtainSelectorData(selectorData.getPluginName()));
+            assertEquals(selectorData, matchDataCache.obtainSelectorData(mockPluginName1, path));
+            assertEquals(ruleData, matchDataCache.obtainRuleData(mockPluginName1, path));
+
+            commonPluginDataSubscriber.unSelectorSubscribe(selectorData);
+
+            assertEquals(Lists.newArrayList(), baseDataCache.obtainSelectorData(selectorData.getPluginName()));
+            assertNull(matchDataCache.obtainSelectorData(mockPluginName1, path));
+            assertNull(matchDataCache.obtainRuleData(mockPluginName1, path));
+            assertNull(matchDataCache.obtainRuleData(mockPluginName1, emptyRulePath));
+            assertEquals(unrelatedRuleData, matchDataCache.obtainRuleData(mockPluginName1, unrelatedRulePath));
+        } finally {
+            matchDataCache.cleanSelectorData();
+            matchDataCache.cleanRuleDataData();
+        }
     }
 
     @Test

--- a/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriberTest.java
+++ b/shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriberTest.java
@@ -150,7 +150,7 @@ public final class CommonPluginDataSubscriberTest {
 
         final SelectorData selectorData = SelectorData.builder().id(mockSelectorId1).enabled(true).pluginName(mockPluginName1).build();
         final RuleData ruleData = RuleData.builder().id("1").selectorId(mockSelectorId1).pluginName(mockPluginName1).build();
-        final RuleData emptyRuleData = RuleData.builder().selectorId(mockSelectorId1).pluginName(mockPluginName1).build();
+        final RuleData emptyRuleData = RuleData.builder().pluginName(mockPluginName1).build();
         final RuleData unrelatedRuleData = RuleData.builder().id("2").selectorId(mockSelectorId2).pluginName(mockPluginName1).build();
         baseDataCache.cacheSelectData(selectorData);
         matchDataCache.cacheSelectorData(path, selectorData, 100, 100);


### PR DESCRIPTION
Fixes #6797 

## What this PR does
@Aias00 

Invalidate the rule match cache when a selector is deleted.

Previously, selector deletion only removed entries from the selector match cache. Cached `RuleData` associated with the deleted selector could remain available, potentially causing requests to be routed using rules belonging to a deleted selector.

This PR updates `CommonPluginDataSubscriber` to:

- Remove cached rule data associated with the deleted selector.
- Remove empty rule cache entries.
- Keep rule cache entries belonging to unrelated selectors.

## Tests

- Added a regression test covering selector deletion and rule match cache invalidation.
- Verified that rules associated with the deleted selector are removed.
- Verified that unrelated rule cache entries remain available.
- Passed:

  ```text
  ./mvnw -pl shenyu-plugin/shenyu-plugin-base test
  Tests run: 113, Failures: 0, Errors: 0, Skipped: 0