### PR TITLE
ci: remove windows build from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,25 +68,11 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        java: [17]
-        os: [ubuntu-latest, windows-latest]
-        include:
-          - java: 17
-            os: ubuntu-latest
-#          - java: 18
-#            os: ubuntu-latest
-          - java: 19
-            os: ubuntu-latest
-          - java: 20
-            os: ubuntu-latest
-          - java: 21
-            os: ubuntu-latest
+        java: [17, 19, 20, 21]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     if: github.repository == 'apache/shenyu' && needs.changes.outputs.code == 'true'
     steps:
-      - name: Support longpaths
-        if: ${{ matrix.os == 'windows-latest'}}
-        run: git config --system core.longpaths true
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -106,7 +92,6 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: "temurin"
       - name: Install mvnd
-        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           MVND_VERSION=1.0.2
@@ -118,17 +103,13 @@ jobs:
           echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
 
       - name: Verify mvnd installation
-        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: mvnd --version || echo "mvnd version check failed, will use maven wrapper as fallback"
 
       - name: Build with Maven
         shell: bash
         run: |
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            echo "Building with maven wrapper on Windows"
-            ./mvnw.cmd -B clean test -Prelease
-          elif mvnd --version > /dev/null 2>&1; then
+          if mvnd --version > /dev/null 2>&1; then
             echo "Using mvnd for build"
             mvnd -B clean test -Prelease -DskipRemoteResources=true
           else


### PR DESCRIPTION
## Summary

Remove `windows-latest` from the CI workflow build matrix and run CI builds on Ubuntu only.

## Changes

- remove `windows-latest` from the matrix
- remove Windows-specific `core.longpaths` setup
- remove the Windows `mvnw.cmd` build branch
- simplify the build matrix to Ubuntu with JDK 17 and 21

## Motivation

This repository primarily validates a Java/Maven server-side project. Running CI on Ubuntu is sufficient for the current validation scope and helps reduce CI runtime and maintenance overhead.