### PR TITLE
[ISSUE #6767] fix(logging): handle missing ClickHouse TTL configuration

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/main/java/org/apache/shenyu/plugin/logging/clickhouse/client/ClickHouseLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/main/java/org/apache/shenyu/plugin/logging/clickhouse/client/ClickHouseLogCollectClient.java
@@ -29,6 +29,7 @@ import com.clickhouse.client.data.ClickHouseLongValue;
 import com.clickhouse.client.data.ClickHouseOffsetDateTimeValue;
 import com.clickhouse.client.data.ClickHouseStringValue;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shenyu.common.utils.DateUtils;
 import org.apache.shenyu.plugin.logging.clickhouse.config.ClickHouseLogCollectConfig;
 import org.apache.shenyu.plugin.logging.clickhouse.constant.ClickHouseLoggingConstant;
@@ -125,7 +126,7 @@ public class ClickHouseLogCollectClient extends AbstractLogConsumeClient<ClickHo
     public void initClient0(@NonNull final ClickHouseLogCollectConfig.ClickHouseLogConfig config) {
         final String username = config.getUsername();
         final String password = config.getPassword();
-        final String ttl = config.getTtl().isEmpty() ? "30" : config.getTtl();
+        final String ttl = StringUtils.defaultIfBlank(config.getTtl(), "30");
         database = config.getDatabase();
         endpoint = ClickHouseNode.builder()
             .host(config.getHost())

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/test/java/org/apache/shenyu/plugin/logging/clickhouse/client/ClickHouseLogCollectClientTest.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/test/java/org/apache/shenyu/plugin/logging/clickhouse/client/ClickHouseLogCollectClientTest.java
@@ -86,6 +86,20 @@ public class ClickHouseLogCollectClientTest {
         Assertions.assertEquals(msg, "false");
     }
 
+    @Test
+    public void testInitClientWithoutTtl() {
+        pluginData.setConfig("{\"host\":\"127.0.0.1\",\"port\":\"1\",\"database\":\"shenyu-gateway\","
+                + "\"username\":\"foo\",\"password\":\"bar\",\"engine\":\"MergeTree\",\"clusterName\":\"cluster\"}");
+        ClickHouseLogCollectConfig.ClickHouseLogConfig config = GsonUtils.getInstance()
+                .fromJson(pluginData.getConfig(), ClickHouseLogCollectConfig.ClickHouseLogConfig.class);
+        Assertions.assertNull(config.getTtl());
+        try {
+            Assertions.assertDoesNotThrow(() -> clickHouseLogCollectClient.initClient0(config));
+        } finally {
+            clickHouseLogCollectClient.close0();
+        }
+    }
+
     @After
     public void clean() {
         clickHouseLogCollectClient.close();


### PR DESCRIPTION
Fixes #6767 

`ClickHouseLogCollectClient.initClient0()` previously called `isEmpty()` directly on the configured TTL value. When the `ttl` field was omitted from the admin configuration, Gson deserialized it as `null`, causing the ClickHouse logging plugin to fail during initialization with a `NullPointerException`.

This PR:

- Uses `StringUtils.defaultIfBlank()` to default missing, empty, or blank TTL values to `30`.
- Preserves explicitly configured TTL values.
- Adds a regression test covering configuration JSON without the `ttl` field.

## Verification

- The regression test reproduces the original exception before the fix.
- The targeted test passes after the fix.
- Relevant tests and Checkstyle pass.

@Aias00 Could you please review this PR?