### PR TITLE
fix: grant requested QoS in SUBACK instead of hard-coded QoS 0

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Subscribe.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/Subscribe.java
@@ -21,7 +21,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
-import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import io.netty.handler.codec.mqtt.MqttMessageType;
@@ -35,7 +34,6 @@ import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
 import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -61,9 +59,12 @@ public class Subscribe extends MessageType {
         int packetId = msg.variableHeader().messageId();
 
         //// todo Regular match
-        List<String> ackTopics = mqttTopicSubscriptions
+        List<MqttTopicSubscription> ackSubscriptions = mqttTopicSubscriptions
                 .stream()
                 .filter(topicSub -> topicSub.qualityOfService() != FAILURE)
+                .collect(Collectors.toList());
+
+        List<String> ackTopics = ackSubscriptions.stream()
                 .map(MqttTopicSubscription::topicName)
                 .collect(Collectors.toList());
 
@@ -76,22 +77,20 @@ public class Subscribe extends MessageType {
             }
         }
 
-        sendSubAckMessage(packetId, ackTopics, channel);
+        sendSubAckMessage(packetId, ackSubscriptions, channel);
     }
 
     /**
      * call back request of message.
      * @param packetId packetId
-     * @param ackTopics ackTopics
+     * @param ackSubscriptions ackSubscriptions
      * @param channel channel
      */
-    private void sendSubAckMessage(final int packetId, final List<String> ackTopics, final Channel channel) {
+    private void sendSubAckMessage(final int packetId, final List<MqttTopicSubscription> ackSubscriptions, final Channel channel) {
 
-        List<Integer> qos = new ArrayList<>();
-        for (int i = 0; i < ackTopics.size(); i++) {
-            // default qos 0
-            qos.add(MqttQoS.AT_MOST_ONCE.value());
-        }
+        List<Integer> qos = ackSubscriptions.stream()
+                .map(topicSub -> topicSub.qualityOfService().value())
+                .collect(Collectors.toList());
 
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.SUBACK, false, AT_MOST_ONCE,
                 false, 0);

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/SubscribeTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/SubscribeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribePayload;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.shenyu.common.utils.Singleton;
+import org.apache.shenyu.protocol.mqtt.repositories.SubscribeRepository;
+import org.apache.shenyu.protocol.mqtt.repositories.TopicRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test case for {@link Subscribe}.
+ */
+@ExtendWith(MockitoExtension.class)
+class SubscribeTest {
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @Mock
+    private Channel channel;
+
+    @Mock
+    private SubscribeRepository subscribeRepository;
+
+    @Mock
+    private TopicRepository topicRepository;
+
+    private final Subscribe subscribe = new Subscribe();
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.channel()).thenReturn(channel);
+        Singleton.INST.single(SubscribeRepository.class, subscribeRepository);
+        Singleton.INST.single(TopicRepository.class, topicRepository);
+    }
+
+    @Test
+    void testSubAckGrantsRequestedQoS() {
+        MqttSubscribeMessage msg = subscribeMessage(10,
+                new MqttTopicSubscription("topic/qos2", MqttQoS.EXACTLY_ONCE),
+                new MqttTopicSubscription("topic/qos0", MqttQoS.AT_MOST_ONCE),
+                new MqttTopicSubscription("topic/qos1", MqttQoS.AT_LEAST_ONCE));
+
+        subscribe.subscribe(ctx, msg);
+
+        MqttSubAckMessage subAck = capturedSubAck();
+        assertEquals(10, subAck.variableHeader().messageId());
+        assertEquals(Arrays.asList(2, 0, 1), subAck.payload().grantedQoSLevels());
+    }
+
+    @Test
+    void testSubAckExcludesFailureSubscriptions() {
+        MqttSubscribeMessage msg = subscribeMessage(20,
+                new MqttTopicSubscription("topic/qos1", MqttQoS.AT_LEAST_ONCE),
+                new MqttTopicSubscription("topic/failure", MqttQoS.FAILURE),
+                new MqttTopicSubscription("topic/qos0", MqttQoS.AT_MOST_ONCE));
+
+        subscribe.subscribe(ctx, msg);
+
+        MqttSubAckMessage subAck = capturedSubAck();
+        assertEquals(Arrays.asList(1, 0), subAck.payload().grantedQoSLevels());
+        verify(topicRepository, never()).get("topic/failure");
+    }
+
+    @Test
+    void testSubscribeWhenConnectedClosesChannel() {
+        ChannelFuture closeFuture = mock(ChannelFuture.class);
+        when(channel.close()).thenReturn(closeFuture);
+        subscribe.setConnected(true);
+
+        subscribe.subscribe(ctx, subscribeMessage(30,
+                new MqttTopicSubscription("topic/qos0", MqttQoS.AT_MOST_ONCE)));
+
+        verify(channel).close();
+        verify(channel, never()).writeAndFlush(any());
+    }
+
+    private MqttSubAckMessage capturedSubAck() {
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(channel).writeAndFlush(captor.capture());
+        return (MqttSubAckMessage) captor.getValue();
+    }
+
+    private MqttSubscribeMessage subscribeMessage(final int packetId, final MqttTopicSubscription... subscriptions) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.SUBSCRIBE, false, MqttQoS.AT_LEAST_ONCE, false, 0);
+        MqttMessageIdVariableHeader variableHeader = MqttMessageIdVariableHeader.from(packetId);
+        return new MqttSubscribeMessage(fixedHeader, variableHeader, new MqttSubscribePayload(Arrays.asList(subscriptions)));
+    }
+}


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary

Changes:
- Subscribe.java: sendSubAckMessage now takes the filtered List<MqttTopicSubscription> and builds the SUBACK grant list from topicSub.qualityOfService().value() instead of        
  hard-coding AT_MOST_ONCE for every topic (MQTT-3.8.4/3.9). FAILURE subscriptions remain excluded from the ack. Removed the now-unused MqttQoS and ArrayList imports.

Test Cases:
  - SubscribeTest.java (new): 3 tests — grants requested QoS (2/0/1), excludes FAILURE subscriptions, closes channel when already connected.

close [#6848](https://github.com/apache/shenyu/issues/6848)