### PR TITLE
fix: handle null password in MqttContext.isValid to avoid NPE

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
+++ b/shenyu-protocol/shenyu-protocol-mqtt/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>reflections</artifactId>
             <version>0.9.11</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttContext.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttContext.java
@@ -19,6 +19,8 @@ package org.apache.shenyu.protocol.mqtt;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
+
 /**
  * mqtt env.
  */
@@ -45,7 +47,7 @@ public class MqttContext {
      * @return true is correct, false unavailable.
      */
     public static boolean isValid(final String userName, final byte[] passwordInBytes) {
-        String password = new String(passwordInBytes);
+        String password = Objects.isNull(passwordInBytes) ? "" : new String(passwordInBytes);
 
         if (StringUtils.isEmpty(password) || StringUtils.isEmpty(userName)) {
             return false;

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttContextTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttContextTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test Case For {@link MqttContext}.
+ */
+public class MqttContextTest {
+
+    private static final String USER_NAME = "testUser";
+
+    private static final String PASSWORD = "testPass";
+
+    private final MqttContext mqttContext = new MqttContext();
+
+    @BeforeEach
+    public void setUp() {
+        mqttContext.setUserName(USER_NAME);
+        mqttContext.setPassword(PASSWORD);
+    }
+
+    @Test
+    public void testIsValidWithCorrectCredentials() {
+        assertTrue(MqttContext.isValid(USER_NAME, PASSWORD.getBytes()));
+    }
+
+    @Test
+    public void testIsValidWithNullPasswordInBytes() {
+        assertFalse(MqttContext.isValid(USER_NAME, null));
+    }
+
+    @Test
+    public void testIsValidWithEmptyPassword() {
+        assertFalse(MqttContext.isValid(USER_NAME, new byte[0]));
+    }
+
+    @Test
+    public void testIsValidWithWrongPassword() {
+        assertFalse(MqttContext.isValid(USER_NAME, "wrongPass".getBytes()));
+    }
+
+    @Test
+    public void testIsValidWithNullUserName() {
+        assertFalse(MqttContext.isValid(null, PASSWORD.getBytes()));
+    }
+
+    @Test
+    public void testIsValidWithEmptyUserName() {
+        assertFalse(MqttContext.isValid("", PASSWORD.getBytes()));
+    }
+}


### PR DESCRIPTION
CONNECT with password flag 0 yields a null passwordInBytes, which caused new String((byte[]) null) to throw and hang the connection without a CONNACK. Treat null as empty so the client receives CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, and add unit tests.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary                                                                                                                                                                            

### Changes:                                                                                                                                                                               
  - Fix NPE in MqttContext.isValid: new String(passwordInBytes) throws when msg.payload().passwordInBytes() is null — any CONNECT with the password flag bit set to 0 (anonymous or  
  username-only clients). The handler thread dies and the client never receives a CONNACK, leaving the connection hanging.                                                           
  - Null passwordInBytes is now treated as empty, so validation fails gracefully and the client receives CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD instead of a hang.             

### Test Cases:
  - Added junit-jupiter test dependency and MqttContextTest with 6 cases covering null/empty/wrong password, null/empty username, and valid credentials.

close [#6847](https://github.com/apache/shenyu/issues/6847)