### PR TITLE
fix: avoid NPE when selector/rule sync data is null (#6890)

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/RuleDataRefresh.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/RuleDataRefresh.java
@@ -69,14 +69,11 @@ public class RuleDataRefresh extends AbstractDataRefresh<RuleData> {
 
     @Override
     protected void refresh(final List<RuleData> data) {
+        pluginDataSubscriber.refreshRuleDataAll();
         if (CollectionUtils.isEmpty(data)) {
             LOG.info("clear all rule cache, old cache");
-            data.forEach(pluginDataSubscriber::unRuleSubscribe);
-            pluginDataSubscriber.refreshRuleDataAll();
-        } else {
-            // update cache for UpstreamCacheManager
-            pluginDataSubscriber.refreshRuleDataAll();
-            data.forEach(pluginDataSubscriber::onRuleSubscribe);
+            return;
         }
+        data.forEach(pluginDataSubscriber::onRuleSubscribe);
     }
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/SelectorDataRefresh.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/SelectorDataRefresh.java
@@ -69,14 +69,11 @@ public class SelectorDataRefresh extends AbstractDataRefresh<SelectorData> {
 
     @Override
     protected void refresh(final List<SelectorData> data) {
+        pluginDataSubscriber.refreshSelectorDataAll();
         if (CollectionUtils.isEmpty(data)) {
             LOG.info("clear all selector cache, old cache");
-            data.forEach(pluginDataSubscriber::unSelectorSubscribe);
-            pluginDataSubscriber.refreshSelectorDataAll();
-        } else {
-            // update cache for UpstreamCacheManager
-            pluginDataSubscriber.refreshSelectorDataAll();
-            data.forEach(pluginDataSubscriber::onSelectorSubscribe);
+            return;
         }
+        data.forEach(pluginDataSubscriber::onSelectorSubscribe);
     }
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/RuleDataRefreshTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/RuleDataRefreshTest.java
@@ -32,6 +32,10 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public final class RuleDataRefreshTest {
 
@@ -77,5 +81,16 @@ public final class RuleDataRefreshTest {
         ruleDataRefresh.refresh(ruleDataList);
         ruleDataList.add(ruleData);
         ruleDataRefresh.refresh(ruleDataList);
+    }
+
+    @Test
+    public void testRefreshWithNullData() {
+        final PluginDataSubscriber subscriber = mock(PluginDataSubscriber.class);
+        final RuleDataRefresh ruleDataRefresh = new RuleDataRefresh(subscriber);
+        // data is null, should not throw NPE; cache is still refreshed unconditionally, then return early
+        ruleDataRefresh.refresh((List<RuleData>) null);
+        verify(subscriber).refreshRuleDataAll();
+        verify(subscriber, never()).unRuleSubscribe(any(RuleData.class));
+        verify(subscriber, never()).onRuleSubscribe(any(RuleData.class));
     }
 }

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/SelectorDataRefreshTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/SelectorDataRefreshTest.java
@@ -28,6 +28,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,5 +81,16 @@ public final class SelectorDataRefreshTest {
         selectorDataRefresh.refresh(selectorDataList);
         selectorDataList.add(selectorData);
         selectorDataRefresh.refresh(selectorDataList);
+    }
+
+    @Test
+    public void testRefreshWithNullData() {
+        final PluginDataSubscriber subscriber = mock(PluginDataSubscriber.class);
+        final SelectorDataRefresh selectorDataRefresh = new SelectorDataRefresh(subscriber);
+        // data is null, should not throw NPE; cache is still refreshed unconditionally, then return early
+        selectorDataRefresh.refresh((List<SelectorData>) null);
+        verify(subscriber).refreshSelectorDataAll();
+        verify(subscriber, never()).unSelectorSubscribe(any(SelectorData.class));
+        verify(subscriber, never()).onSelectorSubscribe(any(SelectorData.class));
     }
 }


### PR DESCRIPTION
Fixes #6890 
## summary
- Restructure refresh() to clear the cache unconditionally first, following the same implementation as `PluginDataRefresh`, and return early when the data is empty, so a null payload clears the cache instead of crashing. Behavior for empty and non-empty data is unchanged.
- Add regression tests covering refresh with null data for both refreshers.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
