### PR TITLE
Fixes #6786:关闭钩子反射访问失败时避免线程异常退出

### DIFF
--- a/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHook.java
+++ b/shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHook.java
@@ -88,12 +88,17 @@ public class ShenyuClientShutdownHook {
                 Field field = clazz.getDeclaredField(props.getProperty("applicationShutdownHooksFieldName", "hooks"));
                 field.setAccessible(true);
                 hooks = (IdentityHashMap<Thread, Thread>) field.get(clazz);
-            } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException ex) {
-                LOG.error(ex.getMessage(), ex);
+            } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException | RuntimeException ex) {
+                LOG.warn("Failed to access application shutdown hooks, skip delaying other hooks.", ex);
+                return;
+            }
+            if (Objects.isNull(hooks)) {
+                LOG.warn("Application shutdown hooks are null, skip delaying other hooks.");
+                return;
             }
             long s = System.currentTimeMillis();
             while (System.currentTimeMillis() - s < delayOtherHooksExecTime) {
-                for (Iterator<Thread> iterator = Objects.requireNonNull(hooks).keySet().iterator(); iterator.hasNext();) {
+                for (Iterator<Thread> iterator = hooks.keySet().iterator(); iterator.hasNext();) {
                     Thread hook = iterator.next();
                     if (hook.getName().equals(ShutdownHookManager.getHookName())) {
                         continue;

--- a/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHookTest.java
+++ b/shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/shutdown/ShenyuClientShutdownHookTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.client.core.shutdown;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public final class ShenyuClientShutdownHookTest {
+
+    @Test
+    void shouldSkipDelayWhenApplicationShutdownHooksCannotBeAccessed() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("applicationShutdownHooksClassName", "org.apache.shenyu.InvalidApplicationShutdownHooks");
+        ReflectionTestUtils.setField(ShenyuClientShutdownHook.class, "props", properties);
+
+        Class<?> threadClass = Class.forName(ShenyuClientShutdownHook.class.getName() + "$TakeoverOtherHooksThread");
+        Constructor<?> constructor = threadClass.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Thread takeoverOtherHooksThread = (Thread) constructor.newInstance();
+
+        assertDoesNotThrow(takeoverOtherHooksThread::run);
+    }
+}


### PR DESCRIPTION
Fixes #6786
## 背景

客户端关闭时会尝试通过反射获取 JVM 的 shutdown hooks，用于延后其他关闭钩子的执行。

在 Java 21 这类有模块访问限制的环境里，反射访问可能抛出
`InaccessibleObjectException`。原来的逻辑只记录异常，后面仍会继续使用
空的 hooks 对象，最终导致后台线程再次抛出 NPE。

## 修改内容

反射访问失败或获取到的 hooks 为空时，记录告警后直接跳过延迟逻辑。

这样在无法访问 JVM 内部 shutdown hooks 的环境中，会正常降级，而不会让
关闭钩子线程异常退出。

同时补充了回归测试，覆盖反射目标不可访问的场景。


## 验证

已执行 `ShenyuClientShutdownHookTest`，测试通过。