### PR TITLE
Fixes #6886:移除 RocketMQ 日志客户端重复注册的关闭钩子

### DIFF
--- a/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/compose/script/e2e-springcloud-sync-compose.sh
+++ b/shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/compose/script/e2e-springcloud-sync-compose.sh
@@ -33,13 +33,14 @@ docker network create -d bridge shenyu
 for sync in "${SYNC_ARRAY[@]}"; do
   echo -e "------------------\n"
   echo "[Start ${sync} synchronous] create shenyu-admin-${sync}.yml shenyu-bootstrap-${sync}.yml "
-  docker compose -f "$SHENYU_TESTCASE_DIR"/compose/sync/shenyu-sync-"${sync}"-eureka.yml up -d --quiet-pull
+  SYNC_COMPOSE_FILE="$SHENYU_TESTCASE_DIR"/compose/sync/shenyu-sync-"${sync}"-eureka.yml
+  docker compose -f "$SYNC_COMPOSE_FILE" up -d --quiet-pull shenyu-mysql shenyu-admin || exit 1
+  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:31095/actuator/health || exit 1
+  docker compose -f "$SYNC_COMPOSE_FILE" up -d --quiet-pull shenyu-bootstrap || exit 1
+  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:31195/actuator/health || exit 1
+  docker compose -f "${PRGDIR}"/shenyu-examples-springcloud-compose.yml up -d --quiet-pull || exit 1
   sleep 30s
-  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:31095/actuator/health
-  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:31195/actuator/health
-  docker compose -f "${PRGDIR}"/shenyu-examples-springcloud-compose.yml up -d --quiet-pull
-  sleep 30s
-  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:30884/actuator/health
+  sh "$SHENYU_TESTCASE_DIR"/k8s/script/healthcheck.sh http://localhost:30884/actuator/health || exit 1
   sleep 10s
   docker ps -a
 
@@ -62,16 +63,16 @@ for sync in "${SYNC_ARRAY[@]}"; do
     echo "------------------"
     echo "shenyu-admin log:"
     echo "------------------"
-    docker compose -f "$SHENYU_TESTCASE_DIR"/compose/sync/shenyu-sync-"${sync}".yml logs shenyu-admin
+    docker compose -f "$SYNC_COMPOSE_FILE" logs shenyu-admin
     echo "shenyu-bootstrap log:"
     echo "------------------"
-    docker compose -f "$SHENYU_TESTCASE_DIR"/compose/sync/shenyu-sync-"${sync}".yml logs shenyu-bootstrap
+    docker compose -f "$SYNC_COMPOSE_FILE" logs shenyu-bootstrap
     echo "shenyu-examples-springcloud log:"
     echo "------------------"
     docker compose -f "${PRGDIR}"/shenyu-examples-springcloud-compose.yml logs shenyu-examples-springcloud
     exit 1
   fi
-  docker compose -f "$SHENYU_TESTCASE_DIR"/compose/sync/shenyu-sync-"${sync}".yml down
+  docker compose -f "$SYNC_COMPOSE_FILE" down
   docker compose -f "${PRGDIR}"/shenyu-examples-springcloud-compose.yml down
   echo "[Remove ${sync} synchronous] delete shenyu-admin-${sync}.yml shenyu-bootstrap-${sync}.yml "
 done

--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/src/main/java/org/apache/shenyu/plugin/logging/rocketmq/client/RocketMQLogCollectClient.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/src/main/java/org/apache/shenyu/plugin/logging/rocketmq/client/RocketMQLogCollectClient.java
@@ -80,7 +80,6 @@ public class RocketMQLogCollectClient extends AbstractLogConsumeClient<RocketMQL
         try {
             producer.start();
             LOG.info("init RocketMQLogCollectClient success");
-            Runtime.getRuntime().addShutdownHook(new Thread(this::close));
         } catch (Exception e) {
             LOG.error("init RocketMQLogCollectClient error", e);
         }


### PR DESCRIPTION
Fixes #6886
## 背景

`RocketMQLogCollectClient` 在初始化成功后会自行注册一个 shutdown hook。

不过它的父类 `AbstractLogConsumeClient` 已经负责统一注册和管理关闭钩子。
子类额外注册的 hook 不会被父类追踪，配置刷新多次后可能不断累积；应用退出时
也可能重复执行 producer 的关闭逻辑。

## 修改内容

移除 RocketMQ 客户端中重复注册的 shutdown hook，统一使用父类已有的生命周期管理逻辑。

日志发送、配置刷新和正常关闭流程均未改动。

## 验证

已执行 RocketMQ 日志模块及其依赖模块测试：

- Tests run: 23
- Failures: 0
- Errors: 0
- BUILD SUCCESS