### PR TITLE
Fixes #6784：移除失效 WebSocket 同步客户端时同步取消健康检查任务

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataService.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataService.java
@@ -145,6 +145,7 @@ public class WebsocketSyncDataService implements SyncDataService {
         while (iterator.hasNext()) {
             ShenyuWebsocketClient websocketClient = iterator.next();
             if (!websocketClient.isOpen()) {
+                websocketClient.nowClose();
                 iterator.remove();
                 continue;
             }

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataServiceTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.sync.data.websocket;
+
+import org.apache.shenyu.common.config.ShenyuConfig;
+import org.apache.shenyu.plugin.sync.data.websocket.client.ShenyuWebsocketClient;
+import org.apache.shenyu.plugin.sync.data.websocket.config.WebsocketConfig;
+import org.apache.shenyu.sync.data.api.AiProxyApiKeyDataSubscriber;
+import org.apache.shenyu.sync.data.api.AuthDataSubscriber;
+import org.apache.shenyu.sync.data.api.DiscoveryUpstreamDataSubscriber;
+import org.apache.shenyu.sync.data.api.MetaDataSubscriber;
+import org.apache.shenyu.sync.data.api.PluginDataSubscriber;
+import org.apache.shenyu.sync.data.api.ProxySelectorDataSubscriber;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class WebsocketSyncDataServiceTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMasterCheckClosesRemovedClient() throws Exception {
+        WebsocketConfig websocketConfig = new WebsocketConfig();
+        websocketConfig.setUrls(Collections.emptyList());
+        WebsocketSyncDataService websocketSyncDataService = new WebsocketSyncDataService(
+                websocketConfig,
+                new ShenyuConfig(),
+                mock(PluginDataSubscriber.class),
+                Collections.<MetaDataSubscriber>emptyList(),
+                Collections.<AuthDataSubscriber>emptyList(),
+                Collections.<ProxySelectorDataSubscriber>emptyList(),
+                Collections.<DiscoveryUpstreamDataSubscriber>emptyList(),
+                Collections.<AiProxyApiKeyDataSubscriber>emptyList(),
+                mock(ServerProperties.class));
+        ShenyuWebsocketClient websocketClient = mock(ShenyuWebsocketClient.class);
+        when(websocketClient.isOpen()).thenReturn(false);
+        Field clientsField = WebsocketSyncDataService.class.getDeclaredField("clients");
+        clientsField.setAccessible(true);
+        List<ShenyuWebsocketClient> clients = (List<ShenyuWebsocketClient>) clientsField
+                .get(websocketSyncDataService);
+        clients.add(websocketClient);
+
+        try {
+            Method masterCheck = WebsocketSyncDataService.class.getDeclaredMethod("masterCheck");
+            masterCheck.setAccessible(true);
+            masterCheck.invoke(websocketSyncDataService);
+            verify(websocketClient).nowClose();
+            assertTrue(clients.isEmpty());
+        } finally {
+            websocketSyncDataService.close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6784

## 背景

`WebsocketSyncDataService` 在巡检时，如果发现某个客户端已经不处于 open 状态，
会直接把它从客户端列表中移除。

但这个分支没有调用客户端的 `nowClose()`。这样客户端关联的健康检查定时任务
还会继续运行，并可能在后台重新建立连接。重连后的客户端已经不在服务的管理列表
里，后续也不会被统一关闭。

## 修改内容

在移除未打开的 WebSocket 客户端前，先调用 `nowClose()`，取消客户端自身的
健康检查任务，再从列表中移除。

该处理方式与同一个方法中 `!isConnectedToMaster()` 分支的关闭逻辑保持一致。

同时补充了回归测试，验证失效客户端会被关闭并移出客户端列表。

## 验证

已执行 WebSocket 同步模块及其依赖模块测试：

- Tests run: 45
- Failures: 0
- Errors: 0
- BUILD SUCCESS