### PR TITLE
[ISSUE #6773] fix: handle unset response status in response transformer

### DIFF
--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplate.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplate.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.server.ServerWebExchange;
@@ -187,7 +188,10 @@ public class AiResponseTransformerTemplate {
                     // as the response body is not yet available when the template is assembled)
                     ObjectNode responseNode = objectMapper.createObjectNode();
                     responseNode.set("headers", responseHeadersJson);
-                    responseNode.put("status", exchange.getResponse().getStatusCode().value());
+                    HttpStatusCode responseStatus = exchange.getResponse().getStatusCode();
+                    if (Objects.nonNull(responseStatus)) {
+                        responseNode.put("status", responseStatus.value());
+                    }
                     responseNode.put("body", "");
 
                     rootNode.set("request", requestNode);

--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplateStatusTest.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplateStatusTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.plugin.ai.transformer.response.template;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Test cases for response status handling in {@link AiResponseTransformerTemplate}.
+ */
+final class AiResponseTransformerTemplateStatusTest {
+
+    @Test
+    void testAssembleMessageWithoutResponseStatus() throws Exception {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        assertNull(exchange.getResponse().getStatusCode());
+
+        AiResponseTransformerTemplate template = new AiResponseTransformerTemplate("Transform this response", request);
+        String message = template.assembleMessage(exchange).block();
+
+        assertNotNull(message);
+        JsonNode responseNode = new ObjectMapper().readTree(message).get("response");
+        assertNotNull(responseNode);
+        assertFalse(responseNode.has("status"));
+    }
+}


### PR DESCRIPTION
Fixes #6773.

`AiResponseTransformerTemplate.assembleMessage()` previously called `value()` directly on the response status code. When the upstream response had no explicitly configured status code, `getStatusCode()` returned `null`, causing a `NullPointerException` and preventing response transformation.

This PR:

- Checks whether the response status code is present before accessing its value.
- Omits the `response.status` field when no status has been explicitly set.
- Preserves the existing behavior for responses with a configured status code.
- Adds a regression test covering responses with an unset status code.

## Verification

- The regression test reproduces the original `NullPointerException` before the fix.
- The regression test passes after the fix.
- Compilation and Checkstyle pass.

@Aias00 Could you please review this PR?