### PR TITLE
[Fix] Guard InstanceCheckService executor shutdown (#6705)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -179,7 +180,9 @@ public class InstanceCheckService {
     public void close() {
         syncDB();
         instanceHealthBeatInfo.clear();
-        executor.shutdown();
+        if (Objects.nonNull(executor)) {
+            executor.shutdown();
+        }
     }
 
     /**

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,6 +117,11 @@ public final class InstanceCheckServiceTest {
         instanceCheckService.handleBeatInfo(dto);
         instanceCheckService.syncDB();
         verify(instanceInfoService, times(1)).createOrUpdate(any(InstanceInfoVO.class));
+    }
+
+    @Test
+    void testCloseWithoutSetup() {
+        assertDoesNotThrow(instanceCheckService::close);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #6705.

`InstanceCheckService.close()` previously called `executor.shutdown()` unconditionally. When `setup()` was not invoked, the executor remained `null`, causing an NPE during application shutdown.

This PR:

- Adds a null check before shutting down the executor.
- Preserves the existing database synchronization and instance cleanup behavior.
- Adds a regression test for calling `close()` without invoking `setup()`.

## Tests

- `InstanceCheckServiceTest`: 8 tests passed.
- `shenyu-admin`: 1,440 tests passed, 0 failures, 1 skipped.
- Checkstyle passed with 0 violations.

@Aias00 Please review this PR when you have time.