### PR TITLE
fix: avoid NPE when plugin handle dataType is null (#6707)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginHandleServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginHandleServiceImpl.java
@@ -206,7 +206,7 @@ public class PluginHandleServiceImpl implements PluginHandleService {
 
     private PluginHandleVO buildPluginHandleVO(final PluginHandleDO pluginHandleDO) {
         List<ShenyuDictVO> dictOptions = null;
-        if (pluginHandleDO.getDataType() == SELECT_BOX_DATA_TYPE) {
+        if (Objects.equals(pluginHandleDO.getDataType(), SELECT_BOX_DATA_TYPE)) {
             dictOptions = shenyuDictMapper.findByType(pluginHandleDO.getField())
                     .stream()
                     .filter(item -> Objects.equals(item.getEnabled(), Boolean.TRUE))
@@ -219,7 +219,7 @@ public class PluginHandleServiceImpl implements PluginHandleService {
     private List<PluginHandleVO> buildPluginHandleVO(final List<PluginHandleDO> pluginHandleDOList) {
 
         List<String> fieldList = pluginHandleDOList.stream()
-                .filter(pluginHandleDO -> pluginHandleDO.getDataType() == SELECT_BOX_DATA_TYPE)
+                .filter(pluginHandleDO -> Objects.equals(pluginHandleDO.getDataType(), SELECT_BOX_DATA_TYPE))
                 .map(PluginHandleDO::getField)
                 .distinct()
                 .collect(Collectors.toList());

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/PluginHandleServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/PluginHandleServiceTest.java
@@ -46,7 +46,9 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -174,6 +176,18 @@ public final class PluginHandleServiceTest {
         assertThat(result.getDictOptions().size(), equalTo(1));
     }
 
+    @Test
+    public void testFindByIdWhenDataTypeIsNull() {
+        PluginHandleDO pluginHandleDO = buildPluginHandleDO();
+        pluginHandleDO.setDataType(null);
+        given(this.pluginHandleMapper.selectById("4")).willReturn(pluginHandleDO);
+
+        PluginHandleVO result = assertDoesNotThrow(() -> this.pluginHandleService.findById("4"));
+
+        assertThat(result, notNullValue());
+        assertNull(result.getDataType());
+    }
+
     private List<ShenyuDictDO> buildShenyuDictDOs() {
         Timestamp now = Timestamp.valueOf(LocalDateTime.now());
         final ShenyuDictDO result = ShenyuDictDO.builder()
@@ -210,6 +224,18 @@ public final class PluginHandleServiceTest {
         final List<PluginHandleVO> result = pluginHandleService.list("4", 2);
         assertThat(result, notNullValue());
         assertEquals(pluginHandleDOs.size(), result.size());
+    }
+
+    @Test
+    public void testListWhenDataTypeIsNull() {
+        PluginHandleDO pluginHandleDO = buildPluginHandleDO();
+        pluginHandleDO.setDataType(null);
+        given(this.pluginHandleMapper.selectByQuery(any())).willReturn(Collections.singletonList(pluginHandleDO));
+
+        List<PluginHandleVO> result = assertDoesNotThrow(() -> this.pluginHandleService.list("4", 2));
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getDataType());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #6707.

This PR prevents `PluginHandleServiceImpl.buildPluginHandleVO` from throwing a `NullPointerException` when `dataType` is null.

## Changes

- Replace unsafe `Integer` autounboxing comparisons with `Objects.equals`.
- Cover both single-item and batch conversion paths.
- Add regression tests for plugin handles with a null `dataType`.

## Testing

- `PluginHandleServiceTest`: passed
- `shenyu-admin` full test suite: 1441 tests, 0 failures, 0 errors

@Aias00 Please help review this PR. Thanks!