### PR TITLE
fix: prevent NPE on mqtt bootstrap server shutdown after failed start

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServer.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServer.java
@@ -26,56 +26,74 @@ import io.netty.util.ResourceLeakDetector;
 import org.apache.shenyu.common.utils.Singleton;
 import org.apache.shenyu.protocol.mqtt.repositories.BaseRepository;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * mqtt server.
  */
 public class MqttBootstrapServer implements BootstrapServer {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MqttBootstrapServer.class);
+
     private static final String REPOSITORY_PACKAGE_NAME = "org.apache.shenyu.protocol.mqtt.repositories";
 
     private static final MqttContext ENV = new MqttContext();
 
-    private EventLoopGroup bossGroup;
+    private volatile EventLoopGroup bossGroup;
 
-    private EventLoopGroup workerGroup;
+    private volatile EventLoopGroup workerGroup;
 
-    private ChannelFuture future;
+    private volatile ChannelFuture future;
 
     @Override
     public void init() {
         try {
             initRepositories();
         } catch (Exception e) {
-            //// todo log
+            LOG.error("MQTT server init repositories failed", e);
         }
     }
 
     @Override
     public void start() {
-        //// todo thread start mqtt server
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.valueOf(ENV.getLeakDetectorLevel().toUpperCase(Locale.ROOT)));
-        bossGroup = new NioEventLoopGroup(ENV.getBossGroupThreadCount());
-        workerGroup = new NioEventLoopGroup(ENV.getWorkerGroupThreadCount());
-        ServerBootstrap bootstrap = new ServerBootstrap();
-        bootstrap.group(bossGroup, workerGroup)
-                .channel(NioServerSocketChannel.class)
-                .childHandler(new MqttTransportServerInitializer(ENV.getMaxPayloadSize()));
-        try {
-            future = bootstrap.bind(ENV.getPort()).sync();
-            //// todo log
-        } catch (InterruptedException e) {
-            //// todo log
-        }
+        CompletableFuture.runAsync(() -> {
+            bossGroup = new NioEventLoopGroup(ENV.getBossGroupThreadCount());
+            workerGroup = new NioEventLoopGroup(ENV.getWorkerGroupThreadCount());
+            ServerBootstrap bootstrap = new ServerBootstrap();
+            bootstrap.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(new MqttTransportServerInitializer(ENV.getMaxPayloadSize()));
+            try {
+                future = bootstrap.bind(ENV.getPort()).sync();
+                LOG.info("MQTT server started on port {}", ENV.getPort());
+            } catch (InterruptedException e) {
+                LOG.error("MQTT server bind interrupted", e);
+                shutdown();
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                LOG.error("MQTT server failed to bind on port {}", ENV.getPort(), e);
+                shutdown();
+            }
+        });
     }
 
     @Override
     public void shutdown() {
-        bossGroup.shutdownGracefully();
-        workerGroup.shutdownGracefully();
-        future.channel().close();
+        if (Objects.nonNull(bossGroup)) {
+            bossGroup.shutdownGracefully();
+        }
+        if (Objects.nonNull(workerGroup)) {
+            workerGroup.shutdownGracefully();
+        }
+        if (Objects.nonNull(future)) {
+            future.channel().close();
+        }
     }
 
     private void initRepositories() throws IllegalAccessException, InstantiationException {

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServerTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt;
+
+import io.netty.channel.EventLoopGroup;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Test cases for {@link MqttBootstrapServer}.
+ */
+public final class MqttBootstrapServerTest {
+
+    @Test
+    public void shutdownWithoutStartDoesNotThrow() {
+        assertDoesNotThrow(new MqttBootstrapServer()::shutdown);
+    }
+
+    @Test
+    public void startWithPortInUseThenShutdownDoesNotThrow() throws Exception {
+        MqttContext env = new MqttContext();
+        env.setBossGroupThreadCount(1);
+        env.setWorkerGroupThreadCount(1);
+        env.setMaxPayloadSize(1024);
+        env.setLeakDetectorLevel("DISABLED");
+        try (ServerSocket socket = new ServerSocket(0)) {
+            env.setPort(socket.getLocalPort());
+            MqttBootstrapServer server = new MqttBootstrapServer();
+            server.start();
+            await().atMost(Duration.ofSeconds(10))
+                    .until(() -> getBossGroup(server).isShutdown());
+            assertDoesNotThrow(server::shutdown);
+        }
+    }
+
+    @Test
+    public void startOnFreePortThenShutdownDoesNotThrow() throws Exception {
+        MqttContext env = new MqttContext();
+        env.setBossGroupThreadCount(1);
+        env.setWorkerGroupThreadCount(1);
+        env.setMaxPayloadSize(1024);
+        env.setLeakDetectorLevel("DISABLED");
+        try (ServerSocket socket = new ServerSocket(0)) {
+            int freePort = socket.getLocalPort();
+            env.setPort(freePort);
+            MqttBootstrapServer server = new MqttBootstrapServer();
+            server.start();
+            await().atMost(Duration.ofSeconds(10))
+                    .until(() -> canConnect(freePort));
+            assertDoesNotThrow(server::shutdown);
+        }
+    }
+
+    private static EventLoopGroup getBossGroup(final MqttBootstrapServer server) throws Exception {
+        Field field = MqttBootstrapServer.class.getDeclaredField("bossGroup");
+        field.setAccessible(true);
+        return (EventLoopGroup) field.get(server);
+    }
+
+    private static boolean canConnect(final int port) {
+        try (Socket ignored = new Socket("127.0.0.1", port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServerTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/MqttBootstrapServerTest.java
@@ -51,7 +51,10 @@ public final class MqttBootstrapServerTest {
             MqttBootstrapServer server = new MqttBootstrapServer();
             server.start();
             await().atMost(Duration.ofSeconds(10))
-                    .until(() -> getBossGroup(server).isShutdown());
+                    .until(() -> {
+                        EventLoopGroup bossGroup = getBossGroup(server);
+                        return bossGroup == null || bossGroup.isShutdown();
+                    });
             assertDoesNotThrow(server::shutdown);
         }
     }


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary

### Changes:

MqttBootstrapServer (shenyu-protocol-mqtt):                                                                                                                                        
                         
  - Failed-start NPE fix: start() previously swallowed InterruptedException, leaving future null so shutdown() threw NPE. Now bind failures are logged, event-loop groups are        
  disposed via shutdown(), and the interrupt flag is restored.                                                                                                                       
  - Null-safe shutdown: shutdown() null-checks bossGroup, workerGroup, and future using Objects.nonNull (checkstyle requirement).                                                    
  - Async start: bind logic moved into CompletableFuture.runAsync(...) (module convention), resolving the //// todo thread start mqtt server marker; exceptions are handled inside   
  the task since callers can no longer observe them. Fields made volatile for cross-thread visibility.                                                                               
  - Logging: added LOG.info on successful start and LOG.error in init()/start() catch blocks.                                                                                        
                                                                                                                                                                                    
### Test Cases: 

MqttBootstrapServerTest:

  - new MqttBootstrapServerTest with 3 cases — shutdown without start, port-in-use start then shutdown, free-port start (await connect) then shutdown.

close [#6747](https://github.com/apache/shenyu/issues/6747)