### PR TITLE
[ISSUE #6551] fix: use resource update event for resource changes

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/publish/ResourceEventPublisher.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/publish/ResourceEventPublisher.java
@@ -71,7 +71,7 @@ public class ResourceEventPublisher implements AdminDataModelChangedEventPublish
      */
     @Override
     public void onUpdated(final ResourceDO resource, final ResourceDO before) {
-        publish(new ResourceChangedEvent(resource, before, EventTypeEnum.RULE_DELETE, SessionUtil.visitorName()));
+        publish(new ResourceChangedEvent(resource, before, EventTypeEnum.RESOURCE_UPDATE, SessionUtil.visitorName()));
     }
     
     /**

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/ResourceEventPublisherTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/ResourceEventPublisherTest.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.admin.service.publish;
 
 import org.apache.shenyu.admin.model.entity.ResourceDO;
+import org.apache.shenyu.admin.model.enums.EventTypeEnum;
 import org.apache.shenyu.admin.model.event.resource.BatchResourceCreatedEvent;
 import org.apache.shenyu.admin.model.event.resource.BatchResourceDeletedEvent;
 import org.apache.shenyu.admin.model.event.resource.ResourceChangedEvent;
@@ -108,6 +109,7 @@ class ResourceEventPublisherTest {
         assertNotNull(event);
         assertEquals(after, event.getAfter());
         assertEquals(before, event.getBefore());
+        assertEquals(EventTypeEnum.RESOURCE_UPDATE, event.getType());
     }
 
     @Test


### PR DESCRIPTION
Fixes #6551.

ResourceEventPublisher#onUpdated incorrectly published resource update events using EventTypeEnum.RULE_DELETE. As a result, resource updates were recorded in the audit log with rule-deletion semantics.

This PR:
- Changes the event type to EventTypeEnum.RESOURCE_UPDATE.
- Adds a regression assertion to verify that resource updates publish the correct event type.

Thanks @Aias00 for reporting this issue. Please review when convenient.