### PR TITLE
[ISSUE #6519] fix: handle missing plugin during client registration

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java
@@ -225,10 +225,13 @@ public abstract class AbstractShenyuClientRegisterServiceImpl extends FallbackSh
 
     @Override
     public void checkNamespacePluginRel(final String namespaceId, final String pluginName) {
+        String errorMsg = String.format("%s plugin not enabled for current namespace or plugin not exist for namespaceId: %s", pluginName, namespaceId);
         PluginDO pluginDO = pluginMapper.selectByName(pluginName);
+        if (Objects.isNull(pluginDO)) {
+            throw new IllegalArgumentException(errorMsg);
+        }
         NamespacePluginVO namespacePluginRelation = namespacePluginRelMapper.selectByPluginIdAndNamespaceId(pluginDO.getId(), namespaceId);
         if (Objects.isNull(namespacePluginRelation)) {
-            String errorMsg = String.format("%s plugin not enabled for current namespace or plugin not exist for namespaceId: %s", pluginName, namespaceId);
             throw new IllegalArgumentException(errorMsg);
         }
     }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImplTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImplTest.java
@@ -192,6 +192,17 @@ public final class AbstractShenyuClientRegisterServiceImplTest {
     }
 
     @Test
+    public void testCheckNamespacePluginRelWhenPluginMissing() {
+        String pluginName = "missing-plugin";
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> abstractShenyuClientRegisterService.checkNamespacePluginRel(SYS_DEFAULT_NAMESPACE_ID, pluginName));
+
+        assertEquals("missing-plugin plugin not enabled for current namespace or plugin not exist for namespaceId: "
+                + SYS_DEFAULT_NAMESPACE_ID, exception.getMessage());
+    }
+
+    @Test
     public void testGetMetaDataService() {
         assertEquals(metaDataService, abstractShenyuClientRegisterService.getMetaDataService());
     }


### PR DESCRIPTION
Fixes #6519.

AbstractShenyuClientRegisterServiceImpl#checkNamespacePluginRel previously accessed pluginDO.getId() without checking whether the plugin record existed. When pluginMapper.selectByName returned null, client registration failed with an internal NullPointerException.

This PR:
- Checks whether the target plugin exists before accessing its ID.
- Throws the existing descriptive IllegalArgumentException when the plugin is missing.
- Adds a regression test covering the missing-plugin scenario and its error message.

Thanks @Aias00 for reporting this issue. Please review when convenient.