### PR TITLE
fix: use computeIfAbsent to prevent lost subscriber updates

### DIFF
--- a/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/main/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepository.java
@@ -41,11 +41,8 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
 
     @Override
     public void add(final List<String> topics, final List<Channel> channels) {
-        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(s -> {
-            List<Channel> list = get(s);
-            list.addAll(channels);
-            TOPIC_CHANNEL_FACTORY.put(s, list);
-        }));
+        CompletableFuture.runAsync(() -> topics.parallelStream().forEach(s ->
+                TOPIC_CHANNEL_FACTORY.computeIfAbsent(s, topic -> new CopyOnWriteArrayList<>()).addAll(channels)));
     }
 
     /**
@@ -54,11 +51,8 @@ public class SubscribeRepository implements BaseRepository<List<String>, List<Ch
      * @param mqttTopicSubscription mqtt subscription info
      */
     public void add(final Channel channel, final List<MqttTopicSubscription> mqttTopicSubscription) {
-        CompletableFuture.runAsync(() -> mqttTopicSubscription.parallelStream().forEach(s -> {
-            List<Channel> channels = get(s.topicName());
-            channels.add(channel);
-            TOPIC_CHANNEL_FACTORY.put(s.topicName(), channels);
-        }));
+        CompletableFuture.runAsync(() -> mqttTopicSubscription.parallelStream().forEach(s ->
+                TOPIC_CHANNEL_FACTORY.computeIfAbsent(s.topicName(), topic -> new CopyOnWriteArrayList<>()).add(channel)));
     }
 
     @Override

--- a/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
+++ b/shenyu-protocol/shenyu-protocol-mqtt/src/test/java/org/apache/shenyu/protocol/mqtt/repositories/SubscribeRepositoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.protocol.mqtt.repositories;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test cases for {@link SubscribeRepository}.
+ */
+public final class SubscribeRepositoryTest {
+
+    private static final String TOPIC = "test/subscribe";
+
+    private static final String MULTI_TOPIC_A = "test/subscribe-a";
+
+    private static final String MULTI_TOPIC_B = "test/subscribe-b";
+
+    private static final String CONCURRENT_TOPIC = "test/concurrent-subscribe";
+
+    private static final String CONCURRENT_TOPICS_TOPIC = "test/concurrent-subscribe-topics";
+
+    private static final int SUBSCRIBER_COUNT = 50;
+
+    private SubscribeRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new SubscribeRepository();
+    }
+
+    @Test
+    public void addChannelSubscribesChannelToTopic() {
+        Channel channel = mock(Channel.class);
+        repository.add(channel, Collections.singletonList(new MqttTopicSubscription(TOPIC, MqttQoS.AT_MOST_ONCE)));
+        await().atMost(Duration.ofSeconds(5)).until(() -> repository.get(TOPIC).contains(channel));
+    }
+
+    @Test
+    public void addTopicsRegistersChannelsForEachTopic() {
+        Channel channel = mock(Channel.class);
+        repository.add(List.of(MULTI_TOPIC_A, MULTI_TOPIC_B), Collections.singletonList(channel));
+        await().atMost(Duration.ofSeconds(5)).until(() ->
+                repository.get(MULTI_TOPIC_A).contains(channel) && repository.get(MULTI_TOPIC_B).contains(channel));
+    }
+
+    @Test
+    public void concurrentAddsToSameTopicDoNotLoseSubscribers() {
+        List<Channel> channels = IntStream.range(0, SUBSCRIBER_COUNT)
+                .mapToObj(i -> mock(Channel.class))
+                .collect(Collectors.toList());
+        channels.parallelStream().forEach(channel -> repository.add(channel,
+                Collections.singletonList(new MqttTopicSubscription(CONCURRENT_TOPIC, MqttQoS.AT_MOST_ONCE))));
+        await().atMost(Duration.ofSeconds(10)).until(() -> repository.get(CONCURRENT_TOPIC).size() == SUBSCRIBER_COUNT);
+    }
+
+    @Test
+    public void concurrentAddsForTopicsDoNotLoseChannels() {
+        List<Channel> channels = IntStream.range(0, SUBSCRIBER_COUNT)
+                .mapToObj(i -> mock(Channel.class))
+                .collect(Collectors.toList());
+        channels.parallelStream().forEach(channel -> repository.add(
+                Collections.singletonList(CONCURRENT_TOPICS_TOPIC), Collections.singletonList(channel)));
+        await().atMost(Duration.ofSeconds(10)).until(() -> repository.get(CONCURRENT_TOPICS_TOPIC).size() == SUBSCRIBER_COUNT);
+    }
+}


### PR DESCRIPTION
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [X] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.

## Summary

### Changes:
  
Fix: lost-update race in SubscribeRepository.add()
  Both add() overloads used a get-then-put pattern: get(topic) returned a transient CopyOnWriteArrayList for an absent topic (via getOrDefault), the channel was added to that transient list, then the list was put into TOPIC_CHANNEL_FACTORY. Under concurrent subscription to a new topic, each thread obtained its own empty list and the last put won —silently dropping the first subscriber.

 Fix: both overloads now use TOPIC_CHANNEL_FACTORY.computeIfAbsent(topic, t -> new CopyOnWriteArrayList<>()) to atomically obtain the canonical list stored in the map, followed by a thread-safe add/addAll on the CopyOnWriteArrayList.

### Test Cases:
  
Tests: unit tests for SubscribeRepository
Added SubscribeRepositoryTest with 4 tests: basic registration via both add() overloads, plus two concurrency regression tests asserting 50 concurrent subscribers to a new topic are all retained.

close [#6746](https://github.com/apache/shenyu/issues/6746)