### PR TITLE
[ISSUE #6780] fix: clear discovery upstream data on empty HTTP refresh

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefresh.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefresh.java
@@ -54,7 +54,8 @@ public class DiscoveryUpstreamDataRefresh extends AbstractDataRefresh<DiscoveryS
     @Override
     protected void refresh(final List<DiscoverySyncData> data) {
         if (CollectionUtils.isEmpty(data)) {
-            LOG.info("clear all plugin data cache");
+            LOG.info("clear all discovery upstream data cache");
+            discoveryUpstreamDataSubscribers.forEach(DiscoveryUpstreamDataSubscriber::refresh);
             return;
         }
         data.forEach(d -> discoveryUpstreamDataSubscribers.forEach(dus -> dus.onSubscribe(d)));

--- a/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefreshTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/refresh/DiscoveryUpstreamDataRefreshTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shenyu.sync.data.http.refresh;
+
+import org.apache.shenyu.sync.data.api.DiscoveryUpstreamDataSubscriber;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public final class DiscoveryUpstreamDataRefreshTest {
+
+    @Test
+    public void testRefreshWithEmptyData() {
+        DiscoveryUpstreamDataSubscriber subscriber = mock(DiscoveryUpstreamDataSubscriber.class);
+        DiscoveryUpstreamDataRefresh dataRefresh = new DiscoveryUpstreamDataRefresh(Collections.singletonList(subscriber));
+
+        dataRefresh.refresh(Collections.emptyList());
+
+        verify(subscriber).refresh();
+    }
+}


### PR DESCRIPTION
## What this PR does

Fixes #6780.

- Calls `refresh()` on all discovery upstream subscribers when HTTP sync receives an empty discovery upstream list.
- Prevents stale discovery upstream data from remaining after all upstreams are removed.
- Corrects the related copy-paste error in the log message.
- Adds a regression test for the empty refresh scenario.

@Aias00, could you please help review this PR? Thank you!