### PR TITLE
[ISSUE #6843] Prevent invalid WebSocket messages from terminating the reader thread

### DIFF
--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClient.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClient.java
@@ -221,22 +221,26 @@ public final class ShenyuWebsocketClient extends WebSocketClient {
     
     @Override
     public void onMessage(final String result) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("onMessage server[{}] result({})", this.getURI().toString(), result);
-        }
-        
-        Map<String, Object> jsonToMap = JsonUtils.jsonToMap(result);
-        Object eventType = jsonToMap.get(RunningModeConstants.EVENT_TYPE);
-        if (Objects.equals(DataEventTypeEnum.RUNNING_MODE.name(), eventType)) {
-            LOG.info("server[{}] handle running mode result({})", this.getURI().toString(), result);
-            this.runningMode = String.valueOf(jsonToMap.get(RunningModeConstants.RUNNING_MODE));
-            if (Objects.equals(RunningModeEnum.STANDALONE.name(), runningMode)) {
-                return;
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("onMessage server[{}] result({})", this.getURI().toString(), result);
             }
-            this.masterUrl = String.valueOf(jsonToMap.get(RunningModeConstants.MASTER_URL));
-            this.isConnectedToMaster = Boolean.TRUE.equals(jsonToMap.get(RunningModeConstants.IS_MASTER));
-        } else {
-            handleResult(result);
+
+            Map<String, Object> jsonToMap = JsonUtils.jsonToMap(result);
+            Object eventType = jsonToMap.get(RunningModeConstants.EVENT_TYPE);
+            if (Objects.equals(DataEventTypeEnum.RUNNING_MODE.name(), eventType)) {
+                LOG.info("server[{}] handle running mode result({})", this.getURI().toString(), result);
+                this.runningMode = String.valueOf(jsonToMap.get(RunningModeConstants.RUNNING_MODE));
+                if (Objects.equals(RunningModeEnum.STANDALONE.name(), runningMode)) {
+                    return;
+                }
+                this.masterUrl = String.valueOf(jsonToMap.get(RunningModeConstants.MASTER_URL));
+                this.isConnectedToMaster = Boolean.TRUE.equals(jsonToMap.get(RunningModeConstants.IS_MASTER));
+            } else {
+                handleResult(result);
+            }
+        } catch (Exception e) {
+            LOG.error("websocket server[{}] handle message error", this.getURI(), e);
         }
     }
     

--- a/shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClientTest.java
+++ b/shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClientTest.java
@@ -117,6 +117,27 @@ public class ShenyuWebsocketClientTest {
     }
 
     @Test
+    public void testOnMessageDropsMalformedMessage() {
+        Assertions.assertDoesNotThrow(() -> shenyuWebsocketClient.onMessage("{invalid-json"));
+    }
+
+    @Test
+    public void testOnMessageDropsUnknownGroupType() {
+        websocketData.setGroupType("UNKNOWN");
+        String json = GsonUtils.getInstance().toJson(websocketData);
+
+        Assertions.assertDoesNotThrow(() -> shenyuWebsocketClient.onMessage(json));
+    }
+
+    @Test
+    public void testOnMessageDropsUnknownEventType() {
+        websocketData.setEventType("UNKNOWN");
+        String json = GsonUtils.getInstance().toJson(websocketData);
+
+        Assertions.assertDoesNotThrow(() -> shenyuWebsocketClient.onMessage(json));
+    }
+
+    @Test
     public void testOnClose() {
         shenyuWebsocketClient = spy(shenyuWebsocketClient);
         doNothing().when(shenyuWebsocketClient).close();


### PR DESCRIPTION
Closes #6843

This PR fixes the unhandled exception issue in `ShenyuWebsocketClient.onMessage()`.

The WebSocket client now catches exceptions raised while processing messages, logs the error, and drops the invalid message without terminating the reader thread.

The added regression tests cover:

- Malformed JSON messages.
- Unknown `groupType` values.
- Unknown `eventType` values.
- Existing valid message processing behavior.

## Tests

- WebSocket client tests passed: 18/18.
- WebSocket sync module tests passed: 48/48.
- Checkstyle passed.

@Aias00, could you please help review this PR? Thanks!