### PR TITLE
fix: scope rule batch delete by namespace(#6825)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/RuleMapper.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/RuleMapper.java
@@ -148,6 +148,24 @@ public interface RuleMapper extends ExistProvider {
     int deleteByIds(List<String> ids);
 
     /**
+     * Select rules by ids and namespace id.
+     *
+     * @param ids primary keys
+     * @param namespaceId namespace id
+     * @return rule list
+     */
+    List<RuleDO> selectByIdsAndNamespaceId(@Param("ids") List<String> ids, @Param("namespaceId") String namespaceId);
+
+    /**
+     * Delete rules by ids and namespace id.
+     *
+     * @param ids primary keys
+     * @param namespaceId namespace id
+     * @return rows int
+     */
+    int deleteByIdsAndNamespaceId(@Param("ids") List<String> ids, @Param("namespaceId") String namespaceId);
+
+    /**
      * list all.
      *
      * @return {@linkplain List}

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java
@@ -422,16 +422,21 @@ public class RuleServiceImpl implements RuleService {
      * delete rules by ids and namespaceId.
      *
      * @param ids primary key.
+     * @param namespaceId namespace id.
      * @return rows
      */
     @Override
     @Transactional(rollbackFor = Exception.class)
     public int deleteByIdsAndNamespaceId(final List<String> ids, final String namespaceId) {
-        List<RuleDO> rules = ruleMapper.selectByIds(ids);
-        final int deleteCount = ruleMapper.deleteByIds(ids);
+        List<RuleDO> rules = ruleMapper.selectByIdsAndNamespaceId(ids, namespaceId);
+        if (CollectionUtils.isEmpty(rules)) {
+            return 0;
+        }
+        final List<String> ruleIds = map(rules, RuleDO::getId);
+        final int deleteCount = ruleMapper.deleteByIdsAndNamespaceId(ruleIds, namespaceId);
         if (deleteCount > 0) {
             ruleEventPublisher.onDeleted(rules);
-            ruleConditionMapper.deleteByRuleIds(ids);
+            ruleConditionMapper.deleteByRuleIds(ruleIds);
         }
         return deleteCount;
     }

--- a/shenyu-admin/src/main/resources/mappers/rule-sqlmap.xml
+++ b/shenyu-admin/src/main/resources/mappers/rule-sqlmap.xml
@@ -209,6 +209,16 @@
         </foreach>
     </select>
 
+    <select id="selectByIdsAndNamespaceId" resultType="org.apache.shenyu.admin.model.entity.RuleDO">
+        select *
+        from rule
+        where id IN
+        <foreach item="id" collection="ids" open="(" separator="," close=")">
+            #{id, jdbcType=VARCHAR}
+        </foreach>
+        AND namespace_id = #{namespaceId, jdbcType=VARCHAR}
+    </select>
+
     <insert id="insert" parameterType="org.apache.shenyu.admin.model.entity.RuleDO">
         INSERT INTO rule (id,
                          date_created,
@@ -380,5 +390,14 @@
                     <foreach item="id" collection="list" open="(" separator="," close=")">
                         #{id, jdbcType=VARCHAR}
                     </foreach>
+    </delete>
+
+    <delete id="deleteByIdsAndNamespaceId">
+        DELETE FROM rule
+              WHERE id IN
+                    <foreach item="id" collection="ids" open="(" separator="," close=")">
+                        #{id, jdbcType=VARCHAR}
+                    </foreach>
+              AND namespace_id = #{namespaceId, jdbcType=VARCHAR}
     </delete>
 </mapper>

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/RuleMapperTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/RuleMapperTest.java
@@ -24,6 +24,8 @@ import org.apache.shenyu.common.utils.UUIDUtils;
 import org.junit.jupiter.api.Test;
 import jakarta.annotation.Resource;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -188,6 +190,23 @@ public final class RuleMapperTest extends AbstractSpringIntegrationTest {
 
         int delete = ruleMapper.delete(ruleDO.getId());
         assertThat(delete, equalTo(1));
+    }
+
+    @Test
+    public void deleteByIdsAndNamespaceId() {
+        RuleDO ruleInNamespace = buildRuleDO();
+        RuleDO ruleInAnotherNamespace = buildRuleDO();
+        ruleInAnotherNamespace.setNamespaceId("another-namespace");
+        assertThat(ruleMapper.insert(ruleInNamespace), equalTo(1));
+        assertThat(ruleMapper.insert(ruleInAnotherNamespace), equalTo(1));
+
+        List<String> ids = Arrays.asList(ruleInNamespace.getId(), ruleInAnotherNamespace.getId());
+        assertThat(ruleMapper.selectByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID).size(), equalTo(1));
+        assertThat(ruleMapper.selectByIdsAndNamespaceId(Collections.singletonList(ruleInAnotherNamespace.getId()), SYS_DEFAULT_NAMESPACE_ID).isEmpty(), equalTo(true));
+        assertThat(ruleMapper.deleteByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID), equalTo(1));
+        assertThat(ruleMapper.selectById(ruleInAnotherNamespace.getId()), equalTo(ruleInAnotherNamespace));
+
+        assertThat(ruleMapper.delete(ruleInAnotherNamespace.getId()), equalTo(1));
     }
 
     private RuleDO buildRuleDO() {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/RuleServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/RuleServiceTest.java
@@ -79,6 +79,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -133,10 +135,20 @@ public final class RuleServiceTest {
     public void testDelete() {
         publishEvent();
         RuleDO ruleDO = buildRuleDO("123");
-        given(this.ruleMapper.selectById("123")).willReturn(ruleDO);
         final List<String> ids = Collections.singletonList(ruleDO.getId());
-        given(this.ruleMapper.deleteByIds(ids)).willReturn(ids.size());
+        given(this.ruleMapper.selectByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID)).willReturn(Collections.singletonList(ruleDO));
+        given(this.ruleMapper.deleteByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID)).willReturn(ids.size());
         assertEquals(this.ruleService.deleteByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID), ids.size());
+        verify(this.ruleConditionMapper).deleteByRuleIds(ids);
+    }
+
+    @Test
+    public void testDeleteWithNoRulesInNamespace() {
+        final List<String> ids = Collections.singletonList("123");
+        given(this.ruleMapper.selectByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID)).willReturn(Collections.emptyList());
+
+        assertEquals(this.ruleService.deleteByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID), 0);
+        verify(this.ruleMapper, never()).deleteByIdsAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID);
     }
 
     @Test


### PR DESCRIPTION
  Fixes #6825.
## Summary
  Scopes rule batch deletion to the supplied namespace.

  - Adds namespace-scoped RuleMapper select and delete statements.
  - Uses `namespace_id` in both the pre-delete query and delete SQL.
  - Deletes rule conditions and publishes delete events only for rules actually matched in the target namespace.
  - Returns `0` without side effects when no requested rule belongs to the namespace.

  ## Tests

  - Updated `RuleServiceTest` for scoped deletion and no-match behavior.
  - Added `RuleMapperTest` coverage for mixed IDs across two namespaces.


<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
