### PR TITLE
fix: bump mvnd to 1.0.6 as 1.0.2 was removed from downloads.apache.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
-          curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+          MVND_VERSION=1.0.6
+          curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
           unzip -q mvnd.zip
           mkdir -p $HOME/.local
           mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/docker-publish-dockerhub.yml
+++ b/.github/workflows/docker-publish-dockerhub.yml
@@ -71,16 +71,16 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
+          MVND_VERSION=1.0.6
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-windows-amd64 $HOME/.local/mvnd
             echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
             echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
           else
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,16 +75,16 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
+          MVND_VERSION=1.0.6
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-windows-amd64 $HOME/.local/mvnd
             echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
             echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
           else
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -82,16 +82,16 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
+          MVND_VERSION=1.0.6
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-windows-amd64 $HOME/.local/mvnd
             echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
             echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
           else
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd
@@ -297,16 +297,16 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
+          MVND_VERSION=1.0.6
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-windows-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-windows-amd64 $HOME/.local/mvnd
             echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
             echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
           else
-            curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+            curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
             unzip -q mvnd.zip
             mkdir -p $HOME/.local
             mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/integrated-test-k8s-ingress.yml
+++ b/.github/workflows/integrated-test-k8s-ingress.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
-          curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+          MVND_VERSION=1.0.6
+          curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
           unzip -q mvnd.zip
           mkdir -p $HOME/.local
           mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/integrated-test.yml
+++ b/.github/workflows/integrated-test.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Install mvnd
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
-          curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+          MVND_VERSION=1.0.6
+          curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
           unzip -q mvnd.zip
           mkdir -p $HOME/.local
           mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd

--- a/.github/workflows/k8s-examples-http.yml
+++ b/.github/workflows/k8s-examples-http.yml
@@ -97,8 +97,8 @@ jobs:
         if: steps.filter.outputs.k8s-examples == 'true'
         shell: bash
         run: |
-          MVND_VERSION=1.0.2
-          curl -sL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+          MVND_VERSION=1.0.6
+          curl -sfL https://downloads.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
           unzip -q mvnd.zip
           mkdir -p $HOME/.local
           mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd


### PR DESCRIPTION
Fixes #7004

### Motivation

Since Aug 29, 2026, CI fails on **all** PRs at the environment-setup step (before any compilation). `mvnd 1.0.2` was removed from `downloads.apache.org` (ASF keeps only the latest releases there; the directory now only hosts `1.0.6/` and `2.0.0-rc-3/`), so the 1.0.2 URL returns 404. Because the workflows use `curl -sL` without `-f`, the 404 HTML page was saved as `mvnd.zip` and `unzip` failed with exit code 9 — e.g. #6347 and #7003.

### Modifications

- Bump `MVND_VERSION` from `1.0.2` to `1.0.6` in all 7 workflows that install mvnd (`ci.yml`, `docker-publish.yml`, `docker-publish-dockerhub.yml`, `e2e-k8s.yml`, `integrated-test.yml`, `integrated-test-k8s-ingress.yml`, `k8s-examples-http.yml`). Artifacts verified available for both `linux-amd64` and `windows-amd64` with the same naming scheme.
- Add `-f` to the mvnd `curl` commands so future download failures fail fast with a clear error instead of a corrupted zip.

### Verifying this change

CI on this PR itself: the mvnd setup step should now succeed and jobs should proceed to actual compilation/tests.
