### PR TITLE
[type:bug] Fix AiProxy forwarding internal fallbackConfig to upstream (#7020)

### DIFF
--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java
@@ -18,6 +18,7 @@
 package org.apache.shenyu.plugin.ai.proxy.enhanced.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.shenyu.common.dto.convert.rule.AiProxyHandle;
 import org.apache.shenyu.common.utils.JsonUtils;
 import org.apache.shenyu.common.utils.Singleton;
@@ -122,6 +123,11 @@ public class AiProxyConfigService {
             }
             if (jsonNode.has("content")) {
                 return jsonNode.get("content").asText();
+            }
+            // Strip internal fallbackConfig from body before forwarding to upstream
+            if (jsonNode.has(FALLBACK_CONFIG) && jsonNode.isObject()) {
+                ((ObjectNode) jsonNode).remove(FALLBACK_CONFIG);
+                return jsonNode.toString();
             }
         } catch (Exception e) {
             // ignore parsing errors and fall back to original body

--- a/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java
+++ b/shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java
@@ -195,7 +195,9 @@ public class AiProxyConfigServiceTest {
     void testExtractPromptWithFallbackConfigButNoPromptOrContent() {
         String requestBody = "{\"fallbackConfig\": {\"model\": \"test-model\"}, \"messages\": [{\"role\": \"user\"}]}";
         String result = configService.extractPrompt(requestBody);
-        assertEquals(requestBody, result);
+        // fallbackConfig should be stripped before forwarding to upstream
+        assertFalse(result.contains("fallbackConfig"));
+        assertTrue(result.contains("messages"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #7020

## What changes were proposed in this pull request?

AiProxy's `extractPrompt` method forwards the entire request body to the upstream AI provider when no `prompt` or `content` field is found at the top level. This includes the internal `fallbackConfig` field with credentials (provider, apiKey, etc.), leaking sensitive configuration to the upstream.

## Changes

- Modified `AiProxyConfigService.extractPrompt()` to strip the `fallbackConfig` field from the JSON body before forwarding to upstream
- Updated test `testExtractPromptWithFallbackConfigButNoPromptOrContent` to verify the fix

## How was this patch tested?

- Unit tests: `AiProxyConfigServiceTest` (19/19 pass)
- Verified that `fallbackConfig` is removed from the forwarded body when present alongside `messages`/other fields