### PR TITLE
fix: enable bean validation for AI proxy API key updates (#6712)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AiProxyApiKeyController.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AiProxyApiKeyController.java
@@ -133,7 +133,7 @@ public class AiProxyApiKeyController implements PagedController<ProxyApiKeyQuery
     @RequiresPermissions("system:aiProxyApiKey:edit")
     public ShenyuAdminResult update(
             @PathVariable("selectorId") final String selectorId,
-            @PathVariable("id") final String id, @RequestBody final ProxyApiKeyDTO dto) {
+            @PathVariable("id") final String id, @Valid @RequestBody final ProxyApiKeyDTO dto) {
         final ProxyApiKeyVO exist = aiProxyApiKeyService.findById(id);
         if (Objects.isNull(exist)) {
             return ShenyuAdminResult.error(AdminConstants.ID_NOT_EXIST);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/AiProxyApiKeyControllerTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/AiProxyApiKeyControllerTest.java
@@ -17,11 +17,16 @@
 
 package org.apache.shenyu.admin.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.apache.shenyu.admin.mapper.SelectorMapper;
 import org.apache.shenyu.admin.model.dto.ProxyApiKeyDTO;
 import org.apache.shenyu.admin.model.entity.SelectorDO;
 import org.apache.shenyu.admin.model.result.ShenyuAdminResult;
+import org.apache.shenyu.admin.model.vo.ProxyApiKeyVO;
 import org.apache.shenyu.admin.service.AiProxyApiKeyService;
+import org.apache.shenyu.admin.utils.ShenyuResultMessage;
 import org.apache.shenyu.common.constant.AdminConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +34,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -76,5 +86,49 @@ public final class AiProxyApiKeyControllerTest {
 
         assertEquals("selector-namespace", dto.getNamespaceId());
         verify(aiProxyApiKeyService).create(eq(dto), eq("selector-1"));
+    }
+
+    @Test
+    public void shouldDelegateUpdateWhenMappingBelongsToSelector() {
+        final ProxyApiKeyDTO dto = new ProxyApiKeyDTO();
+        final ProxyApiKeyVO exist = new ProxyApiKeyVO();
+        exist.setSelectorId("selector-1");
+        when(aiProxyApiKeyService.findById("key-1")).thenReturn(exist);
+        when(aiProxyApiKeyService.update(dto)).thenReturn(1);
+
+        final ShenyuAdminResult result = controller.update("selector-1", "key-1", dto);
+
+        assertEquals(ShenyuResultMessage.UPDATE_SUCCESS, result.getMessage());
+        assertEquals("key-1", dto.getId());
+        verify(aiProxyApiKeyService).update(dto);
+    }
+
+    @Test
+    public void shouldRejectUpdateWhenMappingDoesNotExist() {
+        final ProxyApiKeyDTO dto = new ProxyApiKeyDTO();
+        when(aiProxyApiKeyService.findById("missing-key")).thenReturn(null);
+
+        final ShenyuAdminResult result = controller.update("selector-1", "missing-key", dto);
+
+        assertEquals(AdminConstants.ID_NOT_EXIST, result.getMessage());
+        verify(aiProxyApiKeyService, never()).update(any(ProxyApiKeyDTO.class));
+    }
+
+    @Test
+    public void shouldValidateUpdateRequestBody() throws NoSuchMethodException {
+        final Method update = AiProxyApiKeyController.class.getMethod("update", String.class, String.class,
+                ProxyApiKeyDTO.class);
+        final Parameter requestBody = update.getParameters()[2];
+
+        assertTrue(requestBody.isAnnotationPresent(Valid.class));
+    }
+
+    @Test
+    public void shouldRejectBlankNamespaceIdDuringValidation() {
+        final ProxyApiKeyDTO dto = new ProxyApiKeyDTO();
+        dto.setNamespaceId(" ");
+        final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        assertFalse(validator.validate(dto).isEmpty());
     }
 }


### PR DESCRIPTION
Fixes #6712
## Summary

  - Added `@Valid` to the `AiProxyApiKeyController.update` request body.
  - Enabled existing `ProxyApiKeyDTO` Bean Validation constraints for update requests.
  - Added regression coverage for update success, missing mappings, and validation configuration.

  ## Test

  - Added a test verifying the update request body is annotated with `@Valid`.
  - Added a test verifying blank `namespaceId` violates Bean Validation.
  - Added controller tests for successful updates and missing mappings.
<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
