### PR TITLE
Fix excldue typo in apache-rat exclude patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -825,7 +825,7 @@
                         <exclude>**/.gitpod.yml</exclude>
                         <!-- document files -->
                         <exclude>**/*.md</exclude>
-                        <excldue>**/*.MD</excldue>
+                        <exclude>**/*.MD</exclude>
                         <!-- wasm build files -->
                         <exclude>**/Cargo.lock</exclude>
                         <exclude>**/go.sum</exclude>

--- a/shenyu-e2e/pom.xml
+++ b/shenyu-e2e/pom.xml
@@ -332,7 +332,7 @@
                         <exclude>**/.github/**</exclude>
                         <!-- document files -->
                         <exclude>**/*.md</exclude>
-                        <excldue>**/*.MD</excldue>
+                        <exclude>**/*.MD</exclude>
                         <exclude>**/*.txt</exclude>
                     </excludes>
                 </configuration>


### PR DESCRIPTION
## What
Fixed `<excldue>` → `<exclude>` in the apache-rat plugin config in `pom.xml` and `shenyu-e2e/pom.xml`.

Maven silently ignores unknown tags, so `**/*.MD` was never excluded from license checks.

## Why
Part of #6603 — this PR only fixes the typo; I left the CI verify/rat:check change out so this stays a small, safe diff.

## Test
Diff-only change to POM exclude tags; no runtime behavior change.