### PR TITLE
fix(logging): Fixed binary content type collection containing protobuf

### DIFF
--- a/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/utils/LogCollectUtils.java
+++ b/shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/utils/LogCollectUtils.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class LogCollectUtils {
 
     private static final Set<String> BINARY_TYPE_LIST = Sets.newHashSet("image", "multipart", "cbor",
-            "octet-stream", "pdf", "javascript", "css", "html");
+            "octet-stream", "pdf", "javascript", "css", "html", "x-protobuf");
 
     /**
      * judge whether is binary type.


### PR DESCRIPTION
- Added "x-protobuf" type to binary type list, application/x-protobuf (Common in map vector tiles)
- Ensure content targeting protobuf format is correctly recognized as binary
- Fix the content type judgment logic during log collection

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [ ] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
