### PR TITLE
fix: preserve alert receiver fields during partial updates (#6711)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/AlertReceiverMapper.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/AlertReceiverMapper.java
@@ -56,6 +56,14 @@ public interface AlertReceiverMapper extends ExistProvider {
      * @return object by primary key
      */
     AlertReceiverDO selectByPrimaryKey(String id);
+
+    /**
+     * update record selective.
+     *
+     * @param record the updated record
+     * @return update count
+     */
+    int updateByPrimaryKeySelective(AlertReceiverDO record);
     
     /**
      * update record.

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/AlertReceiverDO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/AlertReceiverDO.java
@@ -39,7 +39,7 @@ public class AlertReceiverDO {
     /**
      * is enabled this receiver.
      */
-    private boolean enable = true;
+    private Boolean enable;
     
     /**
      * Notification information method: 0-SMS 1-Email 2-webhook 3-WeChat Official Account. 
@@ -141,7 +141,7 @@ public class AlertReceiverDO {
     /**
      * match all.
      */
-    private boolean matchAll = true;
+    private Boolean matchAll;
     
     /**
      * match alert levels.
@@ -204,7 +204,7 @@ public class AlertReceiverDO {
      * is enable.
      * @return enable
      */
-    public boolean isEnable() {
+    public Boolean getEnable() {
         return enable;
     }
     
@@ -212,7 +212,7 @@ public class AlertReceiverDO {
      * set enable.
      * @param enable enable
      */
-    public void setEnable(final boolean enable) {
+    public void setEnable(final Boolean enable) {
         this.enable = enable;
     }
     
@@ -540,7 +540,7 @@ public class AlertReceiverDO {
      * is match all.
      * @return match all
      */
-    public boolean isMatchAll() {
+    public Boolean getMatchAll() {
         return matchAll;
     }
     
@@ -548,7 +548,7 @@ public class AlertReceiverDO {
      * set match all.
      * @param matchAll match all
      */
-    public void setMatchAll(final boolean matchAll) {
+    public void setMatchAll(final Boolean matchAll) {
         this.matchAll = matchAll;
     }
     

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertDispatchServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertDispatchServiceImpl.java
@@ -152,8 +152,8 @@ public class AlertDispatchServiceImpl implements AlertDispatchService, Disposabl
                 alertReceiverReference.set(dtoList);
             }
             return dtoList.stream().filter(item -> {
-                if (item.isEnable()) {
-                    if (item.isMatchAll()) {
+                if (Boolean.TRUE.equals(item.getEnable())) {
+                    if (Boolean.TRUE.equals(item.getMatchAll())) {
                         return true;
                     }
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertReceiverServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertReceiverServiceImpl.java
@@ -61,10 +61,10 @@ public class AlertReceiverServiceImpl implements AlertReceiverService {
     public void addReceiver(final AlertReceiverDTO alertReceiverDTO) {
         AlertReceiverDO receiverDO = AlertTransfer.INSTANCE.mapToAlertReceiverDO(alertReceiverDTO);
         receiverDO.setId(UUIDUtils.getInstance().generateShortUuid());
-        if (receiverDO.getEnable() == null) {
+        if (Objects.isNull(receiverDO.getEnable())) {
             receiverDO.setEnable(true);
         }
-        if (receiverDO.getMatchAll() == null) {
+        if (Objects.isNull(receiverDO.getMatchAll())) {
             receiverDO.setMatchAll(true);
         }
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertReceiverServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertReceiverServiceImpl.java
@@ -61,6 +61,12 @@ public class AlertReceiverServiceImpl implements AlertReceiverService {
     public void addReceiver(final AlertReceiverDTO alertReceiverDTO) {
         AlertReceiverDO receiverDO = AlertTransfer.INSTANCE.mapToAlertReceiverDO(alertReceiverDTO);
         receiverDO.setId(UUIDUtils.getInstance().generateShortUuid());
+        if (receiverDO.getEnable() == null) {
+            receiverDO.setEnable(true);
+        }
+        if (receiverDO.getMatchAll() == null) {
+            receiverDO.setMatchAll(true);
+        }
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());
         receiverDO.setDateCreated(currentTime);
         receiverDO.setDateUpdated(currentTime);
@@ -77,7 +83,8 @@ public class AlertReceiverServiceImpl implements AlertReceiverService {
     @Override
     public void updateReceiver(final AlertReceiverDTO alertReceiverDTO) {
         AlertReceiverDO receiverDO = AlertTransfer.INSTANCE.mapToAlertReceiverDO(alertReceiverDTO);
-        alertReceiverMapper.updateByPrimaryKey(receiverDO);
+        receiverDO.setDateUpdated(new Timestamp(System.currentTimeMillis()));
+        alertReceiverMapper.updateByPrimaryKeySelective(receiverDO);
         alertDispatchService.clearCache();
     }
     

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/AlertTransfer.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/AlertTransfer.java
@@ -52,7 +52,7 @@ public enum AlertTransfer {
                     alertReceiverDO.setDiscordChannelId(alertReceiverDTO.getDiscordChannelId());
                     alertReceiverDO.setEmail(alertReceiverDTO.getEmail());
                     alertReceiverDO.setWechatId(alertReceiverDTO.getWechatId());
-                    alertReceiverDO.setEnable(alertReceiverDTO.isEnable());
+                    alertReceiverDO.setEnable(alertReceiverDTO.getEnable());
                     alertReceiverDO.setHookUrl(alertReceiverDTO.getHookUrl());
                     alertReceiverDO.setType(alertReceiverDTO.getType());
                     alertReceiverDO.setLabels(alertReceiverDTO.getLabels());
@@ -65,7 +65,7 @@ public enum AlertTransfer {
                     alertReceiverDO.setSmnTopicUrn(alertReceiverDTO.getSmnTopicUrn());
                     alertReceiverDO.setSmnRegion(alertReceiverDTO.getSmnRegion());
                     alertReceiverDO.setPhone(alertReceiverDTO.getPhone());
-                    alertReceiverDO.setMatchAll(alertReceiverDTO.isMatchAll());
+                    alertReceiverDO.setMatchAll(alertReceiverDTO.getMatchAll());
                     alertReceiverDO.setSlackWebHookUrl(alertReceiverDTO.getSlackWebHookUrl());
                     alertReceiverDO.setNamespaceId(alertReceiverDTO.getNamespaceId());
                     alertReceiverDO.setDateCreated(alertReceiverDTO.getDateCreated());
@@ -95,7 +95,7 @@ public enum AlertTransfer {
                     alertReceiverDTO.setDiscordChannelId(alertReceiverDO.getDiscordChannelId());
                     alertReceiverDTO.setEmail(alertReceiverDO.getEmail());
                     alertReceiverDTO.setWechatId(alertReceiverDO.getWechatId());
-                    alertReceiverDTO.setEnable(alertReceiverDO.isEnable());
+                    alertReceiverDTO.setEnable(alertReceiverDO.getEnable());
                     alertReceiverDTO.setHookUrl(alertReceiverDO.getHookUrl());
                     alertReceiverDTO.setType(alertReceiverDO.getType());
                     alertReceiverDTO.setLabels(alertReceiverDO.getLabels());
@@ -108,7 +108,7 @@ public enum AlertTransfer {
                     alertReceiverDTO.setSmnTopicUrn(alertReceiverDO.getSmnTopicUrn());
                     alertReceiverDTO.setSmnRegion(alertReceiverDO.getSmnRegion());
                     alertReceiverDTO.setPhone(alertReceiverDO.getPhone());
-                    alertReceiverDTO.setMatchAll(alertReceiverDO.isMatchAll());
+                    alertReceiverDTO.setMatchAll(alertReceiverDO.getMatchAll());
                     alertReceiverDTO.setSlackWebHookUrl(alertReceiverDO.getSlackWebHookUrl());
                     alertReceiverDTO.setDateCreated(alertReceiverDO.getDateCreated());
                     alertReceiverDTO.setDateUpdated(alertReceiverDO.getDateUpdated());

--- a/shenyu-admin/src/main/resources/mappers/alert-receiver-sqlmap.xml
+++ b/shenyu-admin/src/main/resources/mappers/alert-receiver-sqlmap.xml
@@ -125,6 +125,39 @@
         FROM alert_receiver
         WHERE id = #{id, jdbcType=VARCHAR}
     </select>
+    <update id="updateByPrimaryKeySelective" parameterType="org.apache.shenyu.admin.model.entity.AlertReceiverDO">
+        update alert_receiver
+        <set>
+            <if test="name != null">name = #{name,jdbcType=VARCHAR},</if>
+            <if test="type != null">type = #{type,jdbcType=TINYINT},</if>
+            <if test="phone != null">phone = #{phone,jdbcType=VARCHAR},</if>
+            <if test="email != null">email = #{email,jdbcType=VARCHAR},</if>
+            <if test="hookUrl != null">hook_url = #{hookUrl,jdbcType=VARCHAR},</if>
+            <if test="wechatId != null">wechat_id = #{wechatId,jdbcType=VARCHAR},</if>
+            <if test="accessToken != null">access_token = #{accessToken,jdbcType=TINYINT},</if>
+            <if test="tgBotToken != null">tg_bot_token = #{tgBotToken,jdbcType=VARCHAR},</if>
+            <if test="tgUserId != null">tg_user_id = #{tgUserId,jdbcType=VARCHAR},</if>
+            <if test="slackWebHookUrl != null">slack_web_hook_url = #{slackWebHookUrl,jdbcType=VARCHAR},</if>
+            <if test="corpId != null">corp_id = #{corpId,jdbcType=VARCHAR},</if>
+            <if test="agentId != null">agent_id = #{agentId,jdbcType=VARCHAR},</if>
+            <if test="appSecret != null">app_secret = #{appSecret,jdbcType=VARCHAR},</if>
+            <if test="discordChannelId != null">discord_channel_id = #{discordChannelId,jdbcType=VARCHAR},</if>
+            <if test="discordBotToken != null">discord_bot_token = #{discordBotToken,jdbcType=VARCHAR},</if>
+            <if test="smnAk != null">smn_ak = #{smnAk,jdbcType=VARCHAR},</if>
+            <if test="smnSk != null">smn_sk = #{smnSk,jdbcType=VARCHAR},</if>
+            <if test="smnProjectId != null">smn_project_id = #{smnProjectId,jdbcType=VARCHAR},</if>
+            <if test="smnRegion != null">smn_region = #{smnRegion,jdbcType=VARCHAR},</if>
+            <if test="smnTopicUrn != null">smn_topic_urn = #{smnTopicUrn,jdbcType=VARCHAR},</if>
+            <if test="labels != null">labels = #{labels,jdbcType=VARCHAR,typeHandler=org.apache.shenyu.admin.mybatis.handler.MapStringTypeHandler},</if>
+            <if test="levels != null">levels = #{levels,jdbcType=VARCHAR,typeHandler=org.apache.shenyu.admin.mybatis.handler.ListByteTypeHandler},</if>
+            <if test="namespaceId != null">namespace_id = #{namespaceId,jdbcType=VARCHAR},</if>
+            <if test="dateCreated != null">date_created = #{dateCreated,jdbcType=TIMESTAMP},</if>
+            <if test="dateUpdated != null">date_updated = #{dateUpdated,jdbcType=TIMESTAMP},</if>
+            <if test="matchAll != null">match_all = #{matchAll,jdbcType=TINYINT},</if>
+            <if test="enable != null">enable = #{enable,jdbcType=TINYINT}</if>
+        </set>
+        where id = #{id,jdbcType=VARCHAR}
+    </update>
     <select id="existed" resultType="java.lang.Boolean">
         select true from alert_receiver where id = #{id} limit 1
     </select>

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/AlertReceiverServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/AlertReceiverServiceTest.java
@@ -29,6 +29,7 @@ import org.apache.shenyu.alert.model.AlertReceiverDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,10 +45,13 @@ import java.util.stream.IntStream;
 import static org.apache.shenyu.common.constant.Constants.SYS_DEFAULT_NAMESPACE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test cases for AlertReceiverService.
@@ -84,8 +88,20 @@ public final class AlertReceiverServiceTest {
 
     @Test
     public void testUpdateReceiver() {
-        given(alertReceiverMapper.updateByPrimaryKey(any())).willReturn(1);
-        alertReceiverService.updateReceiver(new AlertReceiverDTO());
+        AlertReceiverDTO receiverDTO = new AlertReceiverDTO();
+        receiverDTO.setId("receiver-id");
+        receiverDTO.setName("updated-name");
+        given(alertReceiverMapper.updateByPrimaryKeySelective(any())).willReturn(1);
+
+        alertReceiverService.updateReceiver(receiverDTO);
+
+        ArgumentCaptor<AlertReceiverDO> receiverCaptor = ArgumentCaptor.forClass(AlertReceiverDO.class);
+        verify(alertReceiverMapper).updateByPrimaryKeySelective(receiverCaptor.capture());
+        verify(alertReceiverMapper, never()).updateByPrimaryKey(any(AlertReceiverDO.class));
+        assertEquals("receiver-id", receiverCaptor.getValue().getId());
+        assertEquals("updated-name", receiverCaptor.getValue().getName());
+        assertNull(receiverCaptor.getValue().getEnable());
+        assertNull(receiverCaptor.getValue().getMatchAll());
     }
 
     @Test

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/transfer/AlertTransferTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/transfer/AlertTransferTest.java
@@ -28,6 +28,7 @@ import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * test cast for {@link AlertTransfer}.
@@ -114,7 +115,7 @@ public final class AlertTransferTest {
         assertEquals(entity.getDiscordChannelId(), alertReceiverDTO.getDiscordChannelId());
         assertEquals(entity.getEmail(), alertReceiverDTO.getEmail());
         assertEquals(entity.getWechatId(), alertReceiverDTO.getWechatId());
-        assertEquals(entity.isEnable(), alertReceiverDTO.isEnable());
+        assertEquals(entity.getEnable(), alertReceiverDTO.getEnable());
         assertEquals(entity.getHookUrl(), alertReceiverDTO.getHookUrl());
         assertEquals(entity.getType(), alertReceiverDTO.getType());
         assertEquals(entity.getLabels(), alertReceiverDTO.getLabels());
@@ -127,7 +128,7 @@ public final class AlertTransferTest {
         assertEquals(entity.getSmnTopicUrn(), alertReceiverDTO.getSmnTopicUrn());
         assertEquals(entity.getSmnRegion(), alertReceiverDTO.getSmnRegion());
         assertEquals(entity.getPhone(), alertReceiverDTO.getPhone());
-        assertEquals(entity.isMatchAll(), alertReceiverDTO.isMatchAll());
+        assertEquals(entity.getMatchAll(), alertReceiverDTO.getMatchAll());
         assertEquals(entity.getSlackWebHookUrl(), alertReceiverDTO.getSlackWebHookUrl());
         assertEquals(entity.getDateCreated(), alertReceiverDTO.getDateCreated());
         assertEquals(entity.getDateUpdated(), alertReceiverDTO.getDateUpdated());
@@ -147,7 +148,7 @@ public final class AlertTransferTest {
         assertEquals(dto.getDiscordChannelId(), alertReceiverDO.getDiscordChannelId());
         assertEquals(dto.getEmail(), alertReceiverDO.getEmail());
         assertEquals(dto.getWechatId(), alertReceiverDO.getWechatId());
-        assertEquals(dto.isEnable(), alertReceiverDO.isEnable());
+        assertEquals(dto.getEnable(), alertReceiverDO.getEnable());
         assertEquals(dto.getHookUrl(), alertReceiverDO.getHookUrl());
         assertEquals(dto.getType(), alertReceiverDO.getType());
         assertEquals(dto.getLabels(), alertReceiverDO.getLabels());
@@ -160,9 +161,21 @@ public final class AlertTransferTest {
         assertEquals(dto.getSmnTopicUrn(), alertReceiverDO.getSmnTopicUrn());
         assertEquals(dto.getSmnRegion(), alertReceiverDO.getSmnRegion());
         assertEquals(dto.getPhone(), alertReceiverDO.getPhone());
-        assertEquals(dto.isMatchAll(), alertReceiverDO.isMatchAll());
+        assertEquals(dto.getMatchAll(), alertReceiverDO.getMatchAll());
         assertEquals(dto.getSlackWebHookUrl(), alertReceiverDO.getSlackWebHookUrl());
         assertEquals(dto.getDateCreated(), alertReceiverDO.getDateCreated());
         assertEquals(dto.getDateUpdated(), alertReceiverDO.getDateUpdated());
+    }
+
+    @Test
+    void testMapNullBooleanValues() {
+        AlertReceiverDTO dto = new AlertReceiverDTO();
+        AlertReceiverDO entity = AlertTransfer.INSTANCE.mapToAlertReceiverDO(dto);
+        assertNull(entity.getEnable());
+        assertNull(entity.getMatchAll());
+
+        AlertReceiverDTO mappedDto = AlertTransfer.INSTANCE.mapToAlertReceiverDTO(entity);
+        assertNull(mappedDto.getEnable());
+        assertNull(mappedDto.getMatchAll());
     }
 }

--- a/shenyu-alert/src/main/java/org/apache/shenyu/alert/model/AlertReceiverDTO.java
+++ b/shenyu-alert/src/main/java/org/apache/shenyu/alert/model/AlertReceiverDTO.java
@@ -42,7 +42,7 @@ public class AlertReceiverDTO implements Serializable {
     /**
      * is enabled this receiver.
      */
-    private boolean enable = true;
+    private Boolean enable;
     
     /**
      * Notification information method: 0-SMS 1-Email 2-webhook 3-WeChat Official Account. 
@@ -144,7 +144,7 @@ public class AlertReceiverDTO implements Serializable {
     /**
      * match all.
      */
-    private boolean matchAll = true;
+    private Boolean matchAll;
     
     /**
      * match alert levels.
@@ -207,7 +207,7 @@ public class AlertReceiverDTO implements Serializable {
      * is enable.
      * @return enable
      */
-    public boolean isEnable() {
+    public Boolean getEnable() {
         return enable;
     }
     
@@ -215,7 +215,7 @@ public class AlertReceiverDTO implements Serializable {
      * set enable.
      * @param enable enable
      */
-    public void setEnable(final boolean enable) {
+    public void setEnable(final Boolean enable) {
         this.enable = enable;
     }
     
@@ -543,7 +543,7 @@ public class AlertReceiverDTO implements Serializable {
      * is match all.
      * @return match all
      */
-    public boolean isMatchAll() {
+    public Boolean getMatchAll() {
         return matchAll;
     }
     
@@ -551,7 +551,7 @@ public class AlertReceiverDTO implements Serializable {
      * set match all.
      * @param matchAll match all
      */
-    public void setMatchAll(final boolean matchAll) {
+    public void setMatchAll(final Boolean matchAll) {
         this.matchAll = matchAll;
     }
     


### PR DESCRIPTION
Fixes #6711
## Summary

  - Replace `updateByPrimaryKey` with `updateByPrimaryKeySelective` for alert receiver updates.
  - Add the selective mapper method and dynamic MyBatis SQL.
  - Convert `enable` and `matchAll` from primitive `boolean` to nullable `Boolean`.
  - Omitted nullable fields are no longer written back to the database.
  - Preserve the default value `true` when creating a new alert receiver.
  - Add null-safe checks in alert dispatch logic.


  ## Test

  - Updated `AlertReceiverServiceTest` to verify selective updates and prevent calls to the full-column update method.
  - Updated `AlertTransferTest` for nullable Boolean mapping.
  - Added coverage for null `enable` and `matchAll` values.
  - Existing alert dispatch test paths continue to set explicit Boolean values.
  - Performed static checks for remaining primitive getter usage, XML validity, and whitespace errors.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
