### PR TITLE
fix: add transactional boundaries to metadata batch operations (#6708)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java
@@ -108,6 +108,7 @@ public class MetaDataServiceImpl implements MetaDataService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public int deleteByIdsAndNamespaceId(final List<String> ids, final String namespaceId) {
         List<MetaDataDO> deletedMetaData = metaDataMapper.selectByIdListAndNamespaceId(ids, namespaceId);
         if (CollectionUtils.isEmpty(deletedMetaData)) {
@@ -121,6 +122,7 @@ public class MetaDataServiceImpl implements MetaDataService {
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public String enabledByIdsAndNamespaceId(final List<String> ids, final Boolean enabled, final String namespaceId) {
         List<MetaDataDO> metaDataDoList = metaDataMapper.selectByIdListAndNamespaceId(ids, namespaceId);
         if (CollectionUtils.isEmpty(metaDataDoList)) {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/MetaDataServiceTest.java
@@ -60,6 +60,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -151,6 +152,13 @@ public final class MetaDataServiceTest {
                 .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build(), MetaDataDO.builder().build()));
         msg = metaDataService.enabledByIdsAndNamespaceId(ids, false, SYS_DEFAULT_NAMESPACE_ID);
         assertEquals(StringUtils.EMPTY, msg);
+        verify(publisher, never()).onEnabled(any());
+        when(metaDataMapper.updateEnableBatch(ids, true)).thenReturn(ids.size());
+        when(metaDataMapper.selectByIdListAndNamespaceId(ids, SYS_DEFAULT_NAMESPACE_ID))
+                .thenReturn(Arrays.asList(MetaDataDO.builder().build(), MetaDataDO.builder().build(), MetaDataDO.builder().build()));
+        msg = metaDataService.enabledByIdsAndNamespaceId(ids, true, SYS_DEFAULT_NAMESPACE_ID);
+        assertEquals(StringUtils.EMPTY, msg);
+        verify(publisher).onEnabled(any());
     }
 
     /**


### PR DESCRIPTION
Fixes #6708
## Summary

  - Add transactional boundaries to `MetaDataServiceImpl.deleteByIdsAndNamespaceId`.
  - Add transactional boundaries to `MetaDataServiceImpl.enabledByIdsAndNamespaceId`.
  - Preserve the existing update-count guard so enable events are only published after a successful database update.

## Test

  - Added coverage for the `ID_NOT_EXIST` path.
  - Added coverage verifying no enable event is published when the update count is zero.
  - Added coverage verifying the enable event is published after a successful update.
  - Existing metadata deletion tests remain unchanged.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
