### PR TITLE
fix: prevent NPE in instance state checks for null states (#6706)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceInfoVO.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceInfoVO.java
@@ -56,7 +56,7 @@ public class InstanceInfoVO implements Serializable {
     /**
      * status.
      */
-    private int instanceState;
+    private Integer instanceState;
     
     /**
      * created time.
@@ -204,7 +204,7 @@ public class InstanceInfoVO implements Serializable {
      *
      * @return instanceState
      */
-    public int getInstanceState() {
+    public Integer getInstanceState() {
         return instanceState;
     }
 
@@ -213,7 +213,7 @@ public class InstanceInfoVO implements Serializable {
      *
      * @param instanceState instanceState
      */
-    public void setInstanceState(final int instanceState) {
+    public void setInstanceState(final Integer instanceState) {
         this.instanceState = instanceState;
     }
 

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java
@@ -95,6 +95,9 @@ public class InstanceCheckService {
     public void fetchInstanceData() {
         List<InstanceInfoVO> list = instanceInfoService.list();
         list.forEach(instanceInfoVO -> {
+            if (Objects.isNull(instanceInfoVO.getInstanceState())) {
+                instanceInfoVO.setInstanceState(InstanceStatusEnum.DELETED.getCode());
+            }
             String instanceKey = getInstanceKey(instanceInfoVO);
             instanceHealthBeatInfo.put(instanceKey, instanceInfoVO);
         });
@@ -146,7 +149,7 @@ public class InstanceCheckService {
     private void doCheck() {
         instanceHealthBeatInfo.values().forEach(instance -> {
             if (System.currentTimeMillis() - instance.getLastHeartBeatTime() > instanceHeartBeatTimeOut) {
-                if (InstanceStatusEnum.ONLINE.getCode() == instance.getInstanceState()) {
+                if (Objects.equals(InstanceStatusEnum.ONLINE.getCode(), instance.getInstanceState())) {
                     LOG.info("[instanceHealthInfo]namespace:{},type:{},Ip:{},Port:{} offline!",
                             instance.getNamespaceId(), instance.getInstanceType(), instance.getInstanceIp(), instance.getInstancePort());
                     instance.setInstanceState(InstanceStatusEnum.OFFLINE.getCode());
@@ -157,7 +160,7 @@ public class InstanceCheckService {
                 instance.setInstanceState(InstanceStatusEnum.ONLINE.getCode());
             }
             if (System.currentTimeMillis() - instance.getLastHeartBeatTime() > deleteTimeout) {
-                if (InstanceStatusEnum.OFFLINE.getCode() == instance.getInstanceState()) {
+                if (Objects.equals(InstanceStatusEnum.OFFLINE.getCode(), instance.getInstanceState())) {
                     LOG.info("[instanceHealthInfo]namespace:{},type:{},Ip:{},Port:{} deleted!",
                             instance.getNamespaceId(), instance.getInstanceType(), instance.getInstanceIp(), instance.getInstancePort());
                     instance.setInstanceState(InstanceStatusEnum.DELETED.getCode());
@@ -208,7 +211,9 @@ public class InstanceCheckService {
 
     private void collectStateData() {
         if (!CollectionUtils.isEmpty(instanceHealthBeatInfo)) {
-            Map<Integer, Long> pieData = instanceHealthBeatInfo.values().stream().collect(Collectors.groupingBy(InstanceInfoVO::getInstanceState, Collectors.counting()));
+            Map<Integer, Long> pieData = instanceHealthBeatInfo.values().stream()
+                    .filter(instance -> Objects.nonNull(instance.getInstanceState()))
+                    .collect(Collectors.groupingBy(InstanceInfoVO::getInstanceState, Collectors.counting()));
             updateStateHistory(pieData);
         }
     }
@@ -219,7 +224,9 @@ public class InstanceCheckService {
         if (StringUtils.isNotBlank(namespaceId)) {
             instanceInfoVOS = instanceInfoVOS.stream().filter(vo -> namespaceId.equals(vo.getNamespaceId())).collect(Collectors.toList());
         }
-        Map<Integer, Long> pieData = instanceInfoVOS.stream().collect(Collectors.groupingBy(InstanceInfoVO::getInstanceState, Collectors.counting()));
+        Map<Integer, Long> pieData = instanceInfoVOS.stream()
+                .filter(instance -> Objects.nonNull(instance.getInstanceState()))
+                .collect(Collectors.groupingBy(InstanceInfoVO::getInstanceState, Collectors.counting()));
         List<InstanceDataVisualLineVO> lineList = new ArrayList<>();
         for (Integer state : Arrays.asList(0, 1, 2)) {
             Deque<Long> queue = stateHistoryMap.getOrDefault(state, new ArrayDeque<>(MAX_HISTORY_SIZE));

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java
@@ -109,9 +109,11 @@ public class InstanceInfoServiceImpl implements InstanceInfoService {
         instanceInfoVO.setInstancePort(instanceInfoDO.getInstancePort());
         instanceInfoVO.setInstanceType(instanceInfoDO.getInstanceType());
         instanceInfoVO.setInstanceInfo(instanceInfoDO.getInstanceInfo());
+        instanceInfoVO.setInstanceState(instanceInfoDO.getInstanceState());
         instanceInfoVO.setNamespaceId(instanceInfoDO.getNamespaceId());
         instanceInfoVO.setDateCreated(instanceInfoDO.getDateCreated());
         instanceInfoVO.setDateUpdated(instanceInfoDO.getDateUpdated());
+        instanceInfoVO.setLastHeartBeatTime(instanceInfoDO.getLastHeartBeatTime());
         return instanceInfoVO;
     }
 }

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.shenyu.register.common.dto.InstanceBeatInfoDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -73,6 +74,16 @@ public final class InstanceCheckServiceTest {
         InstanceInfoVO cached = instanceCheckService.getInstanceHealthBeatInfo(key);
         assertNotNull(cached);
         assertEquals(vo.getInstanceIp(), cached.getInstanceIp());
+    }
+
+    @Test
+    void testFetchInstanceDataNormalizesNullState() {
+        vo.setInstanceState(null);
+        when(instanceInfoService.list()).thenReturn(Collections.singletonList(vo));
+
+        instanceCheckService.fetchInstanceData();
+
+        assertEquals(0, vo.getInstanceState());
     }
 
     @Test
@@ -160,6 +171,25 @@ public final class InstanceCheckServiceTest {
         InstanceDataVisualVO nsAData = instanceCheckService.getInstanceDataVisual("nsA");
         assertNotNull(nsAData);
         assertThat(nsAData.getPieData(), hasSize(1));
+    }
+
+    @Test
+    void testGetInstanceDataVisualIgnoresNullState() {
+        InstanceBeatInfoDTO dto = buildDTO("3.3.3.3", "8083", "grpc", "nsC");
+        instanceCheckService.handleBeatInfo(dto);
+        instanceCheckService.getInstanceHealthBeatInfo(dto).setInstanceState(null);
+
+        assertDoesNotThrow(() -> instanceCheckService.getInstanceDataVisual(""));
+    }
+
+    @Test
+    void testDoCheckWithNullStateDoesNotThrow() {
+        InstanceBeatInfoDTO dto = buildDTO("4.4.4.4", "8084", "grpc", "nsD");
+        instanceCheckService.handleBeatInfo(dto);
+        InstanceInfoVO cached = instanceCheckService.getInstanceHealthBeatInfo(dto);
+        cached.setInstanceState(null);
+
+        assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(instanceCheckService, "doCheck"));
     }
 
     private InstanceInfoVO buildVO(final String ip, final String port, final String type, final String ns) {


### PR DESCRIPTION
Fixes #6706
## Summary

  - Prevent `InstanceCheckService` from throwing NPE when an instance has a null state.
  - Normalize null states to the default state code when loading instance data.
  - Replace unsafe autounboxing comparisons with `Objects.equals`.
  - Filter null states before `Collectors.groupingBy` in state statistics and visualization.
  - Change `InstanceInfoVO.instanceState` to `Integer` so null database values can be represented safely.
  - Preserve `instanceState` and `lastHeartBeatTime` when mapping `InstanceInfoDO` to `InstanceInfoVO`.

## Test

  - Added coverage for normalizing null instance states during data loading.
  - Added coverage for visualization when an instance has a null state.
  - Added coverage ensuring scheduled `doCheck` does not throw for null states.
  - Existing instance state, namespace filtering, pie chart, and history data tests remain covered.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
