### PR TITLE
fix: use thread-safe upstream lists in UpstreamCheckService (#6704)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
@@ -278,7 +278,7 @@ public class UpstreamCheckService {
         if (!REGISTER_TYPE_HTTP.equalsIgnoreCase(registerType)) {
             return;
         }
-        UPSTREAM_MAP.put(selectorId, new CopyOnWriteArrayList<>(commonUpstreams));
+        UPSTREAM_MAP.put(selectorId, toThreadSafeList(commonUpstreams));
     }
 
     private void scheduled() {
@@ -394,7 +394,7 @@ public class UpstreamCheckService {
         }
         removePendingSync(successList);
         if (!successList.isEmpty()) {
-            UPSTREAM_MAP.put(selectorId, new CopyOnWriteArrayList<>(successList));
+            UPSTREAM_MAP.put(selectorId, toThreadSafeList(successList));
             updateSelectorHandler(selectorId, successList);
         } else {
             UPSTREAM_MAP.remove(selectorId);
@@ -405,6 +405,10 @@ public class UpstreamCheckService {
     private void removePendingSync(final List<CommonUpstream> successList) {
         PENDING_SYNC.removeIf(NumberUtils.INTEGER_ZERO::equals);
         successList.forEach(commonUpstream -> PENDING_SYNC.remove(commonUpstream.hashCode()));
+    }
+
+    private List<CommonUpstream> toThreadSafeList(final List<CommonUpstream> upstreams) {
+        return upstreams instanceof CopyOnWriteArrayList ? upstreams : new CopyOnWriteArrayList<>(upstreams);
     }
 
     private void updateSelectorHandler(final String selectorId, final List<CommonUpstream> aliveList) {

--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java
@@ -61,7 +61,6 @@ import org.springframework.stereotype.Component;
 import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -279,7 +278,7 @@ public class UpstreamCheckService {
         if (!REGISTER_TYPE_HTTP.equalsIgnoreCase(registerType)) {
             return;
         }
-        UPSTREAM_MAP.put(selectorId, commonUpstreams);
+        UPSTREAM_MAP.put(selectorId, new CopyOnWriteArrayList<>(commonUpstreams));
     }
 
     private void scheduled() {
@@ -395,7 +394,7 @@ public class UpstreamCheckService {
         }
         removePendingSync(successList);
         if (!successList.isEmpty()) {
-            UPSTREAM_MAP.put(selectorId, successList);
+            UPSTREAM_MAP.put(selectorId, new CopyOnWriteArrayList<>(successList));
             updateSelectorHandler(selectorId, successList);
         } else {
             UPSTREAM_MAP.remove(selectorId);
@@ -478,7 +477,7 @@ public class UpstreamCheckService {
                 .filter(Objects::nonNull)
                 .forEach(selectorDO -> {
                     String name = pluginMap.get(selectorDO.getPluginId());
-                    List<CommonUpstream> commonUpstreams = new LinkedList<>();
+                    List<CommonUpstream> commonUpstreams = new CopyOnWriteArrayList<>();
                     discoveryUpstreamService.findBySelectorId(selectorDO.getId()).stream()
                             .map(DiscoveryTransfer.INSTANCE::mapToCommonUpstream)
                             .forEach(commonUpstreams::add);

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java
@@ -260,8 +260,10 @@ public final class UpstreamCheckServiceTest {
         upstreamCheckService.fetchUpstreamData();
         assertTrue(upstreamMap.containsKey(MOCK_SELECTOR_NAME));
         assertEquals(2, upstreamMap.get(MOCK_SELECTOR_NAME).size());
+        assertTrue(upstreamMap.get(MOCK_SELECTOR_NAME) instanceof CopyOnWriteArrayList);
         assertTrue(upstreamMap.containsKey(MOCK_SELECTOR_NAME_OTHER));
         assertEquals(2, upstreamMap.get(MOCK_SELECTOR_NAME_OTHER).size());
+        assertTrue(upstreamMap.get(MOCK_SELECTOR_NAME_OTHER) instanceof CopyOnWriteArrayList);
     }
 
     @Test


### PR DESCRIPTION
Fixes #6704
## Summary

  - Build upstream lists in `UpstreamCheckService#fetchUpstreamData` with `CopyOnWriteArrayList` instead of `LinkedList`.
  - Prevent concurrent registration updates and scheduled health-check iteration from causing
  `ConcurrentModificationException`.

  ## Test

  - Updated `UpstreamCheckServiceTest#testFetchUpstreamData` to verify the loaded upstream lists are `CopyOnWriteArrayList`
  instances.
  - Kept the existing assertions for selector entries and upstream counts.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
