### PR TITLE
fix: prevent NPE when fetching data with stale discovery handler(#6702)

### DIFF
--- a/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java
+++ b/shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java
@@ -398,7 +398,13 @@ public class ProxySelectorServiceImpl implements ProxySelectorService {
     @Override
     public void fetchData(final String discoveryHandlerId) {
         DiscoveryHandlerDO discoveryHandlerDO = discoveryHandlerMapper.selectById(discoveryHandlerId);
+        if (Objects.isNull(discoveryHandlerDO)) {
+            return;
+        }
         DiscoveryDO discoveryDO = discoveryMapper.selectById(discoveryHandlerDO.getDiscoveryId());
+        if (Objects.isNull(discoveryDO)) {
+            return;
+        }
         ProxySelectorDO proxySelectorDO = proxySelectorMapper.selectByHandlerId(discoveryHandlerId);
         DiscoveryHandlerDTO discoveryHandlerDTO = DiscoveryTransfer.INSTANCE.mapToDTO(discoveryHandlerDO);
         if (Objects.nonNull(proxySelectorDO)) {

--- a/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ProxySelectorServiceTest.java
+++ b/shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ProxySelectorServiceTest.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.shenyu.common.constant.Constants.SYS_DEFAULT_NAMESPACE_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -154,6 +155,69 @@ class ProxySelectorServiceTest {
 
         assertEquals(proxySelectorService.update(proxySelectorDTO), ShenyuResultMessage.UPDATE_SUCCESS);
         verify(discoveryUpstreamMapper, never()).deleteByDiscoveryHandlerId(any());
+    }
+
+    @Test
+    void testFetchDataWithProxySelector() {
+        DiscoveryHandlerDO discoveryHandlerDO = new DiscoveryHandlerDO();
+        discoveryHandlerDO.setId("handler-1");
+        discoveryHandlerDO.setDiscoveryId("discovery-1");
+        given(discoveryHandlerMapper.selectById("handler-1")).willReturn(discoveryHandlerDO);
+
+        DiscoveryDO discoveryDO = new DiscoveryDO();
+        discoveryDO.setDiscoveryType("local");
+        given(discoveryMapper.selectById("discovery-1")).willReturn(discoveryDO);
+
+        ProxySelectorDO proxySelectorDO = buildProxySelectorDO();
+        given(proxySelectorMapper.selectByHandlerId("handler-1")).willReturn(proxySelectorDO);
+        DiscoveryProcessor discoveryProcessor = mock(DiscoveryProcessor.class);
+        given(discoveryProcessorHolder.chooseProcessor("local")).willReturn(discoveryProcessor);
+
+        proxySelectorService.fetchData("handler-1");
+
+        verify(discoveryProcessor).fetchAll(any(), any());
+    }
+
+    @Test
+    void testFetchDataWithMissingDiscoveryHandler() {
+        given(discoveryHandlerMapper.selectById("missing-handler")).willReturn(null);
+
+        assertDoesNotThrow(() -> proxySelectorService.fetchData("missing-handler"));
+
+        verify(discoveryMapper, never()).selectById(any());
+        verify(proxySelectorMapper, never()).selectByHandlerId(any());
+        verify(selectorMapper, never()).selectByDiscoveryHandlerId(any());
+        verify(discoveryProcessorHolder, never()).chooseProcessor(any());
+    }
+
+    @Test
+    void testFetchDataWithMissingDiscovery() {
+        DiscoveryHandlerDO discoveryHandlerDO = new DiscoveryHandlerDO();
+        discoveryHandlerDO.setDiscoveryId("missing-discovery");
+        given(discoveryHandlerMapper.selectById("handler-1")).willReturn(discoveryHandlerDO);
+        given(discoveryMapper.selectById("missing-discovery")).willReturn(null);
+
+        assertDoesNotThrow(() -> proxySelectorService.fetchData("handler-1"));
+
+        verify(proxySelectorMapper, never()).selectByHandlerId(any());
+        verify(selectorMapper, never()).selectByDiscoveryHandlerId(any());
+        verify(discoveryProcessorHolder, never()).chooseProcessor(any());
+    }
+
+    @Test
+    void testFetchDataWithoutBoundSelector() {
+        DiscoveryHandlerDO discoveryHandlerDO = new DiscoveryHandlerDO();
+        discoveryHandlerDO.setId("handler-1");
+        discoveryHandlerDO.setDiscoveryId("discovery-1");
+        given(discoveryHandlerMapper.selectById("handler-1")).willReturn(discoveryHandlerDO);
+
+        DiscoveryDO discoveryDO = new DiscoveryDO();
+        discoveryDO.setDiscoveryType("local");
+        given(discoveryMapper.selectById("discovery-1")).willReturn(discoveryDO);
+
+        assertDoesNotThrow(() -> proxySelectorService.fetchData("handler-1"));
+
+        verify(discoveryProcessorHolder, never()).chooseProcessor(any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #6702
## Summary
  - Add null checks for the discovery handler and discovery records in `ProxySelectorServiceImpl.fetchData`.
  - Return early when a stale discovery handler ID or a missing discovery record is encountered.

  ## Test
  - Added a test for fetching data through a valid proxy selector.
  - Added a test verifying that a missing discovery handler does not throw an exception or invoke downstream components.
  - Added a test verifying that a missing discovery record does not throw an exception or invoke downstream components.
  - Added a boundary test for a discovery handler without a bound proxy selector or selector.

<!-- Describe your PR here; e.g. Fixes #issueNo -->

<!--
Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
-->
Make sure that:

- [x] You have read the [contribution guidelines](https://shenyu.apache.org/community/contributor-guide).
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] Your local test passed `./mvnw clean install -Dmaven.javadoc.skip=true`.
